### PR TITLE
Prettify ReSpec config

### DIFF
--- a/index.html
+++ b/index.html
@@ -472,7 +472,548 @@ table.simple {
         display: none;
     }
 }
-</style><link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/W3C-ED"><!--[if lt IE 9]><script src='https://www.w3.org/2008/site/js/html5shiv.js'></script><![endif]--><script id="respecFinalConfig" type="application/json">{<br>  "specStatus": "ED",<br>  "previousMaturity": "WD",<br>  "previousPublishDate": "2014-08-28T07:00:00.000Z",<br>  "shortName": "encrypted-media",<br>  "edDraftURI": "https://w3c.github.io/encrypted-media/",<br>  "editors": [<br>    {<br>      "name": "David Dorwin",<br>      "url": "",<br>      "company": "Google Inc.",<br>      "companyURL": "https://www.google.com/"<br>    },<br>    {<br>      "name": "Jerry Smith",<br>      "url": "",<br>      "company": "Microsoft Corporation",<br>      "companyURL": "https://www.microsoft.com/"<br>    },<br>    {<br>      "name": "Mark Watson",<br>      "url": "",<br>      "company": "Netflix Inc.",<br>      "companyURL": "https://www.netflix.com/"<br>    },<br>    {<br>      "name": "Adrian Bateman (until May 2014)",<br>      "url": "",<br>      "company": "Microsoft Corporation",<br>      "companyURL": "https://www.microsoft.com/"<br>    }<br>  ],<br>  "otherLinks": [<br>    {<br>      "key": "Repository",<br>      "href": "https://github.com/w3c/encrypted-media/"<br>    }<br>  ],<br>  "emeDefGroupName": "encrypted-media",<br>  "emeUnusedGroupNameExcludeList": [<br>    "eme-references-from-registry"<br>  ],<br>  "wg": "HTML Working Group",<br>  "wgURI": "http://www.w3.org/html/wg/",<br>  "wgPublicList": "public-html-media",<br>  "wgPatentURI": "https://www.w3.org/2004/01/pp-impl/40318/status",<br>  "noIDLIn": true,<br>  "scheme": "https",<br>  "preProcess": [<br>    null<br>  ],<br>  "definitionMap": {<br>    "initialization data type": [<br>      {<br>        "0": {},<br>        "context": {},<br>        "length": 1<br>      }<br>    ],<br>    "notsupportederror": [<br>      {<br>        "0": {},<br>        "context": {},<br>        "length": 1<br>      }<br>    ],<br>    "invalidstateerror": [<br>      {<br>        "0": {},<br>        "context": {},<br>        "length": 1<br>      }<br>    ],<br>    "invalidaccesserror": [<br>      {<br>        "0": {},<br>        "context": {},<br>        "length": 1<br>      }<br>    ],<br>    "quotaexceedederror": [<br>      {<br>        "0": {},<br>        "context": {},<br>        "length": 1<br>      }<br>    ]<br>  },<br>  "postProcess": [<br>    null<br>  ],<br>  "localBiblio": {<br>    "EME-REGISTRY": {<br>      "title": "Encrypted Media Extensions Stream Format and Initialization Data Format Registry",<br>      "href": "initdata-format-registry.html",<br>      "authors": [<br>        "David Dorwin",<br>        "Adrian Bateman",<br>        "Mark Watson"<br>      ],<br>      "publisher": "W3C"<br>    },<br>    "JWS": {<br>      "authors": [<br>        "M. Jones",<br>        "J. Bradley",<br>        "N. Sakimura"<br>      ],<br>      "date": "25 September 2014",<br>      "href": "https://tools.ietf.org/html/draft-ietf-jose-json-web-signature-33",<br>      "publisher": "IETF",<br>      "status": "Internet Draft",<br>      "title": "JSON Web Signature (JWS)"<br>    }<br>  },<br>  "l10n": {<br>    "this_version": "This version:",<br>    "latest_published_version": "Latest published version:",<br>    "latest_editors_draft": "Latest editor's draft:",<br>    "editor": "Editor:",<br>    "editors": "Editors:",<br>    "author": "Author:",<br>    "authors": "Authors:",<br>    "abstract": "Abstract",<br>    "sotd": "Status of This Document",<br>    "status_at_publication": "This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current W3C publications and the latest revision of this technical report can be found in the <a href='http://www.w3.org/TR/'>W3C technical reports index</a> at http://www.w3.org/TR/.",<br>    "toc": "Table of Contents",<br>    "note": "Note",<br>    "fig": "Fig. ",<br>    "bug_tracker": "Bug tracker:",<br>    "file_a_bug": "file a bug",<br>    "open_bugs": "open bugs",<br>    "open_parens": "(",<br>    "close_parens": ")"<br>  },<br>  "doRDFa": true,<br>  "license": "w3c",<br>  "isCCBY": false,<br>  "isCGBG": false,<br>  "isCGFinal": false,<br>  "isBasic": false,<br>  "isWebSpec": false,<br>  "isRegular": true,<br>  "title": "Encrypted Media Extensions",<br>  "subtitle": "",<br>  "publishDate": "2015-09-03T18:07:25.000Z",<br>  "publishYear": 2015,<br>  "publishHumanDate": "03 September 2015",<br>  "isNoTrack": false,<br>  "isRecTrack": false,<br>  "isMemberSubmission": false,<br>  "isTeamSubmission": false,<br>  "isSubmission": false,<br>  "anOrA": "an",<br>  "isTagFinding": false,<br>  "maturity": "ED",<br>  "thisVersion": "https://w3c.github.io/encrypted-media/",<br>  "latestVersion": "http://www.w3.org/TR/encrypted-media/",<br>  "prevVersion": "http://www.w3.org/TR/2014/WD-encrypted-media-20140828/",<br>  "multipleEditors": true,<br>  "alternatesHTML": "",<br>  "longStatus": "Editor's Draft",<br>  "textStatus": "Editor's Draft",<br>  "showThisVersion": true,<br>  "showPreviousVersion": false,<br>  "notYetRec": false,<br>  "isRec": false,<br>  "notRec": true,<br>  "isUnofficial": false,<br>  "prependW3C": true,<br>  "isED": true,<br>  "isLC": false,<br>  "isCR": false,<br>  "isPR": false,<br>  "isPER": false,<br>  "isMO": false,<br>  "isIGNote": false,<br>  "dashDate": "2015-09-03",<br>  "publishISODate": "2015-09-03T18:07:25.000Z",<br>  "shortISODate": "2015-09-03",<br>  "processVersion": "2015",<br>  "isNewProcess": true,<br>  "sotdCustomParagraph": "\n      <p>The working group maintains <a href=\"https://github.com/w3c/encrypted-media/issues\">a list of all bug reports that the editors have not yet tried to address</a>; there are also open bugs in the <a href=\"https://www.w3.org/brief/MjY5\">previous bug tracker</a>. This draft highlights some of the pending issues that are still to be discussed in the working group. No decision has been taken on the outcome of these issues including whether they are valid.</p>\n      <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should join the mailing list mentioned below and take part in the discussions.</p>\n\n      <p class=\"issue\"><a href=\"https://www.w3.org/Bugs/Public/show_bug.cgi?id=20944\">Bug 20944</a> - The specification should do more to encourage/ensure CDM-level interoperability.</p>\n      <p class=\"issue\">This specification contains sections for describing <a href=\"#security\">security</a> and <a href=\"#privacy\">privacy</a> considerations. These sections are not final and review is welcome.</p>\n\n<!-- This will be populated when addressing https://www.w3.org/Bugs/Public/show_bug.cgi?id=23827.\n      <p>The following features are <strong>at risk</strong> and may be removed due to lack of implementation.\n      </p>\n      <ul>\n        <li><a def-id=\"\"></a></li>\n      </ul>\n -->\n    ",<br>  "multipleWGs": false,<br>  "wgHTML": "<a href='http://www.w3.org/html/wg/'>HTML Working Group</a>",<br>  "humanLCEnd": "30 November 1899",<br>  "humanCREnd": "30 November 1899",<br>  "humanPREnd": "30 November 1899",<br>  "humanPEREnd": "30 November 1899",<br>  "recNotExpected": false,<br>  "subjectPrefixEnc": "undefined",<br>  "normativeReferences": {<br>    "HTML5": true,<br>    "MIXED-CONTENT": true,<br>    "RFC6381": true,<br>    "WebIDL": true,<br>    "DOM": true,<br>    "COOKIES": true,<br>    "ENCODING": true,<br>    "JWK": true<br>  },<br>  "informativeReferences": {<br>    "EME-REGISTRY": true,<br>    "RFC6838": true,<br>    "MEDIA-SOURCE": true,<br>    "JWS": true<br>  },<br>  "respecRFC2119": {<br>    "MUST": true,<br>    "MUST NOT": true,<br>    "MAY": true,<br>    "RECOMMENDED": true,<br>    "SHALL": true,<br>    "SHOULD": true,<br>    "SHOULD NOT": true,<br>    "REQUIRED": true,<br>    "SHALL NOT": true,<br>    "OPTIONAL": true<br>  },<br>  "biblio": {<br>    "HTML5": {<br>      "aliasOf": "html5",<br>      "id": "HTML5"<br>    },<br>    "html5": {<br>      "authors": [<br>        "Ian Hickson",<br>        "Robin Berjon",<br>        "Steve Faulkner",<br>        "Travis Leithead",<br>        "Erika Doyle Navara",<br>        "Edward O'Connor",<br>        "Silvia Pfeiffer"<br>      ],<br>      "href": "http://www.w3.org/TR/html5/",<br>      "title": "HTML5",<br>      "status": "REC",<br>      "publisher": "W3C",<br>      "deliveredBy": [<br>        {<br>          "url": "http://www.w3.org/html/wg/",<br>          "shortname": "html"<br>        }<br>      ],<br>      "versions": [<br>        "html5-20141028",<br>        "html5-20140916",<br>        "html5-20140731",<br>        "html5-20140617",<br>        "html5-20140429",<br>        "html5-20140204",<br>        "html5-20130806",<br>        "html5-20121217",<br>        "html5-20121025",<br>        "html5-20120329",<br>        "html5-20110525",<br>        "html5-20110405",<br>        "html5-20110113",<br>        "html5-20101019",<br>        "html5-20100624",<br>        "html5-20100304",<br>        "html5-20090825",<br>        "html5-20090423",<br>        "html5-20090212",<br>        "html5-20080610",<br>        "html5-20080122"<br>      ],<br>      "edDraft": "http://www.w3.org/html/wg/drafts/html/master/",<br>      "obsoletes": [<br>        "Window",<br>        "web-forms-2"<br>      ],<br>      "id": "html5",<br>      "date": "28 October 2014"<br>    },<br>    "MIXED-CONTENT": {<br>      "aliasOf": "mixed-content",<br>      "id": "MIXED-CONTENT"<br>    },<br>    "mixed-content": {<br>      "href": "http://www.w3.org/TR/mixed-content/",<br>      "title": "Mixed Content",<br>      "status": "CR",<br>      "publisher": "W3C",<br>      "edDraft": "https://w3c.github.io/webappsec/specs/mixedcontent/",<br>      "deliveredBy": [<br>        {<br>          "url": "http://www.w3.org/2011/webappsec/",<br>          "shortname": "webappsec"<br>        }<br>      ],<br>      "versions": [<br>        "mixed-content-20150317",<br>        "mixed-content-20141113",<br>        "mixed-content-20140916",<br>        "mixed-content-20140722"<br>      ],<br>      "authors": [<br>        "Mike West"<br>      ],<br>      "id": "mixed-content",<br>      "date": "17 March 2015"<br>    },<br>    "RFC6381": {<br>      "aliasOf": "rfc6381",<br>      "id": "RFC6381"<br>    },<br>    "rfc6381": {<br>      "href": "https://tools.ietf.org/html/rfc6381",<br>      "title": "The 'Codecs' and 'Profiles' Parameters for \"Bucket\" Media Types",<br>      "authors": [<br>        "R. Gellens",<br>        "D. Singer",<br>        "P. Frojdh"<br>      ],<br>      "status": "Proposed Standard",<br>      "obsoletes": [<br>        "RFC4281"<br>      ],<br>      "publisher": "IETF",<br>      "id": "rfc6381",<br>      "date": "August 2011"<br>    },<br>    "WebIDL": {<br>      "aliasOf": "WebIDL-1",<br>      "id": "WebIDL"<br>    },<br>    "WebIDL-1": {<br>      "authors": [<br>        "Cameron McCormack",<br>        "Boris Zbarsky"<br>      ],<br>      "href": "http://www.w3.org/TR/WebIDL-1/",<br>      "title": "WebIDL Level 1",<br>      "status": "WD",<br>      "publisher": "W3C",<br>      "edDraft": "https://heycam.github.io/webidl/",<br>      "deliveredBy": [<br>        {<br>          "url": "http://www.w3.org/2008/webapps/",<br>          "shortname": "webapps"<br>        }<br>      ],<br>      "versions": [<br>        "WebIDL-1-20150804",<br>        "WebIDL-1-20120419",<br>        "WebIDL-1-20120207",<br>        "WebIDL-1-20110927",<br>        "WebIDL-1-20110712",<br>        "WebIDL-1-20101021",<br>        "WebIDL-1-20081219",<br>        "WebIDL-1-20080829",<br>        "WebIDL-1-20080410",<br>        "WebIDL-1-20071017"<br>      ],<br>      "id": "WebIDL-1",<br>      "date": "4 August 2015"<br>    },<br>    "DOM": {<br>      "aliasOf": "dom",<br>      "id": "DOM"<br>    },<br>    "dom": {<br>      "authors": [<br>        "Anne van Kesteren",<br>        "Aryeh Gregor",<br>        "Ms2ger",<br>        "Alex Russell",<br>        "Robin Berjon"<br>      ],<br>      "href": "http://www.w3.org/TR/dom/",<br>      "title": "W3C DOM4",<br>      "status": "LCWD",<br>      "publisher": "W3C",<br>      "deliveredBy": [<br>        {<br>          "url": "http://www.w3.org/html/wg/",<br>          "shortname": "html"<br>        }<br>      ],<br>      "versions": [<br>        "dom-20150618",<br>        "dom-20150428",<br>        "dom-20140710",<br>        "dom-20140508",<br>        "dom-20140204",<br>        "dom-20131107",<br>        "dom-20121206",<br>        "dom-20120405",<br>        "dom-20120105",<br>        "dom-20110915",<br>        "dom-20110531",<br>        "dom-20101007"<br>      ],<br>      "edDraft": "https://w3c.github.io/dom/",<br>      "id": "dom",<br>      "date": "18 June 2015"<br>    },<br>    "COOKIES": {<br>      "aliasOf": "RFC6265",<br>      "id": "COOKIES"<br>    },<br>    "RFC6265": {<br>      "aliasOf": "rfc6265",<br>      "id": "RFC6265"<br>    },<br>    "rfc6265": {<br>      "href": "https://tools.ietf.org/html/rfc6265",<br>      "title": "HTTP State Management Mechanism",<br>      "authors": [<br>        "A. Barth"<br>      ],<br>      "status": "Proposed Standard",<br>      "obsoletes": [<br>        "RFC2965"<br>      ],<br>      "publisher": "IETF",<br>      "id": "rfc6265",<br>      "date": "April 2011"<br>    },<br>    "ENCODING": {<br>      "aliasOf": "encoding",<br>      "id": "ENCODING"<br>    },<br>    "encoding": {<br>      "authors": [<br>        "Anne van Kesteren",<br>        "Joshua Bell",<br>        "Addison Phillips"<br>      ],<br>      "href": "http://www.w3.org/TR/encoding/",<br>      "title": "Encoding",<br>      "status": "CR",<br>      "publisher": "W3C",<br>      "deliveredBy": [<br>        {<br>          "url": "http://www.w3.org/International/core/",<br>          "shortname": "i18n_core"<br>        }<br>      ],<br>      "versions": [<br>        "encoding-20140916",<br>        "encoding-20140603",<br>        "encoding-20140128"<br>      ],<br>      "edDraft": "https://encoding.spec.whatwg.org/",<br>      "id": "encoding",<br>      "date": "16 September 2014"<br>    },<br>    "JWK": {<br>      "authors": [<br>        "Mike Jones"<br>      ],<br>      "date": "28 May 2013",<br>      "href": "https://tools.ietf.org/html/draft-ietf-jose-json-web-key-11",<br>      "publisher": "IETF",<br>      "status": "Internet Draft",<br>      "title": "JSON Web Key (JWK)",<br>      "id": "JWK"<br>    },<br>    "RFC6838": {<br>      "aliasOf": "rfc6838",<br>      "id": "RFC6838"<br>    },<br>    "rfc6838": {<br>      "href": "https://tools.ietf.org/html/rfc6838",<br>      "title": "Media Type Specifications and Registration Procedures",<br>      "authors": [<br>        "N. Freed",<br>        "J. Klensin",<br>        "T. Hansen"<br>      ],<br>      "status": "Best Current Practice",<br>      "obsoletes": [<br>        "RFC4288"<br>      ],<br>      "publisher": "IETF",<br>      "id": "rfc6838",<br>      "date": "January 2013"<br>    },<br>    "MEDIA-SOURCE": {<br>      "aliasOf": "media-source",<br>      "id": "MEDIA-SOURCE"<br>    },<br>    "media-source": {<br>      "authors": [<br>        "Aaron Colwell",<br>        "Adrian Bateman",<br>        "Mark Watson"<br>      ],<br>      "href": "http://www.w3.org/TR/media-source/",<br>      "title": "Media Source Extensions",<br>      "status": "CR",<br>      "publisher": "W3C",<br>      "deliveredBy": [<br>        {<br>          "url": "http://www.w3.org/html/wg/",<br>          "shortname": "html"<br>        }<br>      ],<br>      "versions": [<br>        "media-source-20150331",<br>        "media-source-20140717",<br>        "media-source-20140109",<br>        "media-source-20130905",<br>        "media-source-20130415",<br>        "media-source-20130129"<br>      ],<br>      "edDraft": "https://w3c.github.io/media-source/",<br>      "id": "media-source",<br>      "date": "31 March 2015"<br>    },<br>    "EME-REGISTRY": {<br>      "title": "Encrypted Media Extensions Stream Format and Initialization Data Format Registry",<br>      "href": "initdata-format-registry.html",<br>      "authors": [<br>        "David Dorwin",<br>        "Adrian Bateman",<br>        "Mark Watson"<br>      ],<br>      "publisher": "W3C"<br>    },<br>    "JWS": {<br>      "authors": [<br>        "M. Jones",<br>        "J. Bradley",<br>        "N. Sakimura"<br>      ],<br>      "date": "25 September 2014",<br>      "href": "https://tools.ietf.org/html/draft-ietf-jose-json-web-signature-33",<br>      "publisher": "IETF",<br>      "status": "Internet Draft",<br>      "title": "JSON Web Signature (JWS)"<br>    }<br>  },<br>  "noIDLSorting": false,<br>  "noIDLSectionTitle": false,<br>  "tocIntroductory": false,<br>  "maxTocLevel": 0<br>}</script></head>
+</style><link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/W3C-ED"><!--[if lt IE 9]><script src='https://www.w3.org/2008/site/js/html5shiv.js'></script><![endif]--><script id="respecFinalConfig" type="application/json">
+{
+  "specStatus": "ED",
+  "previousMaturity": "WD",
+  "previousPublishDate": "2014-08-28T07:00:00.000Z",
+  "shortName": "encrypted-media",
+  "edDraftURI": "https://w3c.github.io/encrypted-media/",
+  "editors": [
+    {
+      "name": "David Dorwin",
+      "url": "",
+      "company": "Google Inc.",
+      "companyURL": "https://www.google.com/"
+    },
+    {
+      "name": "Jerry Smith",
+      "url": "",
+      "company": "Microsoft Corporation",
+      "companyURL": "https://www.microsoft.com/"
+    },
+    {
+      "name": "Mark Watson",
+      "url": "",
+      "company": "Netflix Inc.",
+      "companyURL": "https://www.netflix.com/"
+    },
+    {
+      "name": "Adrian Bateman (until May 2014)",
+      "url": "",
+      "company": "Microsoft Corporation",
+      "companyURL": "https://www.microsoft.com/"
+    }
+  ],
+  "otherLinks": [
+    {
+      "key": "Repository",
+      "href": "https://github.com/w3c/encrypted-media/"
+    }
+  ],
+  "emeDefGroupName": "encrypted-media",
+  "emeUnusedGroupNameExcludeList": [
+    "eme-references-from-registry"
+  ],
+  "wg": "HTML Working Group",
+  "wgURI": "http://www.w3.org/html/wg/",
+  "wgPublicList": "public-html-media",
+  "wgPatentURI": "https://www.w3.org/2004/01/pp-impl/40318/status",
+  "noIDLIn": true,
+  "scheme": "https",
+  "preProcess": [
+    null
+  ],
+  "definitionMap": {
+    "initialization data type": [
+      {
+        "0": {},
+        "context": {},
+        "length": 1
+      }
+    ],
+    "notsupportederror": [
+      {
+        "0": {},
+        "context": {},
+        "length": 1
+      }
+    ],
+    "invalidstateerror": [
+      {
+        "0": {},
+        "context": {},
+        "length": 1
+      }
+    ],
+    "invalidaccesserror": [
+      {
+        "0": {},
+        "context": {},
+        "length": 1
+      }
+    ],
+    "quotaexceedederror": [
+      {
+        "0": {},
+        "context": {},
+        "length": 1
+      }
+    ]
+  },
+  "postProcess": [
+    null
+  ],
+  "localBiblio": {
+    "EME-REGISTRY": {
+      "title": "Encrypted Media Extensions Stream Format and Initialization Data Format Registry",
+      "href": "initdata-format-registry.html",
+      "authors": [
+        "David Dorwin",
+        "Adrian Bateman",
+        "Mark Watson"
+      ],
+      "publisher": "W3C"
+    },
+    "JWS": {
+      "authors": [
+        "M. Jones",
+        "J. Bradley",
+        "N. Sakimura"
+      ],
+      "date": "25 September 2014",
+      "href": "https://tools.ietf.org/html/draft-ietf-jose-json-web-signature-33",
+      "publisher": "IETF",
+      "status": "Internet Draft",
+      "title": "JSON Web Signature (JWS)"
+    }
+  },
+  "l10n": {
+    "this_version": "This version:",
+    "latest_published_version": "Latest published version:",
+    "latest_editors_draft": "Latest editor's draft:",
+    "editor": "Editor:",
+    "editors": "Editors:",
+    "author": "Author:",
+    "authors": "Authors:",
+    "abstract": "Abstract",
+    "sotd": "Status of This Document",
+    "status_at_publication": "This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current W3C publications and the latest revision of this technical report can be found in the <a href='http://www.w3.org/TR/'>W3C technical reports index</a> at http://www.w3.org/TR/.",
+    "toc": "Table of Contents",
+    "note": "Note",
+    "fig": "Fig. ",
+    "bug_tracker": "Bug tracker:",
+    "file_a_bug": "file a bug",
+    "open_bugs": "open bugs",
+    "open_parens": "(",
+    "close_parens": ")"
+  },
+  "doRDFa": true,
+  "license": "w3c",
+  "isCCBY": false,
+  "isCGBG": false,
+  "isCGFinal": false,
+  "isBasic": false,
+  "isWebSpec": false,
+  "isRegular": true,
+  "title": "Encrypted Media Extensions",
+  "subtitle": "",
+  "publishDate": "2015-09-03T18:07:25.000Z",
+  "publishYear": 2015,
+  "publishHumanDate": "03 September 2015",
+  "isNoTrack": false,
+  "isRecTrack": false,
+  "isMemberSubmission": false,
+  "isTeamSubmission": false,
+  "isSubmission": false,
+  "anOrA": "an",
+  "isTagFinding": false,
+  "maturity": "ED",
+  "thisVersion": "https://w3c.github.io/encrypted-media/",
+  "latestVersion": "http://www.w3.org/TR/encrypted-media/",
+  "prevVersion": "http://www.w3.org/TR/2014/WD-encrypted-media-20140828/",
+  "multipleEditors": true,
+  "alternatesHTML": "",
+  "longStatus": "Editor's Draft",
+  "textStatus": "Editor's Draft",
+  "showThisVersion": true,
+  "showPreviousVersion": false,
+  "notYetRec": false,
+  "isRec": false,
+  "notRec": true,
+  "isUnofficial": false,
+  "prependW3C": true,
+  "isED": true,
+  "isLC": false,
+  "isCR": false,
+  "isPR": false,
+  "isPER": false,
+  "isMO": false,
+  "isIGNote": false,
+  "dashDate": "2015-09-03",
+  "publishISODate": "2015-09-03T18:07:25.000Z",
+  "shortISODate": "2015-09-03",
+  "processVersion": "2015",
+  "isNewProcess": true,
+  "sotdCustomParagraph": "\n      <p>The working group maintains <a href=\"https://github.com/w3c/encrypted-media/issues\">a list of all bug reports that the editors have not yet tried to address</a>; there are also open bugs in the <a href=\"https://www.w3.org/brief/MjY5\">previous bug tracker</a>. This draft highlights some of the pending issues that are still to be discussed in the working group. No decision has been taken on the outcome of these issues including whether they are valid.</p>\n      <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should join the mailing list mentioned below and take part in the discussions.</p>\n\n      <p class=\"issue\"><a href=\"https://www.w3.org/Bugs/Public/show_bug.cgi?id=20944\">Bug 20944</a> - The specification should do more to encourage/ensure CDM-level interoperability.</p>\n      <p class=\"issue\">This specification contains sections for describing <a href=\"#security\">security</a> and <a href=\"#privacy\">privacy</a> considerations. These sections are not final and review is welcome.</p>\n\n<!-- This will be populated when addressing https://www.w3.org/Bugs/Public/show_bug.cgi?id=23827.\n      <p>The following features are <strong>at risk</strong> and may be removed due to lack of implementation.\n      </p>\n      <ul>\n        <li><a def-id=\"\"></a></li>\n      </ul>\n -->\n    ",
+  "multipleWGs": false,
+  "wgHTML": "<a href='http://www.w3.org/html/wg/'>HTML Working Group</a>",
+  "humanLCEnd": "30 November 1899",
+  "humanCREnd": "30 November 1899",
+  "humanPREnd": "30 November 1899",
+  "humanPEREnd": "30 November 1899",
+  "recNotExpected": false,
+  "subjectPrefixEnc": "undefined",
+  "normativeReferences": {
+    "HTML5": true,
+    "MIXED-CONTENT": true,
+    "RFC6381": true,
+    "WebIDL": true,
+    "DOM": true,
+    "COOKIES": true,
+    "ENCODING": true,
+    "JWK": true
+  },
+  "informativeReferences": {
+    "EME-REGISTRY": true,
+    "RFC6838": true,
+    "MEDIA-SOURCE": true,
+    "JWS": true
+  },
+  "respecRFC2119": {
+    "MUST": true,
+    "MUST NOT": true,
+    "MAY": true,
+    "RECOMMENDED": true,
+    "SHALL": true,
+    "SHOULD": true,
+    "SHOULD NOT": true,
+    "REQUIRED": true,
+    "SHALL NOT": true,
+    "OPTIONAL": true
+  },
+  "biblio": {
+    "HTML5": {
+      "aliasOf": "html5",
+      "id": "HTML5"
+    },
+    "html5": {
+      "authors": [
+        "Ian Hickson",
+        "Robin Berjon",
+        "Steve Faulkner",
+        "Travis Leithead",
+        "Erika Doyle Navara",
+        "Edward O'Connor",
+        "Silvia Pfeiffer"
+      ],
+      "href": "http://www.w3.org/TR/html5/",
+      "title": "HTML5",
+      "status": "REC",
+      "publisher": "W3C",
+      "deliveredBy": [
+        {
+          "url": "http://www.w3.org/html/wg/",
+          "shortname": "html"
+        }
+      ],
+      "versions": [
+        "html5-20141028",
+        "html5-20140916",
+        "html5-20140731",
+        "html5-20140617",
+        "html5-20140429",
+        "html5-20140204",
+        "html5-20130806",
+        "html5-20121217",
+        "html5-20121025",
+        "html5-20120329",
+        "html5-20110525",
+        "html5-20110405",
+        "html5-20110113",
+        "html5-20101019",
+        "html5-20100624",
+        "html5-20100304",
+        "html5-20090825",
+        "html5-20090423",
+        "html5-20090212",
+        "html5-20080610",
+        "html5-20080122"
+      ],
+      "edDraft": "http://www.w3.org/html/wg/drafts/html/master/",
+      "obsoletes": [
+        "Window",
+        "web-forms-2"
+      ],
+      "id": "html5",
+      "date": "28 October 2014"
+    },
+    "MIXED-CONTENT": {
+      "aliasOf": "mixed-content",
+      "id": "MIXED-CONTENT"
+    },
+    "mixed-content": {
+      "href": "http://www.w3.org/TR/mixed-content/",
+      "title": "Mixed Content",
+      "status": "CR",
+      "publisher": "W3C",
+      "edDraft": "https://w3c.github.io/webappsec/specs/mixedcontent/",
+      "deliveredBy": [
+        {
+          "url": "http://www.w3.org/2011/webappsec/",
+          "shortname": "webappsec"
+        }
+      ],
+      "versions": [
+        "mixed-content-20150317",
+        "mixed-content-20141113",
+        "mixed-content-20140916",
+        "mixed-content-20140722"
+      ],
+      "authors": [
+        "Mike West"
+      ],
+      "id": "mixed-content",
+      "date": "17 March 2015"
+    },
+    "RFC6381": {
+      "aliasOf": "rfc6381",
+      "id": "RFC6381"
+    },
+    "rfc6381": {
+      "href": "https://tools.ietf.org/html/rfc6381",
+      "title": "The 'Codecs' and 'Profiles' Parameters for \"Bucket\" Media Types",
+      "authors": [
+        "R. Gellens",
+        "D. Singer",
+        "P. Frojdh"
+      ],
+      "status": "Proposed Standard",
+      "obsoletes": [
+        "RFC4281"
+      ],
+      "publisher": "IETF",
+      "id": "rfc6381",
+      "date": "August 2011"
+    },
+    "WebIDL": {
+      "aliasOf": "WebIDL-1",
+      "id": "WebIDL"
+    },
+    "WebIDL-1": {
+      "authors": [
+        "Cameron McCormack",
+        "Boris Zbarsky"
+      ],
+      "href": "http://www.w3.org/TR/WebIDL-1/",
+      "title": "WebIDL Level 1",
+      "status": "WD",
+      "publisher": "W3C",
+      "edDraft": "https://heycam.github.io/webidl/",
+      "deliveredBy": [
+        {
+          "url": "http://www.w3.org/2008/webapps/",
+          "shortname": "webapps"
+        }
+      ],
+      "versions": [
+        "WebIDL-1-20150804",
+        "WebIDL-1-20120419",
+        "WebIDL-1-20120207",
+        "WebIDL-1-20110927",
+        "WebIDL-1-20110712",
+        "WebIDL-1-20101021",
+        "WebIDL-1-20081219",
+        "WebIDL-1-20080829",
+        "WebIDL-1-20080410",
+        "WebIDL-1-20071017"
+      ],
+      "id": "WebIDL-1",
+      "date": "4 August 2015"
+    },
+    "DOM": {
+      "aliasOf": "dom",
+      "id": "DOM"
+    },
+    "dom": {
+      "authors": [
+        "Anne van Kesteren",
+        "Aryeh Gregor",
+        "Ms2ger",
+        "Alex Russell",
+        "Robin Berjon"
+      ],
+      "href": "http://www.w3.org/TR/dom/",
+      "title": "W3C DOM4",
+      "status": "LCWD",
+      "publisher": "W3C",
+      "deliveredBy": [
+        {
+          "url": "http://www.w3.org/html/wg/",
+          "shortname": "html"
+        }
+      ],
+      "versions": [
+        "dom-20150618",
+        "dom-20150428",
+        "dom-20140710",
+        "dom-20140508",
+        "dom-20140204",
+        "dom-20131107",
+        "dom-20121206",
+        "dom-20120405",
+        "dom-20120105",
+        "dom-20110915",
+        "dom-20110531",
+        "dom-20101007"
+      ],
+      "edDraft": "https://w3c.github.io/dom/",
+      "id": "dom",
+      "date": "18 June 2015"
+    },
+    "COOKIES": {
+      "aliasOf": "RFC6265",
+      "id": "COOKIES"
+    },
+    "RFC6265": {
+      "aliasOf": "rfc6265",
+      "id": "RFC6265"
+    },
+    "rfc6265": {
+      "href": "https://tools.ietf.org/html/rfc6265",
+      "title": "HTTP State Management Mechanism",
+      "authors": [
+        "A. Barth"
+      ],
+      "status": "Proposed Standard",
+      "obsoletes": [
+        "RFC2965"
+      ],
+      "publisher": "IETF",
+      "id": "rfc6265",
+      "date": "April 2011"
+    },
+    "ENCODING": {
+      "aliasOf": "encoding",
+      "id": "ENCODING"
+    },
+    "encoding": {
+      "authors": [
+        "Anne van Kesteren",
+        "Joshua Bell",
+        "Addison Phillips"
+      ],
+      "href": "http://www.w3.org/TR/encoding/",
+      "title": "Encoding",
+      "status": "CR",
+      "publisher": "W3C",
+      "deliveredBy": [
+        {
+          "url": "http://www.w3.org/International/core/",
+          "shortname": "i18n_core"
+        }
+      ],
+      "versions": [
+        "encoding-20140916",
+        "encoding-20140603",
+        "encoding-20140128"
+      ],
+      "edDraft": "https://encoding.spec.whatwg.org/",
+      "id": "encoding",
+      "date": "16 September 2014"
+    },
+    "JWK": {
+      "authors": [
+        "Mike Jones"
+      ],
+      "date": "28 May 2013",
+      "href": "https://tools.ietf.org/html/draft-ietf-jose-json-web-key-11",
+      "publisher": "IETF",
+      "status": "Internet Draft",
+      "title": "JSON Web Key (JWK)",
+      "id": "JWK"
+    },
+    "RFC6838": {
+      "aliasOf": "rfc6838",
+      "id": "RFC6838"
+    },
+    "rfc6838": {
+      "href": "https://tools.ietf.org/html/rfc6838",
+      "title": "Media Type Specifications and Registration Procedures",
+      "authors": [
+        "N. Freed",
+        "J. Klensin",
+        "T. Hansen"
+      ],
+      "status": "Best Current Practice",
+      "obsoletes": [
+        "RFC4288"
+      ],
+      "publisher": "IETF",
+      "id": "rfc6838",
+      "date": "January 2013"
+    },
+    "MEDIA-SOURCE": {
+      "aliasOf": "media-source",
+      "id": "MEDIA-SOURCE"
+    },
+    "media-source": {
+      "authors": [
+        "Aaron Colwell",
+        "Adrian Bateman",
+        "Mark Watson"
+      ],
+      "href": "http://www.w3.org/TR/media-source/",
+      "title": "Media Source Extensions",
+      "status": "CR",
+      "publisher": "W3C",
+      "deliveredBy": [
+        {
+          "url": "http://www.w3.org/html/wg/",
+          "shortname": "html"
+        }
+      ],
+      "versions": [
+        "media-source-20150331",
+        "media-source-20140717",
+        "media-source-20140109",
+        "media-source-20130905",
+        "media-source-20130415",
+        "media-source-20130129"
+      ],
+      "edDraft": "https://w3c.github.io/media-source/",
+      "id": "media-source",
+      "date": "31 March 2015"
+    },
+    "EME-REGISTRY": {
+      "title": "Encrypted Media Extensions Stream Format and Initialization Data Format Registry",
+      "href": "initdata-format-registry.html",
+      "authors": [
+        "David Dorwin",
+        "Adrian Bateman",
+        "Mark Watson"
+      ],
+      "publisher": "W3C"
+    },
+    "JWS": {
+      "authors": [
+        "M. Jones",
+        "J. Bradley",
+        "N. Sakimura"
+      ],
+      "date": "25 September 2014",
+      "href": "https://tools.ietf.org/html/draft-ietf-jose-json-web-signature-33",
+      "publisher": "IETF",
+      "status": "Internet Draft",
+      "title": "JSON Web Signature (JWS)"
+    }
+  },
+  "noIDLSorting": false,
+  "noIDLSectionTitle": false,
+  "tocIntroductory": false,
+  "maxTocLevel": 0
+}
+</script></head>
   <body class="h-entry" role="document" id="respecDocument"><div class="head" role="contentinfo" id="respecHeader">
   <p>
       


### PR DESCRIPTION
I was about to submit a PR that would add a few changes to enable [automatic publication of the WD with Echidna](https://github.com/w3c/echidna/wiki/FAQ).

One of the necessary changes is to [add the W3C IDs of all editors of the spec](https://github.com/w3c/echidna/wiki/Preparing-your-document#data-editor-id) to the ReSpec config.

Before editing that *very long* line, I thought maybe we could format it better?

This PR tries to do that. I think the change isn't complete; this `script` element has to be moved somewhere else for ReSpec to be able to use it.

Can someone take a look, and confirm this is a good idea? Specifically, that this chunk of JSON isn't automatically overwritten by some tool&hellip;