### PR TITLE
Fix #148: Update CENC and ISOBMFF references

### DIFF
--- a/format-registry/initdata/cenc-respec.html
+++ b/format-registry/initdata/cenc-respec.html
@@ -76,8 +76,8 @@
 
       localBiblio: {
           "CENC": {
-            title: "ISO/IEC 23001-7:2015, Information technology — MPEG systems technologies — Part 7: Common encryption in ISO Base Media File Format files - 2nd Edition",
-            href: "https://www.iso.org/obp/ui/#iso:std:iso-iec:23001:-7:ed-2:v1",
+            title: "ISO/IEC 23001-7:2016, Information technology — MPEG systems technologies — Part 7: Common encryption in ISO base media file format files",
+            href: "https://www.iso.org/obp/ui/#iso:std:iso-iec:23001:-7:ed-3:v1:en",
             status: "International Standard",
             publisher: "ISO/IEC"
           }

--- a/format-registry/initdata/cenc.html
+++ b/format-registry/initdata/cenc.html
@@ -270,7 +270,7 @@ table.simple {
     "encrypted-media",
     "eme-references-from-registry"
   ],
-  "wg": "HTML Working Group",
+  "wg": "HTML Media Extensions Working Group",
   "wgURI": "http://www.w3.org/html/wg/",
   "wgPublicList": "public-html-media",
   "wgPatentURI": "https://www.w3.org/2004/01/pp-impl/40318/status",
@@ -285,8 +285,8 @@ table.simple {
   ],
   "localBiblio": {
     "CENC": {
-      "title": "ISO/IEC 23001-7:2015, Information technology — MPEG systems technologies — Part 7: Common encryption in ISO Base Media File Format files - 2nd Edition",
-      "href": "https://www.iso.org/obp/ui/#iso:std:iso-iec:23001:-7:ed-2:v1",
+      "title": "ISO/IEC 23001-7:2016, Information technology — MPEG systems technologies — Part 7: Common encryption in ISO base media file format files",
+      "href": "https://www.iso.org/obp/ui/#iso:std:iso-iec:23001:-7:ed-3:v1:en",
       "status": "International Standard",
       "publisher": "ISO/IEC"
     },
@@ -312,12 +312,12 @@ table.simple {
     }
   }
 }</script></head>
-  <body class="h-entry toc-inline" role="document" id="respecDocument"><div class="head" role="contentinfo" id="respecHeader">
+  <body class="h-entry" role="document" id="respecDocument"><div class="head" role="contentinfo" id="respecHeader">
   <p>
             <a class="logo" href="http://www.w3.org/"><img width="72" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" alt="W3C"></a>
   </p>
   <h1 class="title p-name" id="title" property="dcterms:title">"cenc" Initialization Data Format</h1>
-  <h2 id="w3c-editor-s-draft-25-april-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2016-04-25">25 April 2016</time></h2>
+  <h2 id="w3c-editor-s-draft-17-may-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2016-05-17">17 May 2016</time></h2>
   <dl>
       <dt>This version:</dt>
       <dd><a class="u-url" href="https://w3c.github.io/encrypted-media/format-registry/initdata/cenc.html">https://w3c.github.io/encrypted-media/format-registry/initdata/cenc.html</a></dd>
@@ -377,7 +377,7 @@ table.simple {
       <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should join the mailing list mentioned below and take part in the discussions.</p>
     
           <p>
-            This document was published by the <a href="http://www.w3.org/html/wg/">HTML Working Group</a> as an Editor's Draft.
+            This document was published by the <a href="http://www.w3.org/html/wg/">HTML Media Extensions Working Group</a> as an Editor's Draft.
               If you wish to make comments regarding this document, please send them to
               <a href="mailto:public-html-media@w3.org">public-html-media@w3.org</a>
               (<a href="mailto:public-html-media-request@w3.org?subject=subscribe">subscribe</a>,
@@ -486,8 +486,8 @@ table.simple {
 
   
 
-</section><section id="references" class="appendix" typeof="bibo:Chapter" resource="#references" property="bibo:hasPart"><!--OddPage--><h2 id="h-references" resource="#h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>References</span></h2><section id="normative-references" typeof="bibo:Chapter" resource="#normative-references" property="bibo:hasPart"><h3 id="h-normative-references" resource="#h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.1 </span>Normative references</span></h3><dl class="bibliography" resource=""><dt id="bib-CENC">[CENC]</dt><dd>ISO/IEC. <a href="https://www.iso.org/obp/ui/#iso:std:iso-iec:23001:-7:ed-2:v1" property="dc:requires"><cite>ISO/IEC 23001-7:2015, Information technology — MPEG systems technologies — Part 7: Common encryption in ISO Base Media File Format files - 2nd Edition</cite></a>. International Standard. URL: <a href="https://www.iso.org/obp/ui/#iso:std:iso-iec:23001:-7:ed-2:v1" property="dc:requires">https://www.iso.org/obp/ui/#iso:std:iso-iec:23001:-7:ed-2:v1</a>
-</dd><dt id="bib-ENCRYPTED-MEDIA">[ENCRYPTED-MEDIA]</dt><dd>David Dorwin; Jerry Smith; Mark Watson; Adrian Bateman. W3C. <a href="http://www.w3.org/TR/encrypted-media/" property="dc:requires"><cite>Encrypted Media Extensions</cite></a>. 21 April 2016. W3C Working Draft. URL: <a href="http://www.w3.org/TR/encrypted-media/" property="dc:requires">http://www.w3.org/TR/encrypted-media/</a>
+</section><section id="references" class="appendix" typeof="bibo:Chapter" resource="#references" property="bibo:hasPart"><!--OddPage--><h2 id="h-references" resource="#h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>References</span></h2><section id="normative-references" typeof="bibo:Chapter" resource="#normative-references" property="bibo:hasPart"><h3 id="h-normative-references" resource="#h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.1 </span>Normative references</span></h3><dl class="bibliography" resource=""><dt id="bib-CENC">[CENC]</dt><dd>ISO/IEC. <a href="https://www.iso.org/obp/ui/#iso:std:iso-iec:23001:-7:ed-3:v1:en" property="dc:requires"><cite>ISO/IEC 23001-7:2016, Information technology — MPEG systems technologies — Part 7: Common encryption in ISO base media file format files</cite></a>. International Standard. URL: <a href="https://www.iso.org/obp/ui/#iso:std:iso-iec:23001:-7:ed-3:v1:en" property="dc:requires">https://www.iso.org/obp/ui/#iso:std:iso-iec:23001:-7:ed-3:v1:en</a>
+</dd><dt id="bib-ENCRYPTED-MEDIA">[ENCRYPTED-MEDIA]</dt><dd>David Dorwin; Jerry Smith; Mark Watson; Adrian Bateman. W3C. <a href="http://www.w3.org/TR/encrypted-media/" property="dc:requires"><cite>Encrypted Media Extensions</cite></a>. 17 May 2016. W3C Working Draft. URL: <a href="http://www.w3.org/TR/encrypted-media/" property="dc:requires">http://www.w3.org/TR/encrypted-media/</a>
 </dd></dl></section><section id="informative-references" typeof="bibo:Chapter" resource="#informative-references" property="bibo:hasPart"><h3 id="h-informative-references" resource="#h-informative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.2 </span>Informative references</span></h3><dl class="bibliography" resource=""><dt id="bib-EME-STREAM-REGISTRY">[EME-STREAM-REGISTRY]</dt><dd>David Dorwin; Adrian Bateman; Mark Watson. W3C. <a href="../stream/" property="dc:references"><cite>Encrypted Media Extensions Stream Format Registry</cite></a>. URL: <a href="../stream/" property="dc:references">../stream/</a>
 </dd><dt id="bib-MPEGDASH">[MPEGDASH]</dt><dd><a href="http://standards.iso.org/ittf/PubliclyAvailableStandards/c065274_ISO_IEC_23009-1_2014.zip" property="dc:references"><cite>ISO/IEC 23009-1:2014 Information technology -- Dynamic adaptive streaming over HTTP (DASH) -- Part 1: Media presentation description and segment formats</cite></a>. URL: <a href="http://standards.iso.org/ittf/PubliclyAvailableStandards/c065274_ISO_IEC_23009-1_2014.zip" property="dc:references">http://standards.iso.org/ittf/PubliclyAvailableStandards/c065274_ISO_IEC_23009-1_2014.zip</a>
 </dd></dl></section></section><p role="navigation" id="back-to-top"><a href="#toc"><abbr title="Back to Top">↑</abbr></a></p><script async="" defer="" src="https://www.w3.org/scripts/TR/2016/fixup.js"></script></body></html>

--- a/format-registry/stream/mp4.html
+++ b/format-registry/stream/mp4.html
@@ -238,7 +238,7 @@ table.simple {
     "encrypted-media",
     "eme-references-from-registry"
   ],
-  "wg": "HTML Working Group",
+  "wg": "HTML Media Extensions Working Group",
   "wgURI": "http://www.w3.org/html/wg/",
   "wgPublicList": "public-html-media",
   "wgPatentURI": "https://www.w3.org/2004/01/pp-impl/40318/status",
@@ -280,12 +280,12 @@ table.simple {
     }
   }
 }</script></head>
-  <body class="h-entry toc-inline" role="document" id="respecDocument"><div class="head" role="contentinfo" id="respecHeader">
+  <body class="h-entry" role="document" id="respecDocument"><div class="head" role="contentinfo" id="respecHeader">
   <p>
             <a class="logo" href="http://www.w3.org/"><img width="72" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" alt="W3C"></a>
   </p>
   <h1 class="title p-name" id="title" property="dcterms:title">ISO Common Encryption ('cenc') Protection Scheme for ISO Base Media File Format Stream Format</h1>
-  <h2 id="w3c-editor-s-draft-25-april-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2016-04-25">25 April 2016</time></h2>
+  <h2 id="w3c-editor-s-draft-17-may-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2016-05-17">17 May 2016</time></h2>
   <dl>
       <dt>This version:</dt>
       <dd><a class="u-url" href="https://w3c.github.io/encrypted-media/format-registry/stream/mp4.html">https://w3c.github.io/encrypted-media/format-registry/stream/mp4.html</a></dd>
@@ -342,7 +342,7 @@ table.simple {
       <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should join the mailing list mentioned below and take part in the discussions.</p>
     
           <p>
-            This document was published by the <a href="http://www.w3.org/html/wg/">HTML Working Group</a> as an Editor's Draft.
+            This document was published by the <a href="http://www.w3.org/html/wg/">HTML Media Extensions Working Group</a> as an Editor's Draft.
               If you wish to make comments regarding this document, please send them to
               <a href="mailto:public-html-media@w3.org">public-html-media@w3.org</a>
               (<a href="mailto:public-html-media-request@w3.org?subject=subscribe">subscribe</a>,
@@ -414,6 +414,6 @@ table.simple {
 
 <section id="references" class="appendix" typeof="bibo:Chapter" resource="#references" property="bibo:hasPart"><!--OddPage--><h2 id="h-references" resource="#h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>References</span></h2><section id="normative-references" typeof="bibo:Chapter" resource="#normative-references" property="bibo:hasPart"><h3 id="h-normative-references" resource="#h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.1 </span>Normative references</span></h3><dl class="bibliography" resource=""><dt id="bib-CENC">[CENC]</dt><dd>ISO/IEC. <a href="https://www.iso.org/obp/ui/#iso:std:iso-iec:23001:-7:ed-2:v1" property="dc:requires"><cite>ISO/IEC 23001-7:2015, Information technology — MPEG systems technologies — Part 7: Common encryption in ISO Base Media File Format files - 2nd Edition</cite></a>. International Standard. URL: <a href="https://www.iso.org/obp/ui/#iso:std:iso-iec:23001:-7:ed-2:v1" property="dc:requires">https://www.iso.org/obp/ui/#iso:std:iso-iec:23001:-7:ed-2:v1</a>
 </dd><dt id="bib-EME-INITDATA-REGISTRY">[EME-INITDATA-REGISTRY]</dt><dd>David Dorwin; Adrian Bateman; Mark Watson. W3C. <a href="../initdata/" property="dc:requires"><cite>Encrypted Media Extensions Initialization Data Format Registry</cite></a>. URL: <a href="../initdata/" property="dc:requires">../initdata/</a>
-</dd><dt id="bib-ENCRYPTED-MEDIA">[ENCRYPTED-MEDIA]</dt><dd>David Dorwin; Jerry Smith; Mark Watson; Adrian Bateman. W3C. <a href="http://www.w3.org/TR/encrypted-media/" property="dc:requires"><cite>Encrypted Media Extensions</cite></a>. 21 April 2016. W3C Working Draft. URL: <a href="http://www.w3.org/TR/encrypted-media/" property="dc:requires">http://www.w3.org/TR/encrypted-media/</a>
-</dd><dt id="bib-ISOBMFF">[ISOBMFF]</dt><dd><a href="http://standards.iso.org/ittf/PubliclyAvailableStandards/c061988_ISO_IEC_14496-12_2012.zip" property="dc:requires"><cite>Information technology -- Coding of audio-visual objects -- Part 12: ISO base media file format</cite></a> ISO/IEC 14496-12:2012. URL: <a href="http://standards.iso.org/ittf/PubliclyAvailableStandards/c061988_ISO_IEC_14496-12_2012.zip" property="dc:requires">http://standards.iso.org/ittf/PubliclyAvailableStandards/c061988_ISO_IEC_14496-12_2012.zip</a> 
+</dd><dt id="bib-ENCRYPTED-MEDIA">[ENCRYPTED-MEDIA]</dt><dd>David Dorwin; Jerry Smith; Mark Watson; Adrian Bateman. W3C. <a href="http://www.w3.org/TR/encrypted-media/" property="dc:requires"><cite>Encrypted Media Extensions</cite></a>. 17 May 2016. W3C Working Draft. URL: <a href="http://www.w3.org/TR/encrypted-media/" property="dc:requires">http://www.w3.org/TR/encrypted-media/</a>
+</dd><dt id="bib-ISOBMFF">[ISOBMFF]</dt><dd>ISO/IEC. <a href="http://standards.iso.org/ittf/PubliclyAvailableStandards/c068960_ISO_IEC_14496-12_2015.zip" property="dc:requires"><cite>Information technology — Coding of audio-visual objects — Part 12: ISO Base Media File Format</cite></a>. December 2015. International Standard. URL: <a href="http://standards.iso.org/ittf/PubliclyAvailableStandards/c068960_ISO_IEC_14496-12_2015.zip" property="dc:requires">http://standards.iso.org/ittf/PubliclyAvailableStandards/c068960_ISO_IEC_14496-12_2015.zip</a>
 </dd></dl></section></section><p role="navigation" id="back-to-top"><a href="#toc"><abbr title="Back to Top">↑</abbr></a></p><script async="" defer="" src="https://www.w3.org/scripts/TR/2016/fixup.js"></script></body></html>


### PR DESCRIPTION
-  Manually updated CENC reference info in cenc-respec.html
-  Updated snapshot of mp4-respec.html to get new ISOBMFF reference info
from specref