### PR TITLE
Fix #196: Be more explicit about the implications of empty robustness strings

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -1282,7 +1282,7 @@
             <div class="note">
             <p>
               Implementations MUST configure the CDM to support at least the robustness levels specified in the configuration of the MediaKeySystemAccess object used to create the MediaKeys object.
-              Exact configuration of the CDM is implementation-dependent Implementations and MAY be set to the use the highest robustness level in the configuration even if a higher robustness level is available.
+              Exact configuration of the CDM is implementation-specific, and implementations MAY configure the CDM to use the highest robustness level in the configuration even if a higher robustness level is available.
               If only the empty string is specified, implementations MAY be configured to use the lowest robustness level the implementation supports.
             </p>
             <p>

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -1266,15 +1266,28 @@
         <dl title="dictionary MediaKeySystemMediaCapability" class='idl'>
           <dt>DOMString contentType = ""</dt>
           <dd>
-            The type of the <a def-id="media-resource">media resource</a>.
-            Its value must be a <a def-id="mime-types">valid MIME type</a> [[!HTML5]].
-            The codecs parameter, which certain MIME types define, might be necessary to specify exactly how the resource is encoded. [[!RFC6381]]
-            The empty string is invalid.
+            <p>
+              The type of the <a def-id="media-resource">media resource</a>.
+              Its value must be a <a def-id="mime-types">valid MIME type</a> [[!HTML5]].
+              The codecs parameter, which certain MIME types define, might be necessary to specify exactly how the resource is encoded. [[!RFC6381]]
+              The empty string is invalid.
+            </p>
           </dd>
           <dt>DOMString robustness = ""</dt>
           <dd>
-            The robustness level associated with the content type.
-            The empty string indicates that any ability to decrypt and decode the content type is acceptable.
+            <p>
+              The robustness level associated with the content type.
+              The empty string indicates that any ability to decrypt and decode the content type is acceptable.
+            </p>
+            <div class="note">
+            <p>
+              Implementations MUST configure the CDM to support at least the robustness levels specified in the configuration of the MediaKeySystemAccess object used to create the MediaKeys object.
+              Exact configuration of the CDM is implementation-dependent Implementations and MAY be set to the use the highest robustness level in the configuration even if a higher robustness level is available.
+              If only the empty string is specified, implementations MAY be configured to use the lowest robustness level the implementation supports.
+            </p>
+            <p>
+              Applications SHOULD specify the robustness level(s) they require to avoid unexpected client incompatibilities.
+            </p>
           </dd>
         </dl>
 

--- a/index.html
+++ b/index.html
@@ -914,7 +914,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
     }
   </script>
 </head>
-<body class="h-entry toc-inline" role="document" id="respecDocument">
+<body class="h-entry" role="document" id="respecDocument">
   <div class="head" role="contentinfo" id="respecHeader">
     <p>
       <a class="logo" href="http://www.w3.org/"><img width="72" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" alt="W3C"></a>
@@ -2687,32 +2687,17 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         <h4 id="h-dictionary-mediakeysystemmediacapability-members" resource="#h-dictionary-mediakeysystemmediacapability-members"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.3.1 </span>Dictionary <a class="idlType" href="#idl-def-MediaKeySystemMediaCapability"><code>MediaKeySystemMediaCapability</code></a> Members</span></h4>
         <dl class="dictionary-members"><dt id="widl-MediaKeySystemMediaCapability-contentType"><code>contentType</code> of type <span class="idlMemberType">DOMString</span>, defaulting to <code>""</code></dt>
           <dd>
-            <p>
-              The type of the <a href="http://www.w3.org/TR/html5/embedded-content-0.html#media-resource">media resource</a>. Its value must be a <a href="http://www.w3.org/TR/html5/embedded-content-0.html#mime-types">valid MIME type</a> [<cite><a class="bibref" href="#bib-HTML5">HTML5</a></cite>]. The codecs parameter, which certain MIME types define, might be necessary to specify exactly how the resource is encoded. [<cite><a class="bibref" href="#bib-RFC6381">RFC6381</a></cite>] The empty string is invalid.
-            </p>
+            The type of the <a href="http://www.w3.org/TR/html5/embedded-content-0.html#media-resource">media resource</a>. Its value must be a <a href="http://www.w3.org/TR/html5/embedded-content-0.html#mime-types">valid MIME type</a> [<cite><a class="bibref" href="#bib-HTML5">HTML5</a></cite>]. The codecs parameter, which certain MIME types define, might be necessary to specify exactly how the resource is encoded. [<cite><a class="bibref" href="#bib-RFC6381">RFC6381</a></cite>] The empty string is invalid.
           </dd><dt id="widl-MediaKeySystemMediaCapability-robustness"><code>robustness</code> of type <span class="idlMemberType">DOMString</span>, defaulting to <code>""</code></dt>
           <dd>
-            <p>
-              The robustness level associated with the content type. The empty string indicates that any ability to decrypt and decode the content type is acceptable.
-            </p>
-            <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note44"><span>Note</span></div>
-              <div class="">
-                <p>
-                  Implementations <em class="rfc2119" title="MUST">MUST</em> configure the CDM to support at least the robustness levels specified in the configuration of the MediaKeySystemAccess object used to create the MediaKeys object. Exact configuration of the CDM is implementation-dependent Implementations and <em class="rfc2119" title="MAY">MAY</em> be set to the use the highest robustness level in the configuration even if a higher robustness level is available. If only the empty string is specified, implementations <em class="rfc2119" title="MAY">MAY</em> be configured to use the lowest robustness level the implementation supports.
-                </p>
-                <p>
-                  Applications <em class="rfc2119" title="SHOULD">SHOULD</em> specify the robustness level(s) they require to avoid unexpected client incompatibilities.
-                </p>
-              </div>
-            </div>
+            The robustness level associated with the content type. The empty string indicates that any ability to decrypt and decode the content type is acceptable.
           </dd>
         </dl>
       </section>
 
       <p>In order for the capability represented by this object to be considered supported, <code><a href="#widl-MediaKeySystemMediaCapability-contentType">contentType</a></code> <em class="rfc2119" title="MUST NOT">MUST NOT</em> be the empty string and its entire value, including all codecs, <em class="rfc2119" title="MUST">MUST</em> be supported with <code><a href="#widl-MediaKeySystemMediaCapability-robustness">robustness</a></code>.</p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note45"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note44"><span>Note</span></div>
         <p class="">If any of a set of codecs is acceptable, use a separate instances of this dictionary for each codec.</p>
       </div>
     </section>
@@ -2772,7 +2757,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                     </dd>
                   </dl>
                   <div class="note">
-                    <div class="note-title marker" aria-level="4" role="heading" id="h-note46"><span>Note</span></div>
+                    <div class="note-title marker" aria-level="4" role="heading" id="h-note45"><span>Note</span></div>
                     <p class="">The value of <var>distinctive identifier requirement</var> cannot be <code><a href="#idl-def-MediaKeysRequirement.optional">"optional"</a></code>.</p>
                   </div>
                 </li>
@@ -2792,7 +2777,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                     </dd>
                   </dl>
                   <div class="note">
-                    <div class="note-title marker" aria-level="4" role="heading" id="h-note47"><span>Note</span></div>
+                    <div class="note-title marker" aria-level="4" role="heading" id="h-note46"><span>Note</span></div>
                     <p class="">The value of <var>persistent state requirement</var> cannot be <code><a href="#idl-def-MediaKeysRequirement.optional">"optional"</a></code>.</p>
                   </div>
                 </li>
@@ -2860,7 +2845,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                 Return this object's <var>configuration</var> value.
               </p>
               <div class="note">
-                <div class="note-title marker" aria-level="4" role="heading" id="h-note48"><span>Note</span></div>
+                <div class="note-title marker" aria-level="4" role="heading" id="h-note47"><span>Note</span></div>
                 <p class="">
                   This results in a new JavaScript object being created and initialized from <var>configuration</var> each time this method is called.
                 </p>
@@ -2930,13 +2915,13 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
             The <dfn id="key-usage-accuracy" data-dfn-type="dfn"><var>key usage accuracy</var></dfn> is implementation-dependant but <em class="rfc2119" title="SHALL NOT">SHALL NOT</em> be greater than 60 seconds.
           </p>
           <div class="note">
-            <div class="note-title marker" aria-level="3" role="heading" id="h-note49"><span>Note</span></div>
+            <div class="note-title marker" aria-level="3" role="heading" id="h-note48"><span>Note</span></div>
             <p class="">
               Because the license and keys are not persisted, this record implicitly proves that the keys are no longer available in the session.
             </p>
           </div>
           <div class="note">
-            <div class="note-title marker" aria-level="3" role="heading" id="h-note50"><span>Note</span></div>
+            <div class="note-title marker" aria-level="3" role="heading" id="h-note49"><span>Note</span></div>
             <p class="">
               User agents <em class="rfc2119" title="MAY">MAY</em> implement this mechanism by means other than persisting data on key destruction - for example by persisting data during playback which is later used to infer the fact of key destruction - provided the observable behavior is compliant to this specification.
             </p>
@@ -2999,14 +2984,14 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
             <li>
               <p>If this object's <var>supported session types</var> value does not contain <var>sessionType</var>, <a href="https://heycam.github.io/webidl/#dfn-throw">throw</a> [<cite><a class="bibref" href="#bib-WebIDL">WebIDL</a></cite>] a <code><a href="#dfn-NotSupportedError">NotSupportedError</a></code>.</p>
               <div class="note">
-                <div class="note-title marker" aria-level="4" role="heading" id="h-note51"><span>Note</span></div>
+                <div class="note-title marker" aria-level="4" role="heading" id="h-note50"><span>Note</span></div>
                 <p class=""><var>sessionType</var> values for which the <a href="#is-persistent-session-type">Is persistent session type?</a> algorithm returns <code>true</code> will fail if this object's <var>persistent state allowed</var> value is <code>false</code>.</p>
               </div>
             </li>
             <li>
               <p>If the implementation does not support <a href="#idl-def-MediaKeySession" class="idlType"><code>MediaKeySession</code></a> operations in the current state, <a href="https://heycam.github.io/webidl/#dfn-throw">throw</a> [<cite><a class="bibref" href="#bib-WebIDL">WebIDL</a></cite>] an <code><a href="#dfn-InvalidStateError">InvalidStateError</a></code>.</p>
               <div class="note">
-                <div class="note-title marker" aria-level="4" role="heading" id="h-note52"><span>Note</span></div>
+                <div class="note-title marker" aria-level="4" role="heading" id="h-note51"><span>Note</span></div>
                 <p class="">Some implementations are unable to execute <a href="#idl-def-MediaKeySession" class="idlType"><code>MediaKeySession</code></a> algorithms until this <a href="#idl-def-MediaKeys" class="idlType"><code>MediaKeys</code></a> object is associated with a media element using <code><a href="#widl-HTMLMediaElement-setMediaKeys-Promise-void--MediaKeys-mediaKeys">setMediaKeys()</a></code>. This step enables applications to detect this uncommon behavior before attempting to perform such operations.
                 </p>
               </div>
@@ -3060,7 +3045,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
           <p id="server-certificate">Provides a server certificate to be used to encrypt messages to the license server.</p>
           <p>Key Systems that use such certificates <em class="rfc2119" title="MUST">MUST</em> also support requesting the certificate from the server via the <a href="#queue-message">Queue a "message" Event</a> algorithm.</p>
           <div class="note">
-            <div class="note-title marker" aria-level="4" role="heading" id="h-note53"><span>Note</span></div>
+            <div class="note-title marker" aria-level="4" role="heading" id="h-note52"><span>Note</span></div>
             <p class="">This method allows an application to proactively provide a server certificate to implementations that support it to avoid the additional round trip should the CDM request it. It is intended as an optimization, and applications are not required to use it.
             </p>
           </div>
@@ -3198,7 +3183,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       A MediaKeySession object <em class="rfc2119" title="SHALL NOT">SHALL NOT</em> be destroyed and <em class="rfc2119" title="SHALL">SHALL</em> continue to receive events if it has not been closed and the <a href="#idl-def-MediaKeys" class="idlType"><code>MediaKeys</code></a> object that created it remains accessible. Otherwise, a MediaKeySession object that is no longer accessible to JavaScript <em class="rfc2119" title="SHALL NOT">SHALL NOT</em> receive further events and <em class="rfc2119" title="MAY">MAY</em> be destroyed.
     </p>
     <div class="note">
-      <div class="note-title marker" aria-level="3" role="heading" id="h-note54"><span>Note</span></div>
+      <div class="note-title marker" aria-level="3" role="heading" id="h-note53"><span>Note</span></div>
       <p class="">
         The above rule implies that the CDM instance must not be destroyed until all <a href="#idl-def-MediaKeys" class="idlType"><code>MediaKeys</code></a> objects and all <a href="#idl-def-MediaKeySession" class="idlType"><code>MediaKeySession</code></a> objects associated with the CDM instance are destroyed.
       </p>
@@ -3231,7 +3216,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         <dd>
           <p>The <a href="#time">time</a> after which the key(s) in the session will no longer be <a href="#usable-for-decryption">usable for decryption</a>, or <code>NaN</code> if no such time exists or if the license explicitly never expires, as determined by the CDM.</p>
           <div class="note">
-            <div class="note-title marker" aria-level="4" role="heading" id="h-note55"><span>Note</span></div>
+            <div class="note-title marker" aria-level="4" role="heading" id="h-note54"><span>Note</span></div>
             <p class="">This value <em class="rfc2119" title="MAY">MAY</em> change during the session lifetime, such as when an action triggers the start of a window.</p>
           </div>
         </dd><dt id="widl-MediaKeySession-keyStatuses"><code>keyStatuses</code> of type <span class="idlAttrType"><a href="#idl-def-MediaKeyStatusMap" class="idlType"><code>MediaKeyStatusMap</code></a></span>, readonly       </dt>
@@ -3239,12 +3224,12 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
           <p>A reference to a read-only map of <a href="#decryption-key-id">key IDs</a> <a href="#known-key">known</a> to the session to the current status of the associated key. Each entry <em class="rfc2119" title="MUST">MUST</em> have a unique key ID.
           </p>
           <div class="note">
-            <div class="note-title marker" aria-level="4" role="heading" id="h-note56"><span>Note</span></div>
+            <div class="note-title marker" aria-level="4" role="heading" id="h-note55"><span>Note</span></div>
             <p class="">The map entries and their values may be updated whenever the event loop spins. The map <em class="rfc2119" title="MUST NOT">MUST NOT</em> ever be inconsistent or partially updated, but it may change between accesses if the event loop spins in between the accesses. Key IDs may be added as the result of a <code><a href="#widl-MediaKeySession-load-Promise-boolean--DOMString-sessionId">load()</a></code> or <code><a href="#widl-MediaKeySession-update-Promise-void--BufferSource-response">update()</a></code> call. Key IDs may be removed as the result of a <code><a href="#widl-MediaKeySession-update-Promise-void--BufferSource-response">update()</a></code> call that removes knowledge of existing keys (or replaces the existing set of keys with a new set). Key IDs <em class="rfc2119" title="MUST NOT">MUST NOT</em> be removed because they became unusable, such as due to expiration. Instead, such keys <em class="rfc2119" title="MUST">MUST</em> be given an appropriate status, such as <code><a href="#idl-def-MediaKeyStatus.expired">"expired"</a></code>.
             </p>
           </div>
           <div class="note">
-            <div class="note-title marker" aria-level="4" role="heading" id="h-note57"><span>Note</span></div>
+            <div class="note-title marker" aria-level="4" role="heading" id="h-note56"><span>Note</span></div>
             <p class="">
               Some older platforms may contain Key System implementations that do not expose key IDs, making it impossible to provide a compliant user agent implementation. To maximize interoperability, user agent implementations exposing such CDMs <em class="rfc2119" title="SHOULD">SHOULD</em> implement this member as follows: Whenever a non-empty list is appropriate, such as when the <a href="#key-session">key session</a> represented by this object may contain <a href="#decryption-key">key(s)</a>, populate the map with a single pair containing the one-byte key ID <code>0</code> and the <a href="#idl-def-MediaKeyStatus" class="idlType"><code>MediaKeyStatus</code></a> most appropriate for the aggregated status of this object.
             </p>
@@ -3268,7 +3253,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         <dd>
           <p>Indicates that the application no longer needs the session and the CDM should release any resources associated with the session and close it. Persisted data should not be released or cleared.</p>
           <div class="note">
-            <div class="note-title marker" aria-level="4" role="heading" id="h-note58"><span>Note</span></div>
+            <div class="note-title marker" aria-level="4" role="heading" id="h-note57"><span>Note</span></div>
             <p class="">The returned promise is resolved when the request has been processed, and the <code><a href="#widl-MediaKeySession-closed">closed</a></code> attribute promise is resolved when the session is closed.</p>
           </div>
           <div><em>No parameters.</em></div>
@@ -3296,7 +3281,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                 <li>
                   <p>Use <var>cdm</var> to close the <a href="#key-session">session</a> associated with <var>session</var>.</p>
                   <div class="note">
-                    <div class="note-title marker" aria-level="4" role="heading" id="h-note59"><span>Note</span></div>
+                    <div class="note-title marker" aria-level="4" role="heading" id="h-note58"><span>Note</span></div>
                     <p class="">Closing the key session results in the destruction of any license(s) and key(s) that have not been explicitly stored.</p>
                   </div>
                 </li>
@@ -3309,7 +3294,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                     <li>
                       <p>Resolve <var>promise</var>.</p>
                       <div class="note">
-                        <div class="note-title marker" aria-level="4" role="heading" id="h-note60"><span>Note</span></div>
+                        <div class="note-title marker" aria-level="4" role="heading" id="h-note59"><span>Note</span></div>
                         <p class="">Since promise handlers are queued as microtasks, these will be executed ahead of any events queued by the preceding steps.</p>
                       </div>
                     </li>
@@ -3422,7 +3407,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                         <dd>
                           <p>Let <var>requested license type</var> be a temporary non-persistable license.</p>
                           <div class="note">
-                            <div class="note-title marker" aria-level="4" role="heading" id="h-note61"><span>Note</span></div>
+                            <div class="note-title marker" aria-level="4" role="heading" id="h-note60"><span>Note</span></div>
                             <p class="">The returned license must not be persistable or require persisting information related to it.</p>
                           </div>
                         </dd>
@@ -3529,7 +3514,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                     <li>
                       <p>Resolve <var>promise</var>.</p>
                       <div class="note">
-                        <div class="note-title marker" aria-level="4" role="heading" id="h-note62"><span>Note</span></div>
+                        <div class="note-title marker" aria-level="4" role="heading" id="h-note61"><span>Note</span></div>
                         <p class="">Since promise handlers are queued as microtasks, these will be executed ahead of any events queued by the preceding steps.</p>
                       </div>
                     </li>
@@ -3593,7 +3578,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                 <li>
                   <p>Let <var>sanitized session ID</var> be a validated and/or sanitized version of <var>sessionId</var>.</p>
                   <div class="note">
-                    <div class="note-title marker" aria-level="4" role="heading" id="h-note63"><span>Note</span></div>
+                    <div class="note-title marker" aria-level="4" role="heading" id="h-note62"><span>Note</span></div>
                     <p class="">The user agent should thoroughly validate the sessionId value before passing it to the CDM. At a minimum, this should include checking that the length and value (e.g. alphanumeric) are reasonable.
                     </p>
                   </div>
@@ -3604,7 +3589,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                 <li>
                   <p>If there is an unclosed session in this object's <a href="https://www.w3.org/TR/dom/#concept-document">Document</a> whose <code><a href="#widl-MediaKeySession-sessionId">sessionId</a></code> attribute is <var>sanitized session ID</var>, reject <var>promise</var> with a <code><a href="#dfn-QuotaExceededError">QuotaExceededError</a></code>.</p>
                   <div class="note">
-                    <div class="note-title marker" aria-level="4" role="heading" id="h-note64"><span>Note</span></div>
+                    <div class="note-title marker" aria-level="4" role="heading" id="h-note63"><span>Note</span></div>
                     <p class="">In other words, do not create a session if a non-closed session, regardless of type, already exists for this <var>sanitized session ID</var> in this browsing context.</p>
                   </div>
                 </li>
@@ -3636,7 +3621,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                     <li>
                       <p>If there is an unclosed session in any <a href="https://www.w3.org/TR/dom/#concept-document">Document</a> representing the <var>session data</var>, reject <var>promise</var> with a <code><a href="#dfn-QuotaExceededError">QuotaExceededError</a></code>.</p>
                       <div class="note">
-                        <div class="note-title marker" aria-level="4" role="heading" id="h-note65"><span>Note</span></div>
+                        <div class="note-title marker" aria-level="4" role="heading" id="h-note64"><span>Note</span></div>
                         <p class="">In other words, do not create a session if a non-closed persistent session already exists for this <var>sanitized session ID</var> in any browsing context.</p>
                       </div>
                     </li>
@@ -3689,7 +3674,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                       <p>Resolve <var>promise</var> with <code>true</code>.
                       </p>
                       <div class="note">
-                        <div class="note-title marker" aria-level="4" role="heading" id="h-note66"><span>Note</span></div>
+                        <div class="note-title marker" aria-level="4" role="heading" id="h-note65"><span>Note</span></div>
                         <p class="">Since promise handlers are queued as microtasks, these will be executed ahead of any events queued by the preceding steps.</p>
                       </div>
                       <p></p>
@@ -3745,7 +3730,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                             Destroy the license(s) and/or key(s) associated with the session.
                           </p>
                           <div class="note">
-                            <div class="note-title marker" aria-level="4" role="heading" id="h-note67"><span>Note</span></div>
+                            <div class="note-title marker" aria-level="4" role="heading" id="h-note66"><span>Note</span></div>
                             <p class="">
                               This implies destruction of the license(s) and/or keys(s) whether they are in memory, persistent store or both.
                             </p>
@@ -3820,7 +3805,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                     <li>
                       <p>Resolve <var>promise</var>.</p>
                       <div class="note">
-                        <div class="note-title marker" aria-level="4" role="heading" id="h-note68"><span>Note</span></div>
+                        <div class="note-title marker" aria-level="4" role="heading" id="h-note67"><span>Note</span></div>
                         <p class="">Since promise handlers are queued as microtasks, these will be executed ahead of any events queued by the preceding steps.</p>
                       </div>
                     </li>
@@ -3877,7 +3862,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                 <li>
                   <p>Let <var>sanitized response</var> be a validated and/or sanitized version of <var>response copy</var>.</p>
                   <div class="note">
-                    <div class="note-title marker" aria-level="4" role="heading" id="h-note69"><span>Note</span></div>
+                    <div class="note-title marker" aria-level="4" role="heading" id="h-note68"><span>Note</span></div>
                     <p class="">The user agent should thoroughly validate the response before passing it to the CDM. This may include verifying values are within reasonable limits, stripping irrelevant data or fields, pre-parsing it, sanitizing it, and/or generating a fully sanitized version. The user agent should check that the length and values of fields are reasonable. Unknown fields should be rejected or removed.
                     </p>
                   </div>
@@ -3909,7 +3894,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                         <dt>If <var>sanitized response</var> contains a license or key(s)</dt>
                         <dd>
                           <div class="note">
-                            <div class="note-title marker" aria-level="4" role="heading" id="h-note70"><span>Note</span></div>
+                            <div class="note-title marker" aria-level="4" role="heading" id="h-note69"><span>Note</span></div>
                             <p class="">This includes an initial license, an updated license, and a license renewal message.</p>
                           </div>
                           <p>Process <var>sanitized response</var>, following the stipulation for the first matching condition from the following list:</p>
@@ -3942,15 +3927,15 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                           <p>See also <a href="#session-storage">Session Storage and Persistence</a>.</p>
                           <p>State information, including keys, for each session <em class="rfc2119" title="MUST">MUST</em> be stored in such a way that closing one session does not affect the observable state in other session(s), even if they contain overlapping key IDs.</p>
                           <div class="note">
-                            <div class="note-title marker" aria-level="4" role="heading" id="h-note71"><span>Note</span></div>
+                            <div class="note-title marker" aria-level="4" role="heading" id="h-note70"><span>Note</span></div>
                             <p class="">When <var>sanitized response</var> contains key(s) and/or related data, <var>cdm</var> will likely store (in memory) the key and related data indexed by key ID.</p>
                           </div>
                           <div class="note">
-                            <div class="note-title marker" aria-level="4" role="heading" id="h-note72"><span>Note</span></div>
+                            <div class="note-title marker" aria-level="4" role="heading" id="h-note71"><span>Note</span></div>
                             <p class="">The replacement algorithm within a session is <a href="#key-system">Key System</a>-dependent.</p>
                           </div>
                           <div class="note">
-                            <div class="note-title marker" aria-level="4" role="heading" id="h-note73"><span>Note</span></div>
+                            <div class="note-title marker" aria-level="4" role="heading" id="h-note72"><span>Note</span></div>
                             <p class="">It is <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em> that CDM implementations support a standard and reasonably high minimum number of keys per <a href="#idl-def-MediaKeySession" class="idlType"><code>MediaKeySession</code></a> object, including a standard replacement algorithm, and a standard and reasonably high minimum number of <a href="#idl-def-MediaKeySession" class="idlType"><code>MediaKeySession</code></a> objects. This enables a reasonable number of key rotation algorithms to be implemented across user agents and may reduce the likelihood of playback interruptions in use cases that involve various streams in the same element (i.e. adaptive streams, various audio and video tracks) using different keys.
                             </p>
                           </div>
@@ -3964,7 +3949,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                                 Close the <a href="#key-session">session</a> and clear <em>all</em> stored session data associated with this object, including the <code><a href="#widl-MediaKeySession-sessionId">sessionId</a></code> and license destruction record.
                               </p>
                               <div class="note">
-                                <div class="note-title marker" aria-level="4" role="heading" id="h-note74"><span>Note</span></div>
+                                <div class="note-title marker" aria-level="4" role="heading" id="h-note73"><span>Note</span></div>
                                 <p class="">A subsequent call to <code><a href="#widl-MediaKeySession-load-Promise-boolean--DOMString-sessionId">load()</a></code> with the value of this object's <code><a href="#widl-MediaKeySession-sessionId">sessionId</a></code> would fail because there is no data stored for that session ID.</p>
                               </div>
                             </li>
@@ -3982,7 +3967,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                                 Close the <a href="#key-session">session</a> and clear <em>all</em> stored session data associated with this object, including the <code><a href="#widl-MediaKeySession-sessionId">sessionId</a></code> and the <a href="#record-of-key-usage">record of key usage</a>.
                               </p>
                               <div class="note">
-                                <div class="note-title marker" aria-level="4" role="heading" id="h-note75"><span>Note</span></div>
+                                <div class="note-title marker" aria-level="4" role="heading" id="h-note74"><span>Note</span></div>
                                 <p class="">A subsequent call to <code><a href="#widl-MediaKeySession-load-Promise-boolean--DOMString-sessionId">load()</a></code> with the value of this object's <code><a href="#widl-MediaKeySession-sessionId">sessionId</a></code> would fail because there is no data stored for that session ID.</p>
                               </div>
                             </li>
@@ -3994,7 +3979,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                         <dt>Otherwise</dt>
                         <dd>Process <var>sanitized response</var>, not storing any session data.
                           <div class="note">
-                            <div class="note-title marker" aria-level="4" role="heading" id="h-note76"><span>Note</span></div>
+                            <div class="note-title marker" aria-level="4" role="heading" id="h-note75"><span>Note</span></div>
                             <p class="">For example, <var>sanitized response</var> may contain information that will be used to generate another <code><a href="#dom-evt-message">message</a></code> event. In this case, there is no need to verify the contents against the <var>sessionType</var>.
                             </p>
                           </div>
@@ -4051,7 +4036,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                     <li>
                       <p>Resolve <var>promise</var>.</p>
                       <div class="note">
-                        <div class="note-title marker" aria-level="4" role="heading" id="h-note77"><span>Note</span></div>
+                        <div class="note-title marker" aria-level="4" role="heading" id="h-note76"><span>Note</span></div>
                         <p class="">Since promise handlers are queued as microtasks, these will be executed ahead of any events queued by the preceding steps.</p>
                       </div>
                     </li>
@@ -4072,7 +4057,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <p>The MediaKeyStatusMap object is a read-only map of <a href="#decryption-key-id">key IDs</a> to the current status of the associated key.</p>
       <p>A key's status is independent of whether the key is currently being used and of media data.</p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note78"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note77"><span>Note</span></div>
         <p class="">For example, if a key has output requirements that cannot currently be met, the key's status should be <code><a href="#idl-def-MediaKeyStatus.output-downscaled">"output-downscaled"</a></code> or <code><a href="#idl-def-MediaKeyStatus.output-restricted">"output-restricted"</a></code>, as appropriate, regardless of whether that key has been or is currently needed to decrypt media data.</p>
       </div>
       <pre class="idl"><span class="idlInterface" id="idl-def-MediaKeyStatusMap">interface <span class="idlInterfaceID">MediaKeyStatusMap</span> {
@@ -4279,7 +4264,7 @@ interface <span class="idlInterfaceID">MediaKeyMessageEvent</span> : <span class
             <p>Implementations <em class="rfc2119" title="MUST NOT">MUST NOT</em> require applications to handle message types. Implementations <em class="rfc2119" title="MUST">MUST</em> support applications that do not differentiate messages and <em class="rfc2119" title="MUST NOT">MUST NOT</em> require that applications handle message types. Specifically, Key Systems <em class="rfc2119" title="MUST">MUST</em> support passing all types of messages to a single URL.
             </p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note79"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note78"><span>Note</span></div>
               <p class="">This attribute allows an application to differentiate messages without parsing the message. It is intended to enable optional application and/or server optimizations, but applications are not required to use it.
               </p>
             </div>
@@ -4369,7 +4354,7 @@ interface <span class="idlInterfaceID">MediaKeyMessageEvent</span> : <span class
         <p>The Update Key Statuses algorithm updates the set of <a href="#known-key">known</a> keys for a <a href="#idl-def-MediaKeySession" class="idlType"><code>MediaKeySession</code></a> or the status of one or more of the keys. Requests to run this algorithm include a target <a href="#idl-def-MediaKeySession" class="idlType"><code>MediaKeySession</code></a> object and a sequence of <a href="#decryption-key-id">key ID</a> and associated <a href="#idl-def-MediaKeyStatus" class="idlType"><code>MediaKeyStatus</code></a> pairs.
         </p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note80"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note79"><span>Note</span></div>
           <p class="">The algorithm is always run in a task.</p>
         </div>
         <p>The following steps are run:</p>
@@ -4402,7 +4387,7 @@ interface <span class="idlInterfaceID">MediaKeyMessageEvent</span> : <span class
               </li>
             </ol>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note81"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note80"><span>Note</span></div>
               <p class="">The effect of this steps is that the contents of <var>session</var>'s <code><a href="#widl-MediaKeySession-keyStatuses">keyStatuses</a></code> attribute are replaced without invalidating existing references to the attribute. This replacement is atomic from a script perspective. That is, script <em class="rfc2119" title="MUST NOT">MUST NOT</em> ever see a partially populated sequence.
               </p>
             </div>
@@ -4421,7 +4406,7 @@ interface <span class="idlInterfaceID">MediaKeyMessageEvent</span> : <span class
         <p>The Update Expiration algorithm updates the expiration time of a <a href="#idl-def-MediaKeySession" class="idlType"><code>MediaKeySession</code></a>. Requests to run this algorithm include a target <a href="#idl-def-MediaKeySession" class="idlType"><code>MediaKeySession</code></a> object and the new expiration time, which may be <code>NaN</code>.
         </p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note82"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note81"><span>Note</span></div>
           <p class="">The algorithm is always run in a task.</p>
         </div>
         <p>The following steps are run:</p>
@@ -4445,14 +4430,14 @@ interface <span class="idlInterfaceID">MediaKeyMessageEvent</span> : <span class
         <h4 id="h-session-closed" resource="#h-session-closed"><span property="xhv:role" resource="xhv:heading"><span class="secno">6.6.4 </span>Session Closed</span></h4>
         <p>The Session Closed algorithm updates the <a href="#idl-def-MediaKeySession" class="idlType"><code>MediaKeySession</code></a> state after a <a href="#key-session">session</a> has been closed.</p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note83"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note82"><span>Note</span></div>
           <p class="">The algorithm is always run in a task.</p>
         </div>
         <p>
           Closing a <a href="#key-session">session</a> means that the license(s) and key(s) associated with it are no longer available to decrypt <a href="http://www.w3.org/TR/html5/embedded-content-0.html#media-data">media data</a>. All <a href="#idl-def-MediaKeySession" class="idlType"><code>MediaKeySession</code></a> methods will fail and no further events will be queued for this object after this algorithm is run.
         </p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note84"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note83"><span>Note</span></div>
           <div class="">
             <p>
               The CDM may close a session at any point, such as when the session is no longer needed or when system resources are lost. In that case, the <a href="#monitor-cdm">Monitor for CDM Changes</a> algorithm detects the change and runs this algorithm.
@@ -4479,7 +4464,7 @@ interface <span class="idlInterfaceID">MediaKeyMessageEvent</span> : <span class
               <li>
                 <p>Use <var>cdm</var> to store <var>session</var>'s <var>record of key usage</var>, if it exists.</p>
                 <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note85"><span>Note</span></div>
+                  <div class="note-title marker" aria-level="5" role="heading" id="h-note84"><span>Note</span></div>
                   <div class="">
                     <p>
                       The <var>record of key usage</var> may not exist if no keys have been used in the session or if it has been deleted as a result of the <code><a href="#widl-MediaKeySession-update-Promise-void--BufferSource-response">update()</a></code> method processing an acknowledgement of the record of key usage.
@@ -4532,7 +4517,7 @@ interface <span class="idlInterfaceID">MediaKeyMessageEvent</span> : <span class
                   If <var>session</var>'s <var>session type</var> is <code><a href="#idl-def-MediaKeySessionType.persistent-usage-record">"persistent-usage-record"</a></code>, store <var>session</var>'s <var>record of key usage</var>, if it exists.
                 </p>
                 <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note86"><span>Note</span></div>
+                  <div class="note-title marker" aria-level="5" role="heading" id="h-note85"><span>Note</span></div>
                   <p class="">
                     Since it has no effects observable to the document, this step may be run asynchronously, including after the document has unloaded.
                   </p>
@@ -4550,7 +4535,7 @@ interface <span class="idlInterfaceID">MediaKeyMessageEvent</span> : <span class
           <a href="#idl-def-MediaKeySession" class="idlType"><code>MediaKeySession</code></a> object in parallel to the main event loop but not in parallel to other procedures defined in this specification that are run in parallel to the main event loop.
         </p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note87"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note86"><span>Note</span></div>
           <p class="">This algorithm only applies to CDM state changes that are not covered by other algorithms. For example, <code><a href="#widl-MediaKeySession-update-Promise-void--BufferSource-response">update()</a></code> may result in messages, key status changes and/or expiration changes, but those are all handled within that algorithm.</p>
         </div>
         <p>
@@ -4721,7 +4706,7 @@ interface <span class="idlInterfaceID">MediaKeyMessageEvent</span> : <span class
       <li>
         <p>For each block of encrypted <a href="http://www.w3.org/TR/html5/embedded-content-0.html#media-data">media data</a> encountered during the <a href="http://www.w3.org/TR/html5/embedded-content-0.html#concept-media-load-resource">resource fetch algorithm</a>, the user agent <em class="rfc2119" title="SHALL">SHALL</em> run the <a href="#encrypted-block-encountered">Encrypted Block Encountered</a> algorithm in the order the encrypted blocks were encountered.</p>
         <div class="note">
-          <div class="note-title marker" aria-level="3" role="heading" id="h-note88"><span>Note</span></div>
+          <div class="note-title marker" aria-level="3" role="heading" id="h-note87"><span>Note</span></div>
           <p class="">The above step provides flexibility for user agent implementations to perform decryption at any time after an encrypted block is encountered before it is needed for playback.</p>
         </div>
       </li>
@@ -4761,11 +4746,11 @@ interface <span class="idlInterfaceID">MediaKeyMessageEvent</span> : <span class
         <dd>
           <p>Provides the <a href="#idl-def-MediaKeys" class="idlType"><code>MediaKeys</code></a> to use when decrypting media data during playback.</p>
           <div class="note">
-            <div class="note-title marker" aria-level="4" role="heading" id="h-note89"><span>Note</span></div>
+            <div class="note-title marker" aria-level="4" role="heading" id="h-note88"><span>Note</span></div>
             <p class="">Support for clearing or replacing the associated <a href="#idl-def-MediaKeys" class="idlType"><code>MediaKeys</code></a> object during playback is a quality of implementation issue. In many cases it will result in a bad user experience or rejected promise.</p>
           </div>
           <div class="note">
-            <div class="note-title marker" aria-level="4" role="heading" id="h-note90"><span>Note</span></div>
+            <div class="note-title marker" aria-level="4" role="heading" id="h-note89"><span>Note</span></div>
             <p class="">Some implementations may only support decrypting media data provided via Media Source Extensions [<cite><a class="bibref" href="#bib-MEDIA-SOURCE">MEDIA-SOURCE</a></cite>]. This is not reflected in the results of calling <code><a href="#widl-Navigator-requestMediaKeySystemAccess-Promise-MediaKeySystemAccess--DOMString-keySystem-sequence-MediaKeySystemConfiguration--supportedConfigurations">requestMediaKeySystemAccess()</a></code>.
             </p>
           </div>
@@ -4820,7 +4805,7 @@ interface <span class="idlInterfaceID">MediaKeyMessageEvent</span> : <span class
                     <li>
                       <p>If the association cannot currently be removed, let this object's <var>attaching media keys</var> value be false and reject <var>promise</var> with an <code><a href="#dfn-InvalidStateError">InvalidStateError</a></code>.</p>
                       <div class="note">
-                        <div class="note-title marker" aria-level="4" role="heading" id="h-note91"><span>Note</span></div>
+                        <div class="note-title marker" aria-level="4" role="heading" id="h-note90"><span>Note</span></div>
                         <p class="">For example, some implementations may not allow removal during playback.</p>
                       </div>
                     </li>
@@ -4970,7 +4955,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
             <td>The user agent encounters <a href="#initialization-data">Initialization Data</a> in the <a href="http://www.w3.org/TR/html5/embedded-content-0.html#media-data">media data</a>.</td>
             <td>The element's <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#dom-media-readystate">readyState</a></code> is equal to <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#dom-media-have_metadata">HAVE_METADATA</a></code> or greater.
               <div class="note">
-                <div class="note-title marker" aria-level="4" role="heading" id="h-note92"><span>Note</span></div>
+                <div class="note-title marker" aria-level="4" role="heading" id="h-note91"><span>Note</span></div>
                 <p class="">It is possible that the element is playing or has played.</p>
               </div>
             </td>
@@ -5010,7 +4995,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
               </li>
             </ol>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note93"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note92"><span>Note</span></div>
               <p class="">While the media element may allow loading of "Optionally-blockable Content" [<cite><a class="bibref" href="#bib-MIXED-CONTENT">MIXED-CONTENT</a></cite>], the user agent <em class="rfc2119" title="MUST NOT">MUST NOT</em> expose Initialization Data from such media data to the application.</p>
             </div>
           </li>
@@ -5025,11 +5010,11 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
               </li>
             </ul>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note94"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note93"><span>Note</span></div>
               <p class=""><code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#dom-media-readystate">readyState</a></code> is <em>not</em> changed and no algorithms are aborted. This event merely provides information.</p>
             </div>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note95"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note94"><span>Note</span></div>
               <p class="">The <code><a href="#widl-MediaEncryptedEventInit-initData">initData</a></code> attribute will be null if the media data is <em>not</em> <a href="http://www.w3.org/TR/html5/infrastructure.html#cors-same-origin">CORS-same-origin</a> or is <a href="#mixed-content">mixed content</a>. Applications may retrieve the Initialization Data from an alternate source.
               </p>
             </div>
@@ -5037,7 +5022,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
           <li>
             <p>If the media element's <code><a href="#widl-HTMLMediaElement-mediaKeys">mediaKeys</a></code> attribute is null and the implementation requires specification of a <a href="#idl-def-MediaKeys" class="idlType"><code>MediaKeys</code></a> object before decoding potentially-encrypted <a href="http://www.w3.org/TR/html5/embedded-content-0.html#media-data">media data</a>, run the following steps:</p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note96"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note95"><span>Note</span></div>
               <p class="">These steps may be reached when the application provides <a href="http://www.w3.org/TR/html5/embedded-content-0.html#media-data">media data</a> before calling <code><a href="#widl-HTMLMediaElement-setMediaKeys-Promise-void--MediaKeys-mediaKeys">setMediaKeys()</a></code> to provide a <a href="#idl-def-MediaKeys" class="idlType"><code>MediaKeys</code></a> object. Selecting a <a href="#cdm">CDM</a> may affect the pipeline and/or decoders used, so some implementations may delay playback of media data that may contain encrypted blocks until a CDM is specified by passing a <a href="#idl-def-MediaKeys" class="idlType"><code>MediaKeys</code></a> object to <code><a href="#widl-HTMLMediaElement-setMediaKeys-Promise-void--MediaKeys-mediaKeys">setMediaKeys()</a></code>.
               </p>
             </div>
@@ -5092,7 +5077,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
               <li>
                 <p>If <var>cdm</var> is no longer usable for any reason, run the following steps:</p>
                 <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note97"><span>Note</span></div>
+                  <div class="note-title marker" aria-level="5" role="heading" id="h-note96"><span>Note</span></div>
                   <p class="">These steps are intended to be run on unrecoverable failures of the CDM.</p>
                 </div>
                 <ol>
@@ -5110,7 +5095,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
               <li>
                 <p>If there is at least one <a href="#idl-def-MediaKeySession" class="idlType"><code>MediaKeySession</code></a> created by the <var>media keys</var> on which the <a href="#session-closed">Session Closed</a> algorithm has not been run, run the following steps:</p>
                 <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note98"><span>Note</span></div>
+                  <div class="note-title marker" aria-level="5" role="heading" id="h-note97"><span>Note</span></div>
                   <p class="">This check ensures the <var>cdm</var> has finished loading and is a prerequisite for a matching key being available.</p>
                 </div>
                 <ol>
@@ -5120,7 +5105,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
                   <li>
                     <p>Let the <var>block key ID</var> be the key ID of <var>block</var>.</p>
                     <div class="note">
-                      <div class="note-title marker" aria-level="5" role="heading" id="h-note99"><span>Note</span></div>
+                      <div class="note-title marker" aria-level="5" role="heading" id="h-note98"><span>Note</span></div>
                       <p class="">The key ID is generally specified by the container.</p>
                     </div>
                   </li>
@@ -5137,7 +5122,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
                         <p>If any of the <var>available keys</var> corresponds to the <var>block key ID</var> and is <a href="#usable-for-decryption">usable for decryption</a>, let <var>session</var> be a
                           <a href="#idl-def-MediaKeySession" class="idlType"><code>MediaKeySession</code></a> object containing that key and let <var>block key</var> be that key.</p>
                         <div class="note">
-                          <div class="note-title marker" aria-level="5" role="heading" id="h-note100"><span>Note</span></div>
+                          <div class="note-title marker" aria-level="5" role="heading" id="h-note99"><span>Note</span></div>
                           <p class="">If multiple sessions contain a key that is <a href="#usable-for-decryption">usable for decryption</a> for the <var>block key ID</var>, which session and key to use is <a href="#key-system">Key System</a>-dependent.</p>
                         </div>
                       </li>
@@ -5168,7 +5153,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
                               </li>
                             </ol>
                             <div class="note">
-                              <div class="note-title marker" aria-level="5" role="heading" id="h-note101"><span>Note</span></div>
+                              <div class="note-title marker" aria-level="5" role="heading" id="h-note100"><span>Note</span></div>
                               <p class="">
                                 Implementations <em class="rfc2119" title="MAY">MAY</em> optimize the times at which this step is executed provided the recorded key usage times remain accurate to within <var>key usage accuracy</var>.
                               </p>
@@ -5204,7 +5189,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
                                   <li>
                                     <p>Process the decrypted block as normal.</p>
                                     <div class="note">
-                                      <div class="note-title marker" aria-level="5" role="heading" id="h-note102"><span>Note</span></div>
+                                      <div class="note-title marker" aria-level="5" role="heading" id="h-note101"><span>Note</span></div>
                                       <p class="">In other words, decode the block.</p>
                                     </div>
                                   </li>
@@ -5216,13 +5201,13 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
                               </dd>
                             </dl>
                             <div class="note">
-                              <div class="note-title marker" aria-level="5" role="heading" id="h-note103"><span>Note</span></div>
+                              <div class="note-title marker" aria-level="5" role="heading" id="h-note102"><span>Note</span></div>
                               <p class="">Not all decryption problems (i.e. using the wrong key) will result in a decryption failure. In such cases, no error is fired here but one may be fired during decode.</p>
                             </div>
                           </li>
                         </ol>
                         <div class="note">
-                          <div class="note-title marker" aria-level="5" role="heading" id="h-note104"><span>Note</span></div>
+                          <div class="note-title marker" aria-level="5" role="heading" id="h-note103"><span>Note</span></div>
                           <p class="">Otherwise, there is no key for the <var>block key ID</var> in any session so continue.</p>
                         </div>
                       </li>
@@ -5235,7 +5220,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
           <li>
             <p>Run the following steps:</p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note105"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note104"><span>Note</span></div>
               <p class="">These steps are reached when there is no key that is <a href="#usable-for-decryption">usable for decryption</a> for <var>block</var>.</p>
             </div>
             <ol>
@@ -5247,7 +5232,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
         </ol>
 
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note106"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note105"><span>Note</span></div>
           <div class="">
             <p>For frame-based encryption, this may be implemented as follows when the media element attempts to decode a frame as part of the <a href="http://www.w3.org/TR/html5/embedded-content-0.html#concept-media-load-resource">resource fetch algorithm</a>:</p>
             <ol>
@@ -5290,7 +5275,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
           <li>
             <p>Set the <var>media element</var>'s <var>waiting for key</var> value to <code>true</code>.</p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note107"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note106"><span>Note</span></div>
               <p class="">As a result of the above step, the media element will become a <a href="http://www.w3.org/TR/html5/embedded-content-0.html#blocked-media-element">blocked media element</a> if it wasn't already. In that case, the media element will stop playback.</p>
             </div>
           </li>
@@ -5328,7 +5313,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
               <li>
                 <p>Set the <var>media element</var>'s <var>waiting for key</var> value to <code>false</code>.</p>
                 <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note108"><span>Note</span></div>
+                  <div class="note-title marker" aria-level="5" role="heading" id="h-note107"><span>Note</span></div>
                   <p class="">As a result of the above step, the media element may no longer be a <a href="http://www.w3.org/TR/html5/embedded-content-0.html#blocked-media-element">blocked media element</a> and thus playback may resume.</p>
                 </div>
               </li>
@@ -5338,7 +5323,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
                   <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#dom-media-have_enough_data">HAVE_ENOUGH_DATA</a></code> as <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#ready-states">appropriate</a></code>.
                 </p>
                 <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note109"><span>Note</span></div>
+                  <div class="note-title marker" aria-level="5" role="heading" id="h-note108"><span>Note</span></div>
                   <div class="">
                     <p>
                       States beyond <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#dom-media-have_current_data">HAVE_CURRENT_DATA</a></code> and the <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#event-media-canplaythrough">canplaythrough</a></code> event do not (or are unlikely to) consider key availability beyond the current key.
@@ -5394,7 +5379,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
       <p>The use of identifiers, especially <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">Distinctive Identifier(s) or Distinctive Permanent Identifier(s)</a>, by implementations presents a privacy concern. This section defines requirements for avoiding or at least mitigating such concerns.
       </p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note110"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note109"><span>Note</span></div>
         <div class="">
           <p>In summary:</p>
           <ul>
@@ -5428,14 +5413,14 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
           <li>
             <p>Implementations <em class="rfc2119" title="SHOULD">SHOULD</em> avoid <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">use of Distinctive Identifier(s) or Distinctive Permanent Identifier(s)</a>.</p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note111"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note110"><span>Note</span></div>
               <p class="">For example, use identifiers or other values that apply to a group of clients or devices rather than individual clients.</p>
             </div>
           </li>
           <li>
             <p>Implementations <em class="rfc2119" title="SHOULD">SHOULD</em> only <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">use Distinctive Identifier(s) or Distinctive Permanent Identifier(s)</a> when necessary to enforce the policies related to the specific CDM instance and session.</p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note112"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note111"><span>Note</span></div>
               <p class="">For example, <code><a href="#idl-def-MediaKeySessionType.temporary">"temporary"</a></code> and <code><a href="#idl-def-MediaKeySessionType.persistent-license">"persistent-license"</a></code> sessions may have different requirements.</p>
             </div>
           </li>
@@ -5447,7 +5432,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
                 -->
             </p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note113"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note112"><span>Note</span></div>
               <div class="">
                 <p>
                   When supported, applications can select for this mode using <code><a href="#widl-MediaKeySystemConfiguration-distinctiveIdentifier">distinctiveIdentifier</a></code> = <code><a href="#idl-def-MediaKeysRequirement.not-allowed">"not-allowed"</a></code>. Selecting such an option may affect the results of the <code><a href="#widl-Navigator-requestMediaKeySystemAccess-Promise-MediaKeySystemAccess--DOMString-keySystem-sequence-MediaKeySystemConfiguration--supportedConfigurations">requestMediaKeySystemAccess()</a></code> call and/or the license requests that are generated from subsequently generated sessions.
@@ -5471,7 +5456,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
           <p class=""><a href="https://github.com/w3c/encrypted-media/issues/219">Issue 219</a> - Add more specific text about ensuring the desired privacy properties when encrypting identifiers.</p>
         </div>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note114"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note113"><span>Note</span></div>
           <div class="">
             <p>Identifiers may be exposed in the following ways:</p>
             <ul>
@@ -5492,12 +5477,12 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
         </p>
         <p>The server <em class="rfc2119" title="MUST NOT">MUST NOT</em> expose a <a href="#distinctive-identifier">Distinctive Identifier</a> to any entity other than the CDM that sent it.</p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note115"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note114"><span>Note</span></div>
           <p class="">Specifically, it should not be provided to the application or included unencrypted in messages to the CDM. This can be accomplished by encrypting the identifier or message with the identifier or such that it is only decryptable by that specific CDM.
           </p>
         </div>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note116"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note115"><span>Note</span></div>
           <div class="">
             <p>Among other things, this means that:</p>
             <ul>
@@ -5525,7 +5510,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
           All potential identifiers or distinctive values that are not <a href="#permanent-identifier">Permanent Identifiers</a> <em class="rfc2119" title="MUST">MUST</em> be unique per <a href="http://www.w3.org/TR/html5/browsers.html#origin-0">origin</a>. That is, the identifier(s) used for one <a href="http://www.w3.org/TR/html5/browsers.html#origin-0">origin</a> using these APIs <em class="rfc2119" title="MUST">MUST</em> be different from those used for any other origin using the APIs.
         </p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note117"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note116"><span>Note</span></div>
           <div class="">
             <p>This includes but is not limited to <a href="#distinctive-identifier">Distinctive Identifiers</a>.</p>
             <p><a href="#permanent-identifier">Permanent Identifiers</a> <em class="rfc2119" title="MUST NOT">MUST NOT</em> be exposed to the application or origin.</p>
@@ -5558,7 +5543,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
       <h3 id="h-support-multiple-keys" resource="#h-support-multiple-keys"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.3 </span>Support Multiple Keys</span></h3>
       <p>Implementations <em class="rfc2119" title="MUST">MUST</em> support multiple keys in each <a href="#idl-def-MediaKeySession" class="idlType"><code>MediaKeySession</code></a> object.</p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note118"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note117"><span>Note</span></div>
         <p class="">The mechanics of how multiple keys are supported is an implementation detail, but it <em class="rfc2119" title="MUST">MUST</em> be transparent to the application and these APIs.</p>
       </div>
 
@@ -5573,7 +5558,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
         <h4 id="h-licenses-generated-are-independent-of-content-type" resource="#h-licenses-generated-are-independent-of-content-type"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.4.1 </span>Licenses Generated are Independent of Content Type</span></h4>
         <p>Implementations <em class="rfc2119" title="SHOULD">SHOULD</em> allow licenses generated with any <a href="#initialization-data-type">Initialization Data Type</a> they support to be used with any content type.</p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note119"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note118"><span>Note</span></div>
           <p class="">Otherwise, the <code><a href="#widl-Navigator-requestMediaKeySystemAccess-Promise-MediaKeySystemAccess--DOMString-keySystem-sequence-MediaKeySystemConfiguration--supportedConfigurations">requestMediaKeySystemAccess()</a></code> algorithm might, for example, reject a <a href="#idl-def-MediaKeySystemConfiguration" class="idlType"><code>MediaKeySystemConfiguration</code></a> because one of the <code><a href="#widl-MediaKeySystemConfiguration-initDataTypes">initDataTypes</a></code> is not supported with one of the <code><a href="#widl-MediaKeySystemConfiguration-videoCapabilities">videoCapabilities</a></code>.</p>
         </div>
       </section>
@@ -5582,7 +5567,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
         <h4 id="h-support-extraction-from-media-data" resource="#h-support-extraction-from-media-data"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.4.2 </span>Support Extraction From Media Data</span></h4>
         <p>For any supported <a href="#initialization-data-type">Initialization Data Type</a> that may appear in a supported container, the user agents <em class="rfc2119" title="MUST">MUST</em> support <a href="#initdata-encountered">extracting</a> that type of <a href="#initialization-data">Initialization Data</a> from each such supported container.</p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note120"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note119"><span>Note</span></div>
           <p class="">In other words, indicating support for an <a href="#initialization-data-type">Initialization Data Type</a> implies both CDM support for generating license requests and, for container-specific types, user agent support for extracting it from the container. This does <strong>not</strong> mean that implementations must be able to parse <em>any</em> supported <a href="#initialization-data">Initialization Data</a> from <em>any</em> supported content type.
           </p>
         </div>
@@ -5606,7 +5591,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
           <a href="http://www.w3.org/TR/html5/embedded-content-0.html#media-resource">Media resources</a>, including all tracks, <em class="rfc2119" title="MUST">MUST</em> be encrypted and packaged per a container-specific "common encryption" specification that allows the content to be decrypted in a fully specified and compatible way when a key or keys are provided.
         </p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note121"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note120"><span>Note</span></div>
           <p class="">
             The Encrypted Media Extensions Stream Format and Initialization Data Format Registry [<cite><a class="bibref" href="#bib-EME-STREAM-REGISTRY">EME-STREAM-REGISTRY</a></cite>] provides references to such stream formats.
           </p>
@@ -5619,7 +5604,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
           In-band support content, such as captions, described audio, and transcripts, <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> be encrypted.
         </p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note122"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note121"><span>Note</span></div>
           <p class="">
             Decryption of such tracks - especially such that they can be provided back the user agent - is not generally supported by implementations. Thus, encrypting such tracks would prevent them from being widely available for use with accessibility features in user agent implementations.
           </p>
@@ -5639,7 +5624,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
     <p>
     </p>
     <div class="note">
-      <div class="note-title marker" aria-level="3" role="heading" id="h-note123"><span>Note</span></div>
+      <div class="note-title marker" aria-level="3" role="heading" id="h-note122"><span>Note</span></div>
       <p class="">This ensures that there is a common baseline level of functionality that is guaranteed to be supported in all user agents, including those that are entirely open source. Thus, content providers that need only basic decryption can build simple applications that will work on all platforms without needing to work with any content protection providers.
       </p>
     </div>
@@ -5888,13 +5873,13 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
       <p>User Agent and Key System implementations <em class="rfc2119" title="MUST">MUST</em> consider <a href="http://www.w3.org/TR/html5/embedded-content-0.html#media-data">media data</a>, <a href="#initialization-data">Initialization Data</a>, data passed to <code><a href="#widl-MediaKeySession-update-Promise-void--BufferSource-response">update()</a></code>, licenses, key data, and all other data provided by the application as untrusted content and potential attack vectors. They <em class="rfc2119" title="MUST">MUST</em> use appropriate safeguards to mitigate any associated threats and take care to safely parse, decrypt, etc. such data. User Agents <em class="rfc2119" title="SHOULD">SHOULD</em> validate data before passing it to the CDM.
       </p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note124"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note123"><span>Note</span></div>
         <p class="">Such validation is especially important if the CDM does not run in the same (sandboxed) context as, for example, the DOM.</p>
       </div>
 
       <p>Implementations <em class="rfc2119" title="MUST NOT">MUST NOT</em> return active content or passive content that affects program control flow to the application.</p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note125"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note124"><span>Note</span></div>
         <p class="">For example, it is not safe to expose URLs or other information that may have come from media data, such as is the case for the <a href="#initialization-data">Initialization Data</a> passed to <code><a href="#widl-MediaKeySession-generateRequest-Promise-void--DOMString-initDataType-BufferSource-initData">generateRequest()</a></code>. Applications must determine the URLs to use. The <code><a href="#widl-MediaKeyMessageEvent-messageType">messageType</a></code> attribute of the <code><a href="#dom-evt-message">message</a></code> event can be used by the application to select among a set of URLs if applicable.
         </p>
       </div>
@@ -5907,7 +5892,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
       <p>Exploiting a CDM implementation that is not fully sandboxed and/or uses platform features may allow an attacker to access OS or platform features, elevate privilege (e.g. to run as system or root), and/or access drivers, kernel, firmware, hardware, etc. Such features, software, and hardware may not be written to be robust against hostile software or web-based attacks and may not be updated with security fixes, especially compared to the user agent. Lack of, infrequent, or slow updates for fixes to security vulnerabilities in CDM implementations increases the risk. Such CDM implementations and UAs that expose them <em class="rfc2119" title="MUST">MUST</em> be especially careful in all areas of security, including parsing of <a href="#input-data-security">all data</a>.
       </p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note126"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note125"><span>Note</span></div>
         <p class="">User agents should be especially diligent when using a CDM or underlying mechanism that is part of or provided by the client OS, platform and/or hardware.</p>
       </div>
 
@@ -5916,7 +5901,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
         Such implementations <em class="rfc2119" title="SHOULD">SHOULD</em> only be supported on secure contexts to mitigate the potential for <a href="#network-attacks">Network Attacks</a>.
       </p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note127"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note126"><span>Note</span></div>
         <p class="">Granting permissions to unauthenticated origins is equivalent to granting the permissions to any origin in the presence of a network attacker. See also <a href="#privacy-prompts">User Alerts / Prompts</a> and <a href="#privacy-secureorigin">Use Secure Origin and Transport</a>.
         </p>
       </div>
@@ -5980,7 +5965,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
             <p>User Agents <em class="rfc2119" title="SHOULD">SHOULD</em> ensure that users are fully informed and/or give explicit consent before a Key System that presents security concerns that are greater than other user agent features (e.g. DOM content) may be accessed by an <a href="http://www.w3.org/TR/html5/browsers.html#origin-0">origin</a>. Such alerts and consent <em class="rfc2119" title="SHOULD">SHOULD</em> be per <a href="http://www.w3.org/TR/html5/browsers.html#origin-0">origin</a> to avoid valid uses enabling subsequent malicious access. (A full <a href="http://www.w3.org/TR/html5/browsers.html#origin-0">origin</a> <em class="rfc2119" title="MUST">MUST</em> be used rather than just the domain because the protocol is important for security as described above.) User agents <em class="rfc2119" title="SHOULD">SHOULD</em> only persist consent for secure origins (see <a href="#privacy-secureorigin">Secure Origin and Transport</a>), to mitigate the potential for future abuse via <a href="#network-attacks">Network Attacks</a>.
             </p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note128"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note127"><span>Note</span></div>
               <p class="">Granting permissions to unauthenticated origins is equivalent to granting the permissions to any origin in the presence of a network attacker. Alerting or prompting the user for consent on insecure origins without persisting the choice provides at least a minimum level of security because the user would be alerted to unexpected use (e.g. on a site that does not use encrypted media).
               </p>
             </div>
@@ -6016,7 +6001,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
       <p>Using these APIs on shared hosts compromises origin-based security and privacy mitigations implemented by user agents. For example, per-origin <a href="#distinctive-identifier">Distinctive Identifiers</a> are shared by all authors on one host name, and peristed data may be accessed and manipulated by any author on the host. The latter is especially important if, for example, modification or deletion of such data could erase a user's right to specific content.
       </p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note129"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note128"><span>Note</span></div>
         <p class="">Even if a path-restriction feature was made available by user agents, the usual DOM scripting security model would make it trivial to bypass this protection and access the data from any path.</p>
       </div>
       <p>Authors on shared hosts are therefore <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em> to avoid using these APIs because doing so compromises origin-based security and privacy mitigations in user agents.</p>
@@ -6084,7 +6069,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
               It is not possible to extract, derive or infer information from the CDM that is not either explicitly described in this specification or available to the page through other web platform APIs without user permission. This applies to any information that is exposed outside the client device or to the application, including, for example, in CDM messages.
             </p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note130"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note129"><span>Note</span></div>
               <div class="">
                 <p>The type of information covered by this requirement includes but is not limited to:</p>
                 <ul>
@@ -6210,7 +6195,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
           <dd>
             <p>User agents <em class="rfc2119" title="MAY">MAY</em>, possibly in a manner configured by the user, automatically delete <a href="#distinctive-identifier">Distinctive Identifiers</a> and/or other Key System data after a period of time.</p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note131"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note130"><span>Note</span></div>
               <div class="">
                 <p>For example, a user agent could be configured to store such data as session-only storage, deleting the data once the user had closed all the browsing contexts that could access it.</p>
                 <p>This can restrict the ability of a site to track a user, as the site would then only be able to track the user across multiple sessions when he authenticates with the site itself (e.g. by making a purchase or logging in to a service).</p>
@@ -6243,13 +6228,13 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
             <p>User agents <em class="rfc2119" title="MUST">MUST</em> prompt or otherwise inform the user before allowing use of a <a href="#distinctive-identifier">Distinctive Identifier</a> that is not <a href="#per-origin-identifiers">unique per-origin</a> and/or not <a href="#allow-identifiers-cleared">clearable</a> is used. User agents <em class="rfc2119" title="SHOULD">SHOULD</em> prompt or otherwise inform the user before allowing use of all other <a href="#distinctive-identifier">Distinctive Identifier</a>.
             </p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note132"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note131"><span>Note</span></div>
               <p class="">The "not unique per-origin" and "not clearable" conditions cannot be true in a compliant implementation because implementations <em class="rfc2119" title="MUST">MUST</em> <a href="#per-origin-identifiers">use per-origin identifiers</a> and <a href="#allow-identifiers-cleared">allow the user to clear identifiers</a>.</p>
             </div>
             <p>Such alerts and consent <em class="rfc2119" title="SHOULD">SHOULD</em> be per <a href="http://www.w3.org/TR/html5/browsers.html#origin-0">origin</a> to avoid valid uses enabling subsequent malicious access. User agent implementers that consider such alerts or consent appropriate for a Key System implementation <em class="rfc2119" title="SHOULD">SHOULD</em> only support such Key Systems on secure origins (see <a href="#privacy-secureorigin">Secure Origin and Transport</a>), especially if they allow such consent to be persisted.
             </p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note133"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note132"><span>Note</span></div>
               <p class="">Granting permissions to unauthenticated origins is equivalent to granting the permissions to any origin in the presence of a network attacker.</p>
             </div>
           </dd>
@@ -6262,7 +6247,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
         </dl>
 
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note134"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note133"><span>Note</span></div>
           <p class="">While these suggestions prevent trivial use of this API for user tracking, they do not block it altogether. Within a single origin, a site can continue to track the user during a session, and can then pass all this information to a third party along with any identifying information (names, credit card numbers, addresses) obtained by the site. If a third party cooperates with multiple sites to obtain such information, and if identifiers are not
             <!-- Issue #101 may affect this text. --><a href="#per-origin-identifiers">unique per-origin</a>, then a profile can still be created.
           </p>
@@ -6284,7 +6269,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
           <p>Direct Individualization is performed between the <a href="#cdm">CDM</a> and an origin- and application-independent server. The process <em class="rfc2119" title="MUST">MUST</em> be performed by the user agent and <em class="rfc2119" title="MUST NOT">MUST NOT</em> use these APIs.
           </p>
           <div class="note">
-            <div class="note-title marker" aria-level="6" role="heading" id="h-note135"><span>Note</span></div>
+            <div class="note-title marker" aria-level="6" role="heading" id="h-note134"><span>Note</span></div>
             <p class="">For example, such a process may initialize a client device and/or obtain a <a href="#per-origin-identifiers">per-origin</a> <a href="#allow-identifiers-cleared">clearable</a> identifier by communicating with a pre-determined server hosted by the user agent or CDM vendor, possibly <a href="#uses-distinctive-permanent-identifiers">using Distinctive Permanent Identifier(s)</a> or other <a href="#permanent-identifier">Permanent Identifier(s)</a> from the client device.
             </p>
           </div>
@@ -6337,7 +6322,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
               <p><em class="rfc2119" title="MUST">MUST</em> adhere to the <a href="#identifier-requirements">identifier requirements</a>.
               </p>
               <div class="note">
-                <div class="note-title marker" aria-level="6" role="heading" id="h-note136"><span>Note</span></div>
+                <div class="note-title marker" aria-level="6" role="heading" id="h-note135"><span>Note</span></div>
                 <p class="">This includes only using values that are <a href="#per-origin-identifiers">unique per origin</a> and <a href="#allow-identifiers-cleared">clearable</a> and <a href="#encrypt-identifiers">encrypting</a> them as required.</p>
               </div>
             </li>

--- a/index.html
+++ b/index.html
@@ -17,98 +17,74 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       padding: 0.5em;
       color: #333;
       background: #f8f8f8;
-      -webkit-text-size-adjust: none;
     }
     
     .hljs-comment,
-    .diff .hljs-header {
+    .hljs-quote {
       color: #998;
       font-style: italic;
     }
     
     .hljs-keyword,
-    .css .rule .hljs-keyword,
-    .hljs-winutils,
-    .nginx .hljs-title,
-    .hljs-subst,
-    .hljs-request,
-    .hljs-status {
+    .hljs-selector-tag,
+    .hljs-subst {
       color: #333;
       font-weight: bold;
     }
     
     .hljs-number,
-    .hljs-hexcolor,
-    .ruby .hljs-constant {
+    .hljs-literal,
+    .hljs-variable,
+    .hljs-template-variable,
+    .hljs-tag .hljs-attr {
       color: #008080;
     }
     
     .hljs-string,
-    .hljs-tag .hljs-value,
-    .hljs-doctag,
-    .tex .hljs-formula {
+    .hljs-doctag {
       color: #d14;
     }
     
     .hljs-title,
-    .hljs-id,
-    .scss .hljs-preprocessor {
+    .hljs-section,
+    .hljs-selector-id {
       color: #900;
       font-weight: bold;
     }
     
-    .hljs-list .hljs-keyword,
     .hljs-subst {
       font-weight: normal;
     }
     
-    .hljs-class .hljs-title,
     .hljs-type,
-    .vhdl .hljs-literal,
-    .tex .hljs-command {
+    .hljs-class .hljs-title {
       color: #458;
       font-weight: bold;
     }
     
     .hljs-tag,
-    .hljs-tag .hljs-title,
-    .hljs-rule .hljs-property,
-    .django .hljs-tag .hljs-keyword {
+    .hljs-name,
+    .hljs-attribute {
       color: #000080;
       font-weight: normal;
     }
     
-    .hljs-attribute,
-    .hljs-variable,
-    .lisp .hljs-body,
-    .hljs-name {
-      color: #008080;
-    }
-    
-    .hljs-regexp {
+    .hljs-regexp,
+    .hljs-link {
       color: #009926;
     }
     
     .hljs-symbol,
-    .ruby .hljs-symbol .hljs-string,
-    .lisp .hljs-keyword,
-    .clojure .hljs-keyword,
-    .scheme .hljs-keyword,
-    .tex .hljs-special,
-    .hljs-prompt {
+    .hljs-bullet {
       color: #990073;
     }
     
-    .hljs-built_in {
+    .hljs-built_in,
+    .hljs-builtin-name {
       color: #0086b3;
     }
     
-    .hljs-preprocessor,
-    .hljs-pragma,
-    .hljs-pi,
-    .hljs-doctype,
-    .hljs-shebang,
-    .hljs-cdata {
+    .hljs-meta {
       color: #999;
       font-weight: bold;
     }
@@ -121,12 +97,12 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       background: #dfd;
     }
     
-    .diff .hljs-change {
-      background: #0086b3;
+    .hljs-emphasis {
+      font-style: italic;
     }
     
-    .hljs-chunk {
-      color: #aaa;
+    .hljs-strong {
+      font-weight: bold;
     }
   </style>
   <style id="respec-mainstyle">
@@ -938,13 +914,13 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
     }
   </script>
 </head>
-<body class="h-entry" role="document" id="respecDocument">
+<body class="h-entry toc-inline" role="document" id="respecDocument">
   <div class="head" role="contentinfo" id="respecHeader">
     <p>
       <a class="logo" href="http://www.w3.org/"><img width="72" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" alt="W3C"></a>
     </p>
     <h1 class="title p-name" id="title" property="dcterms:title">Encrypted Media Extensions</h1>
-    <h2 id="w3c-editor-s-draft-23-june-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2016-06-23">23 June 2016</time></h2>
+    <h2 id="w3c-editor-s-draft-24-june-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2016-06-24">24 June 2016</time></h2>
     <dl>
       <dt>This version:</dt>
       <dd><a class="u-url" href="https://w3c.github.io/encrypted-media/">https://w3c.github.io/encrypted-media/</a></dd>
@@ -2711,17 +2687,32 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         <h4 id="h-dictionary-mediakeysystemmediacapability-members" resource="#h-dictionary-mediakeysystemmediacapability-members"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.3.1 </span>Dictionary <a class="idlType" href="#idl-def-MediaKeySystemMediaCapability"><code>MediaKeySystemMediaCapability</code></a> Members</span></h4>
         <dl class="dictionary-members"><dt id="widl-MediaKeySystemMediaCapability-contentType"><code>contentType</code> of type <span class="idlMemberType">DOMString</span>, defaulting to <code>""</code></dt>
           <dd>
-            The type of the <a href="http://www.w3.org/TR/html5/embedded-content-0.html#media-resource">media resource</a>. Its value must be a <a href="http://www.w3.org/TR/html5/embedded-content-0.html#mime-types">valid MIME type</a> [<cite><a class="bibref" href="#bib-HTML5">HTML5</a></cite>]. The codecs parameter, which certain MIME types define, might be necessary to specify exactly how the resource is encoded. [<cite><a class="bibref" href="#bib-RFC6381">RFC6381</a></cite>] The empty string is invalid.
+            <p>
+              The type of the <a href="http://www.w3.org/TR/html5/embedded-content-0.html#media-resource">media resource</a>. Its value must be a <a href="http://www.w3.org/TR/html5/embedded-content-0.html#mime-types">valid MIME type</a> [<cite><a class="bibref" href="#bib-HTML5">HTML5</a></cite>]. The codecs parameter, which certain MIME types define, might be necessary to specify exactly how the resource is encoded. [<cite><a class="bibref" href="#bib-RFC6381">RFC6381</a></cite>] The empty string is invalid.
+            </p>
           </dd><dt id="widl-MediaKeySystemMediaCapability-robustness"><code>robustness</code> of type <span class="idlMemberType">DOMString</span>, defaulting to <code>""</code></dt>
           <dd>
-            The robustness level associated with the content type. The empty string indicates that any ability to decrypt and decode the content type is acceptable.
+            <p>
+              The robustness level associated with the content type. The empty string indicates that any ability to decrypt and decode the content type is acceptable.
+            </p>
+            <div class="note">
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note44"><span>Note</span></div>
+              <div class="">
+                <p>
+                  Implementations <em class="rfc2119" title="MUST">MUST</em> configure the CDM to support at least the robustness levels specified in the configuration of the MediaKeySystemAccess object used to create the MediaKeys object. Exact configuration of the CDM is implementation-dependent Implementations and <em class="rfc2119" title="MAY">MAY</em> be set to the use the highest robustness level in the configuration even if a higher robustness level is available. If only the empty string is specified, implementations <em class="rfc2119" title="MAY">MAY</em> be configured to use the lowest robustness level the implementation supports.
+                </p>
+                <p>
+                  Applications <em class="rfc2119" title="SHOULD">SHOULD</em> specify the robustness level(s) they require to avoid unexpected client incompatibilities.
+                </p>
+              </div>
+            </div>
           </dd>
         </dl>
       </section>
 
       <p>In order for the capability represented by this object to be considered supported, <code><a href="#widl-MediaKeySystemMediaCapability-contentType">contentType</a></code> <em class="rfc2119" title="MUST NOT">MUST NOT</em> be the empty string and its entire value, including all codecs, <em class="rfc2119" title="MUST">MUST</em> be supported with <code><a href="#widl-MediaKeySystemMediaCapability-robustness">robustness</a></code>.</p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note44"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note45"><span>Note</span></div>
         <p class="">If any of a set of codecs is acceptable, use a separate instances of this dictionary for each codec.</p>
       </div>
     </section>
@@ -2781,7 +2772,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                     </dd>
                   </dl>
                   <div class="note">
-                    <div class="note-title marker" aria-level="4" role="heading" id="h-note45"><span>Note</span></div>
+                    <div class="note-title marker" aria-level="4" role="heading" id="h-note46"><span>Note</span></div>
                     <p class="">The value of <var>distinctive identifier requirement</var> cannot be <code><a href="#idl-def-MediaKeysRequirement.optional">"optional"</a></code>.</p>
                   </div>
                 </li>
@@ -2801,7 +2792,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                     </dd>
                   </dl>
                   <div class="note">
-                    <div class="note-title marker" aria-level="4" role="heading" id="h-note46"><span>Note</span></div>
+                    <div class="note-title marker" aria-level="4" role="heading" id="h-note47"><span>Note</span></div>
                     <p class="">The value of <var>persistent state requirement</var> cannot be <code><a href="#idl-def-MediaKeysRequirement.optional">"optional"</a></code>.</p>
                   </div>
                 </li>
@@ -2869,7 +2860,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                 Return this object's <var>configuration</var> value.
               </p>
               <div class="note">
-                <div class="note-title marker" aria-level="4" role="heading" id="h-note47"><span>Note</span></div>
+                <div class="note-title marker" aria-level="4" role="heading" id="h-note48"><span>Note</span></div>
                 <p class="">
                   This results in a new JavaScript object being created and initialized from <var>configuration</var> each time this method is called.
                 </p>
@@ -2939,13 +2930,13 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
             The <dfn id="key-usage-accuracy" data-dfn-type="dfn"><var>key usage accuracy</var></dfn> is implementation-dependant but <em class="rfc2119" title="SHALL NOT">SHALL NOT</em> be greater than 60 seconds.
           </p>
           <div class="note">
-            <div class="note-title marker" aria-level="3" role="heading" id="h-note48"><span>Note</span></div>
+            <div class="note-title marker" aria-level="3" role="heading" id="h-note49"><span>Note</span></div>
             <p class="">
               Because the license and keys are not persisted, this record implicitly proves that the keys are no longer available in the session.
             </p>
           </div>
           <div class="note">
-            <div class="note-title marker" aria-level="3" role="heading" id="h-note49"><span>Note</span></div>
+            <div class="note-title marker" aria-level="3" role="heading" id="h-note50"><span>Note</span></div>
             <p class="">
               User agents <em class="rfc2119" title="MAY">MAY</em> implement this mechanism by means other than persisting data on key destruction - for example by persisting data during playback which is later used to infer the fact of key destruction - provided the observable behavior is compliant to this specification.
             </p>
@@ -3008,14 +2999,14 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
             <li>
               <p>If this object's <var>supported session types</var> value does not contain <var>sessionType</var>, <a href="https://heycam.github.io/webidl/#dfn-throw">throw</a> [<cite><a class="bibref" href="#bib-WebIDL">WebIDL</a></cite>] a <code><a href="#dfn-NotSupportedError">NotSupportedError</a></code>.</p>
               <div class="note">
-                <div class="note-title marker" aria-level="4" role="heading" id="h-note50"><span>Note</span></div>
+                <div class="note-title marker" aria-level="4" role="heading" id="h-note51"><span>Note</span></div>
                 <p class=""><var>sessionType</var> values for which the <a href="#is-persistent-session-type">Is persistent session type?</a> algorithm returns <code>true</code> will fail if this object's <var>persistent state allowed</var> value is <code>false</code>.</p>
               </div>
             </li>
             <li>
               <p>If the implementation does not support <a href="#idl-def-MediaKeySession" class="idlType"><code>MediaKeySession</code></a> operations in the current state, <a href="https://heycam.github.io/webidl/#dfn-throw">throw</a> [<cite><a class="bibref" href="#bib-WebIDL">WebIDL</a></cite>] an <code><a href="#dfn-InvalidStateError">InvalidStateError</a></code>.</p>
               <div class="note">
-                <div class="note-title marker" aria-level="4" role="heading" id="h-note51"><span>Note</span></div>
+                <div class="note-title marker" aria-level="4" role="heading" id="h-note52"><span>Note</span></div>
                 <p class="">Some implementations are unable to execute <a href="#idl-def-MediaKeySession" class="idlType"><code>MediaKeySession</code></a> algorithms until this <a href="#idl-def-MediaKeys" class="idlType"><code>MediaKeys</code></a> object is associated with a media element using <code><a href="#widl-HTMLMediaElement-setMediaKeys-Promise-void--MediaKeys-mediaKeys">setMediaKeys()</a></code>. This step enables applications to detect this uncommon behavior before attempting to perform such operations.
                 </p>
               </div>
@@ -3069,7 +3060,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
           <p id="server-certificate">Provides a server certificate to be used to encrypt messages to the license server.</p>
           <p>Key Systems that use such certificates <em class="rfc2119" title="MUST">MUST</em> also support requesting the certificate from the server via the <a href="#queue-message">Queue a "message" Event</a> algorithm.</p>
           <div class="note">
-            <div class="note-title marker" aria-level="4" role="heading" id="h-note52"><span>Note</span></div>
+            <div class="note-title marker" aria-level="4" role="heading" id="h-note53"><span>Note</span></div>
             <p class="">This method allows an application to proactively provide a server certificate to implementations that support it to avoid the additional round trip should the CDM request it. It is intended as an optimization, and applications are not required to use it.
             </p>
           </div>
@@ -3207,7 +3198,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       A MediaKeySession object <em class="rfc2119" title="SHALL NOT">SHALL NOT</em> be destroyed and <em class="rfc2119" title="SHALL">SHALL</em> continue to receive events if it has not been closed and the <a href="#idl-def-MediaKeys" class="idlType"><code>MediaKeys</code></a> object that created it remains accessible. Otherwise, a MediaKeySession object that is no longer accessible to JavaScript <em class="rfc2119" title="SHALL NOT">SHALL NOT</em> receive further events and <em class="rfc2119" title="MAY">MAY</em> be destroyed.
     </p>
     <div class="note">
-      <div class="note-title marker" aria-level="3" role="heading" id="h-note53"><span>Note</span></div>
+      <div class="note-title marker" aria-level="3" role="heading" id="h-note54"><span>Note</span></div>
       <p class="">
         The above rule implies that the CDM instance must not be destroyed until all <a href="#idl-def-MediaKeys" class="idlType"><code>MediaKeys</code></a> objects and all <a href="#idl-def-MediaKeySession" class="idlType"><code>MediaKeySession</code></a> objects associated with the CDM instance are destroyed.
       </p>
@@ -3240,7 +3231,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         <dd>
           <p>The <a href="#time">time</a> after which the key(s) in the session will no longer be <a href="#usable-for-decryption">usable for decryption</a>, or <code>NaN</code> if no such time exists or if the license explicitly never expires, as determined by the CDM.</p>
           <div class="note">
-            <div class="note-title marker" aria-level="4" role="heading" id="h-note54"><span>Note</span></div>
+            <div class="note-title marker" aria-level="4" role="heading" id="h-note55"><span>Note</span></div>
             <p class="">This value <em class="rfc2119" title="MAY">MAY</em> change during the session lifetime, such as when an action triggers the start of a window.</p>
           </div>
         </dd><dt id="widl-MediaKeySession-keyStatuses"><code>keyStatuses</code> of type <span class="idlAttrType"><a href="#idl-def-MediaKeyStatusMap" class="idlType"><code>MediaKeyStatusMap</code></a></span>, readonly       </dt>
@@ -3248,12 +3239,12 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
           <p>A reference to a read-only map of <a href="#decryption-key-id">key IDs</a> <a href="#known-key">known</a> to the session to the current status of the associated key. Each entry <em class="rfc2119" title="MUST">MUST</em> have a unique key ID.
           </p>
           <div class="note">
-            <div class="note-title marker" aria-level="4" role="heading" id="h-note55"><span>Note</span></div>
+            <div class="note-title marker" aria-level="4" role="heading" id="h-note56"><span>Note</span></div>
             <p class="">The map entries and their values may be updated whenever the event loop spins. The map <em class="rfc2119" title="MUST NOT">MUST NOT</em> ever be inconsistent or partially updated, but it may change between accesses if the event loop spins in between the accesses. Key IDs may be added as the result of a <code><a href="#widl-MediaKeySession-load-Promise-boolean--DOMString-sessionId">load()</a></code> or <code><a href="#widl-MediaKeySession-update-Promise-void--BufferSource-response">update()</a></code> call. Key IDs may be removed as the result of a <code><a href="#widl-MediaKeySession-update-Promise-void--BufferSource-response">update()</a></code> call that removes knowledge of existing keys (or replaces the existing set of keys with a new set). Key IDs <em class="rfc2119" title="MUST NOT">MUST NOT</em> be removed because they became unusable, such as due to expiration. Instead, such keys <em class="rfc2119" title="MUST">MUST</em> be given an appropriate status, such as <code><a href="#idl-def-MediaKeyStatus.expired">"expired"</a></code>.
             </p>
           </div>
           <div class="note">
-            <div class="note-title marker" aria-level="4" role="heading" id="h-note56"><span>Note</span></div>
+            <div class="note-title marker" aria-level="4" role="heading" id="h-note57"><span>Note</span></div>
             <p class="">
               Some older platforms may contain Key System implementations that do not expose key IDs, making it impossible to provide a compliant user agent implementation. To maximize interoperability, user agent implementations exposing such CDMs <em class="rfc2119" title="SHOULD">SHOULD</em> implement this member as follows: Whenever a non-empty list is appropriate, such as when the <a href="#key-session">key session</a> represented by this object may contain <a href="#decryption-key">key(s)</a>, populate the map with a single pair containing the one-byte key ID <code>0</code> and the <a href="#idl-def-MediaKeyStatus" class="idlType"><code>MediaKeyStatus</code></a> most appropriate for the aggregated status of this object.
             </p>
@@ -3277,7 +3268,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         <dd>
           <p>Indicates that the application no longer needs the session and the CDM should release any resources associated with the session and close it. Persisted data should not be released or cleared.</p>
           <div class="note">
-            <div class="note-title marker" aria-level="4" role="heading" id="h-note57"><span>Note</span></div>
+            <div class="note-title marker" aria-level="4" role="heading" id="h-note58"><span>Note</span></div>
             <p class="">The returned promise is resolved when the request has been processed, and the <code><a href="#widl-MediaKeySession-closed">closed</a></code> attribute promise is resolved when the session is closed.</p>
           </div>
           <div><em>No parameters.</em></div>
@@ -3305,7 +3296,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                 <li>
                   <p>Use <var>cdm</var> to close the <a href="#key-session">session</a> associated with <var>session</var>.</p>
                   <div class="note">
-                    <div class="note-title marker" aria-level="4" role="heading" id="h-note58"><span>Note</span></div>
+                    <div class="note-title marker" aria-level="4" role="heading" id="h-note59"><span>Note</span></div>
                     <p class="">Closing the key session results in the destruction of any license(s) and key(s) that have not been explicitly stored.</p>
                   </div>
                 </li>
@@ -3318,7 +3309,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                     <li>
                       <p>Resolve <var>promise</var>.</p>
                       <div class="note">
-                        <div class="note-title marker" aria-level="4" role="heading" id="h-note59"><span>Note</span></div>
+                        <div class="note-title marker" aria-level="4" role="heading" id="h-note60"><span>Note</span></div>
                         <p class="">Since promise handlers are queued as microtasks, these will be executed ahead of any events queued by the preceding steps.</p>
                       </div>
                     </li>
@@ -3431,7 +3422,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                         <dd>
                           <p>Let <var>requested license type</var> be a temporary non-persistable license.</p>
                           <div class="note">
-                            <div class="note-title marker" aria-level="4" role="heading" id="h-note60"><span>Note</span></div>
+                            <div class="note-title marker" aria-level="4" role="heading" id="h-note61"><span>Note</span></div>
                             <p class="">The returned license must not be persistable or require persisting information related to it.</p>
                           </div>
                         </dd>
@@ -3538,7 +3529,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                     <li>
                       <p>Resolve <var>promise</var>.</p>
                       <div class="note">
-                        <div class="note-title marker" aria-level="4" role="heading" id="h-note61"><span>Note</span></div>
+                        <div class="note-title marker" aria-level="4" role="heading" id="h-note62"><span>Note</span></div>
                         <p class="">Since promise handlers are queued as microtasks, these will be executed ahead of any events queued by the preceding steps.</p>
                       </div>
                     </li>
@@ -3602,7 +3593,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                 <li>
                   <p>Let <var>sanitized session ID</var> be a validated and/or sanitized version of <var>sessionId</var>.</p>
                   <div class="note">
-                    <div class="note-title marker" aria-level="4" role="heading" id="h-note62"><span>Note</span></div>
+                    <div class="note-title marker" aria-level="4" role="heading" id="h-note63"><span>Note</span></div>
                     <p class="">The user agent should thoroughly validate the sessionId value before passing it to the CDM. At a minimum, this should include checking that the length and value (e.g. alphanumeric) are reasonable.
                     </p>
                   </div>
@@ -3613,7 +3604,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                 <li>
                   <p>If there is an unclosed session in this object's <a href="https://www.w3.org/TR/dom/#concept-document">Document</a> whose <code><a href="#widl-MediaKeySession-sessionId">sessionId</a></code> attribute is <var>sanitized session ID</var>, reject <var>promise</var> with a <code><a href="#dfn-QuotaExceededError">QuotaExceededError</a></code>.</p>
                   <div class="note">
-                    <div class="note-title marker" aria-level="4" role="heading" id="h-note63"><span>Note</span></div>
+                    <div class="note-title marker" aria-level="4" role="heading" id="h-note64"><span>Note</span></div>
                     <p class="">In other words, do not create a session if a non-closed session, regardless of type, already exists for this <var>sanitized session ID</var> in this browsing context.</p>
                   </div>
                 </li>
@@ -3645,7 +3636,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                     <li>
                       <p>If there is an unclosed session in any <a href="https://www.w3.org/TR/dom/#concept-document">Document</a> representing the <var>session data</var>, reject <var>promise</var> with a <code><a href="#dfn-QuotaExceededError">QuotaExceededError</a></code>.</p>
                       <div class="note">
-                        <div class="note-title marker" aria-level="4" role="heading" id="h-note64"><span>Note</span></div>
+                        <div class="note-title marker" aria-level="4" role="heading" id="h-note65"><span>Note</span></div>
                         <p class="">In other words, do not create a session if a non-closed persistent session already exists for this <var>sanitized session ID</var> in any browsing context.</p>
                       </div>
                     </li>
@@ -3698,7 +3689,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                       <p>Resolve <var>promise</var> with <code>true</code>.
                       </p>
                       <div class="note">
-                        <div class="note-title marker" aria-level="4" role="heading" id="h-note65"><span>Note</span></div>
+                        <div class="note-title marker" aria-level="4" role="heading" id="h-note66"><span>Note</span></div>
                         <p class="">Since promise handlers are queued as microtasks, these will be executed ahead of any events queued by the preceding steps.</p>
                       </div>
                       <p></p>
@@ -3754,7 +3745,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                             Destroy the license(s) and/or key(s) associated with the session.
                           </p>
                           <div class="note">
-                            <div class="note-title marker" aria-level="4" role="heading" id="h-note66"><span>Note</span></div>
+                            <div class="note-title marker" aria-level="4" role="heading" id="h-note67"><span>Note</span></div>
                             <p class="">
                               This implies destruction of the license(s) and/or keys(s) whether they are in memory, persistent store or both.
                             </p>
@@ -3829,7 +3820,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                     <li>
                       <p>Resolve <var>promise</var>.</p>
                       <div class="note">
-                        <div class="note-title marker" aria-level="4" role="heading" id="h-note67"><span>Note</span></div>
+                        <div class="note-title marker" aria-level="4" role="heading" id="h-note68"><span>Note</span></div>
                         <p class="">Since promise handlers are queued as microtasks, these will be executed ahead of any events queued by the preceding steps.</p>
                       </div>
                     </li>
@@ -3886,7 +3877,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                 <li>
                   <p>Let <var>sanitized response</var> be a validated and/or sanitized version of <var>response copy</var>.</p>
                   <div class="note">
-                    <div class="note-title marker" aria-level="4" role="heading" id="h-note68"><span>Note</span></div>
+                    <div class="note-title marker" aria-level="4" role="heading" id="h-note69"><span>Note</span></div>
                     <p class="">The user agent should thoroughly validate the response before passing it to the CDM. This may include verifying values are within reasonable limits, stripping irrelevant data or fields, pre-parsing it, sanitizing it, and/or generating a fully sanitized version. The user agent should check that the length and values of fields are reasonable. Unknown fields should be rejected or removed.
                     </p>
                   </div>
@@ -3918,7 +3909,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                         <dt>If <var>sanitized response</var> contains a license or key(s)</dt>
                         <dd>
                           <div class="note">
-                            <div class="note-title marker" aria-level="4" role="heading" id="h-note69"><span>Note</span></div>
+                            <div class="note-title marker" aria-level="4" role="heading" id="h-note70"><span>Note</span></div>
                             <p class="">This includes an initial license, an updated license, and a license renewal message.</p>
                           </div>
                           <p>Process <var>sanitized response</var>, following the stipulation for the first matching condition from the following list:</p>
@@ -3951,15 +3942,15 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                           <p>See also <a href="#session-storage">Session Storage and Persistence</a>.</p>
                           <p>State information, including keys, for each session <em class="rfc2119" title="MUST">MUST</em> be stored in such a way that closing one session does not affect the observable state in other session(s), even if they contain overlapping key IDs.</p>
                           <div class="note">
-                            <div class="note-title marker" aria-level="4" role="heading" id="h-note70"><span>Note</span></div>
+                            <div class="note-title marker" aria-level="4" role="heading" id="h-note71"><span>Note</span></div>
                             <p class="">When <var>sanitized response</var> contains key(s) and/or related data, <var>cdm</var> will likely store (in memory) the key and related data indexed by key ID.</p>
                           </div>
                           <div class="note">
-                            <div class="note-title marker" aria-level="4" role="heading" id="h-note71"><span>Note</span></div>
+                            <div class="note-title marker" aria-level="4" role="heading" id="h-note72"><span>Note</span></div>
                             <p class="">The replacement algorithm within a session is <a href="#key-system">Key System</a>-dependent.</p>
                           </div>
                           <div class="note">
-                            <div class="note-title marker" aria-level="4" role="heading" id="h-note72"><span>Note</span></div>
+                            <div class="note-title marker" aria-level="4" role="heading" id="h-note73"><span>Note</span></div>
                             <p class="">It is <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em> that CDM implementations support a standard and reasonably high minimum number of keys per <a href="#idl-def-MediaKeySession" class="idlType"><code>MediaKeySession</code></a> object, including a standard replacement algorithm, and a standard and reasonably high minimum number of <a href="#idl-def-MediaKeySession" class="idlType"><code>MediaKeySession</code></a> objects. This enables a reasonable number of key rotation algorithms to be implemented across user agents and may reduce the likelihood of playback interruptions in use cases that involve various streams in the same element (i.e. adaptive streams, various audio and video tracks) using different keys.
                             </p>
                           </div>
@@ -3973,7 +3964,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                                 Close the <a href="#key-session">session</a> and clear <em>all</em> stored session data associated with this object, including the <code><a href="#widl-MediaKeySession-sessionId">sessionId</a></code> and license destruction record.
                               </p>
                               <div class="note">
-                                <div class="note-title marker" aria-level="4" role="heading" id="h-note73"><span>Note</span></div>
+                                <div class="note-title marker" aria-level="4" role="heading" id="h-note74"><span>Note</span></div>
                                 <p class="">A subsequent call to <code><a href="#widl-MediaKeySession-load-Promise-boolean--DOMString-sessionId">load()</a></code> with the value of this object's <code><a href="#widl-MediaKeySession-sessionId">sessionId</a></code> would fail because there is no data stored for that session ID.</p>
                               </div>
                             </li>
@@ -3991,7 +3982,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                                 Close the <a href="#key-session">session</a> and clear <em>all</em> stored session data associated with this object, including the <code><a href="#widl-MediaKeySession-sessionId">sessionId</a></code> and the <a href="#record-of-key-usage">record of key usage</a>.
                               </p>
                               <div class="note">
-                                <div class="note-title marker" aria-level="4" role="heading" id="h-note74"><span>Note</span></div>
+                                <div class="note-title marker" aria-level="4" role="heading" id="h-note75"><span>Note</span></div>
                                 <p class="">A subsequent call to <code><a href="#widl-MediaKeySession-load-Promise-boolean--DOMString-sessionId">load()</a></code> with the value of this object's <code><a href="#widl-MediaKeySession-sessionId">sessionId</a></code> would fail because there is no data stored for that session ID.</p>
                               </div>
                             </li>
@@ -4003,7 +3994,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                         <dt>Otherwise</dt>
                         <dd>Process <var>sanitized response</var>, not storing any session data.
                           <div class="note">
-                            <div class="note-title marker" aria-level="4" role="heading" id="h-note75"><span>Note</span></div>
+                            <div class="note-title marker" aria-level="4" role="heading" id="h-note76"><span>Note</span></div>
                             <p class="">For example, <var>sanitized response</var> may contain information that will be used to generate another <code><a href="#dom-evt-message">message</a></code> event. In this case, there is no need to verify the contents against the <var>sessionType</var>.
                             </p>
                           </div>
@@ -4060,7 +4051,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                     <li>
                       <p>Resolve <var>promise</var>.</p>
                       <div class="note">
-                        <div class="note-title marker" aria-level="4" role="heading" id="h-note76"><span>Note</span></div>
+                        <div class="note-title marker" aria-level="4" role="heading" id="h-note77"><span>Note</span></div>
                         <p class="">Since promise handlers are queued as microtasks, these will be executed ahead of any events queued by the preceding steps.</p>
                       </div>
                     </li>
@@ -4081,7 +4072,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <p>The MediaKeyStatusMap object is a read-only map of <a href="#decryption-key-id">key IDs</a> to the current status of the associated key.</p>
       <p>A key's status is independent of whether the key is currently being used and of media data.</p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note77"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note78"><span>Note</span></div>
         <p class="">For example, if a key has output requirements that cannot currently be met, the key's status should be <code><a href="#idl-def-MediaKeyStatus.output-downscaled">"output-downscaled"</a></code> or <code><a href="#idl-def-MediaKeyStatus.output-restricted">"output-restricted"</a></code>, as appropriate, regardless of whether that key has been or is currently needed to decrypt media data.</p>
       </div>
       <pre class="idl"><span class="idlInterface" id="idl-def-MediaKeyStatusMap">interface <span class="idlInterfaceID">MediaKeyStatusMap</span> {
@@ -4288,7 +4279,7 @@ interface <span class="idlInterfaceID">MediaKeyMessageEvent</span> : <span class
             <p>Implementations <em class="rfc2119" title="MUST NOT">MUST NOT</em> require applications to handle message types. Implementations <em class="rfc2119" title="MUST">MUST</em> support applications that do not differentiate messages and <em class="rfc2119" title="MUST NOT">MUST NOT</em> require that applications handle message types. Specifically, Key Systems <em class="rfc2119" title="MUST">MUST</em> support passing all types of messages to a single URL.
             </p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note78"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note79"><span>Note</span></div>
               <p class="">This attribute allows an application to differentiate messages without parsing the message. It is intended to enable optional application and/or server optimizations, but applications are not required to use it.
               </p>
             </div>
@@ -4378,7 +4369,7 @@ interface <span class="idlInterfaceID">MediaKeyMessageEvent</span> : <span class
         <p>The Update Key Statuses algorithm updates the set of <a href="#known-key">known</a> keys for a <a href="#idl-def-MediaKeySession" class="idlType"><code>MediaKeySession</code></a> or the status of one or more of the keys. Requests to run this algorithm include a target <a href="#idl-def-MediaKeySession" class="idlType"><code>MediaKeySession</code></a> object and a sequence of <a href="#decryption-key-id">key ID</a> and associated <a href="#idl-def-MediaKeyStatus" class="idlType"><code>MediaKeyStatus</code></a> pairs.
         </p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note79"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note80"><span>Note</span></div>
           <p class="">The algorithm is always run in a task.</p>
         </div>
         <p>The following steps are run:</p>
@@ -4411,7 +4402,7 @@ interface <span class="idlInterfaceID">MediaKeyMessageEvent</span> : <span class
               </li>
             </ol>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note80"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note81"><span>Note</span></div>
               <p class="">The effect of this steps is that the contents of <var>session</var>'s <code><a href="#widl-MediaKeySession-keyStatuses">keyStatuses</a></code> attribute are replaced without invalidating existing references to the attribute. This replacement is atomic from a script perspective. That is, script <em class="rfc2119" title="MUST NOT">MUST NOT</em> ever see a partially populated sequence.
               </p>
             </div>
@@ -4430,7 +4421,7 @@ interface <span class="idlInterfaceID">MediaKeyMessageEvent</span> : <span class
         <p>The Update Expiration algorithm updates the expiration time of a <a href="#idl-def-MediaKeySession" class="idlType"><code>MediaKeySession</code></a>. Requests to run this algorithm include a target <a href="#idl-def-MediaKeySession" class="idlType"><code>MediaKeySession</code></a> object and the new expiration time, which may be <code>NaN</code>.
         </p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note81"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note82"><span>Note</span></div>
           <p class="">The algorithm is always run in a task.</p>
         </div>
         <p>The following steps are run:</p>
@@ -4454,14 +4445,14 @@ interface <span class="idlInterfaceID">MediaKeyMessageEvent</span> : <span class
         <h4 id="h-session-closed" resource="#h-session-closed"><span property="xhv:role" resource="xhv:heading"><span class="secno">6.6.4 </span>Session Closed</span></h4>
         <p>The Session Closed algorithm updates the <a href="#idl-def-MediaKeySession" class="idlType"><code>MediaKeySession</code></a> state after a <a href="#key-session">session</a> has been closed.</p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note82"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note83"><span>Note</span></div>
           <p class="">The algorithm is always run in a task.</p>
         </div>
         <p>
           Closing a <a href="#key-session">session</a> means that the license(s) and key(s) associated with it are no longer available to decrypt <a href="http://www.w3.org/TR/html5/embedded-content-0.html#media-data">media data</a>. All <a href="#idl-def-MediaKeySession" class="idlType"><code>MediaKeySession</code></a> methods will fail and no further events will be queued for this object after this algorithm is run.
         </p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note83"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note84"><span>Note</span></div>
           <div class="">
             <p>
               The CDM may close a session at any point, such as when the session is no longer needed or when system resources are lost. In that case, the <a href="#monitor-cdm">Monitor for CDM Changes</a> algorithm detects the change and runs this algorithm.
@@ -4488,7 +4479,7 @@ interface <span class="idlInterfaceID">MediaKeyMessageEvent</span> : <span class
               <li>
                 <p>Use <var>cdm</var> to store <var>session</var>'s <var>record of key usage</var>, if it exists.</p>
                 <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note84"><span>Note</span></div>
+                  <div class="note-title marker" aria-level="5" role="heading" id="h-note85"><span>Note</span></div>
                   <div class="">
                     <p>
                       The <var>record of key usage</var> may not exist if no keys have been used in the session or if it has been deleted as a result of the <code><a href="#widl-MediaKeySession-update-Promise-void--BufferSource-response">update()</a></code> method processing an acknowledgement of the record of key usage.
@@ -4541,7 +4532,7 @@ interface <span class="idlInterfaceID">MediaKeyMessageEvent</span> : <span class
                   If <var>session</var>'s <var>session type</var> is <code><a href="#idl-def-MediaKeySessionType.persistent-usage-record">"persistent-usage-record"</a></code>, store <var>session</var>'s <var>record of key usage</var>, if it exists.
                 </p>
                 <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note85"><span>Note</span></div>
+                  <div class="note-title marker" aria-level="5" role="heading" id="h-note86"><span>Note</span></div>
                   <p class="">
                     Since it has no effects observable to the document, this step may be run asynchronously, including after the document has unloaded.
                   </p>
@@ -4559,7 +4550,7 @@ interface <span class="idlInterfaceID">MediaKeyMessageEvent</span> : <span class
           <a href="#idl-def-MediaKeySession" class="idlType"><code>MediaKeySession</code></a> object in parallel to the main event loop but not in parallel to other procedures defined in this specification that are run in parallel to the main event loop.
         </p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note86"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note87"><span>Note</span></div>
           <p class="">This algorithm only applies to CDM state changes that are not covered by other algorithms. For example, <code><a href="#widl-MediaKeySession-update-Promise-void--BufferSource-response">update()</a></code> may result in messages, key status changes and/or expiration changes, but those are all handled within that algorithm.</p>
         </div>
         <p>
@@ -4730,7 +4721,7 @@ interface <span class="idlInterfaceID">MediaKeyMessageEvent</span> : <span class
       <li>
         <p>For each block of encrypted <a href="http://www.w3.org/TR/html5/embedded-content-0.html#media-data">media data</a> encountered during the <a href="http://www.w3.org/TR/html5/embedded-content-0.html#concept-media-load-resource">resource fetch algorithm</a>, the user agent <em class="rfc2119" title="SHALL">SHALL</em> run the <a href="#encrypted-block-encountered">Encrypted Block Encountered</a> algorithm in the order the encrypted blocks were encountered.</p>
         <div class="note">
-          <div class="note-title marker" aria-level="3" role="heading" id="h-note87"><span>Note</span></div>
+          <div class="note-title marker" aria-level="3" role="heading" id="h-note88"><span>Note</span></div>
           <p class="">The above step provides flexibility for user agent implementations to perform decryption at any time after an encrypted block is encountered before it is needed for playback.</p>
         </div>
       </li>
@@ -4770,11 +4761,11 @@ interface <span class="idlInterfaceID">MediaKeyMessageEvent</span> : <span class
         <dd>
           <p>Provides the <a href="#idl-def-MediaKeys" class="idlType"><code>MediaKeys</code></a> to use when decrypting media data during playback.</p>
           <div class="note">
-            <div class="note-title marker" aria-level="4" role="heading" id="h-note88"><span>Note</span></div>
+            <div class="note-title marker" aria-level="4" role="heading" id="h-note89"><span>Note</span></div>
             <p class="">Support for clearing or replacing the associated <a href="#idl-def-MediaKeys" class="idlType"><code>MediaKeys</code></a> object during playback is a quality of implementation issue. In many cases it will result in a bad user experience or rejected promise.</p>
           </div>
           <div class="note">
-            <div class="note-title marker" aria-level="4" role="heading" id="h-note89"><span>Note</span></div>
+            <div class="note-title marker" aria-level="4" role="heading" id="h-note90"><span>Note</span></div>
             <p class="">Some implementations may only support decrypting media data provided via Media Source Extensions [<cite><a class="bibref" href="#bib-MEDIA-SOURCE">MEDIA-SOURCE</a></cite>]. This is not reflected in the results of calling <code><a href="#widl-Navigator-requestMediaKeySystemAccess-Promise-MediaKeySystemAccess--DOMString-keySystem-sequence-MediaKeySystemConfiguration--supportedConfigurations">requestMediaKeySystemAccess()</a></code>.
             </p>
           </div>
@@ -4829,7 +4820,7 @@ interface <span class="idlInterfaceID">MediaKeyMessageEvent</span> : <span class
                     <li>
                       <p>If the association cannot currently be removed, let this object's <var>attaching media keys</var> value be false and reject <var>promise</var> with an <code><a href="#dfn-InvalidStateError">InvalidStateError</a></code>.</p>
                       <div class="note">
-                        <div class="note-title marker" aria-level="4" role="heading" id="h-note90"><span>Note</span></div>
+                        <div class="note-title marker" aria-level="4" role="heading" id="h-note91"><span>Note</span></div>
                         <p class="">For example, some implementations may not allow removal during playback.</p>
                       </div>
                     </li>
@@ -4979,7 +4970,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
             <td>The user agent encounters <a href="#initialization-data">Initialization Data</a> in the <a href="http://www.w3.org/TR/html5/embedded-content-0.html#media-data">media data</a>.</td>
             <td>The element's <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#dom-media-readystate">readyState</a></code> is equal to <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#dom-media-have_metadata">HAVE_METADATA</a></code> or greater.
               <div class="note">
-                <div class="note-title marker" aria-level="4" role="heading" id="h-note91"><span>Note</span></div>
+                <div class="note-title marker" aria-level="4" role="heading" id="h-note92"><span>Note</span></div>
                 <p class="">It is possible that the element is playing or has played.</p>
               </div>
             </td>
@@ -5019,7 +5010,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
               </li>
             </ol>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note92"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note93"><span>Note</span></div>
               <p class="">While the media element may allow loading of "Optionally-blockable Content" [<cite><a class="bibref" href="#bib-MIXED-CONTENT">MIXED-CONTENT</a></cite>], the user agent <em class="rfc2119" title="MUST NOT">MUST NOT</em> expose Initialization Data from such media data to the application.</p>
             </div>
           </li>
@@ -5034,11 +5025,11 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
               </li>
             </ul>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note93"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note94"><span>Note</span></div>
               <p class=""><code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#dom-media-readystate">readyState</a></code> is <em>not</em> changed and no algorithms are aborted. This event merely provides information.</p>
             </div>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note94"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note95"><span>Note</span></div>
               <p class="">The <code><a href="#widl-MediaEncryptedEventInit-initData">initData</a></code> attribute will be null if the media data is <em>not</em> <a href="http://www.w3.org/TR/html5/infrastructure.html#cors-same-origin">CORS-same-origin</a> or is <a href="#mixed-content">mixed content</a>. Applications may retrieve the Initialization Data from an alternate source.
               </p>
             </div>
@@ -5046,7 +5037,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
           <li>
             <p>If the media element's <code><a href="#widl-HTMLMediaElement-mediaKeys">mediaKeys</a></code> attribute is null and the implementation requires specification of a <a href="#idl-def-MediaKeys" class="idlType"><code>MediaKeys</code></a> object before decoding potentially-encrypted <a href="http://www.w3.org/TR/html5/embedded-content-0.html#media-data">media data</a>, run the following steps:</p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note95"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note96"><span>Note</span></div>
               <p class="">These steps may be reached when the application provides <a href="http://www.w3.org/TR/html5/embedded-content-0.html#media-data">media data</a> before calling <code><a href="#widl-HTMLMediaElement-setMediaKeys-Promise-void--MediaKeys-mediaKeys">setMediaKeys()</a></code> to provide a <a href="#idl-def-MediaKeys" class="idlType"><code>MediaKeys</code></a> object. Selecting a <a href="#cdm">CDM</a> may affect the pipeline and/or decoders used, so some implementations may delay playback of media data that may contain encrypted blocks until a CDM is specified by passing a <a href="#idl-def-MediaKeys" class="idlType"><code>MediaKeys</code></a> object to <code><a href="#widl-HTMLMediaElement-setMediaKeys-Promise-void--MediaKeys-mediaKeys">setMediaKeys()</a></code>.
               </p>
             </div>
@@ -5101,7 +5092,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
               <li>
                 <p>If <var>cdm</var> is no longer usable for any reason, run the following steps:</p>
                 <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note96"><span>Note</span></div>
+                  <div class="note-title marker" aria-level="5" role="heading" id="h-note97"><span>Note</span></div>
                   <p class="">These steps are intended to be run on unrecoverable failures of the CDM.</p>
                 </div>
                 <ol>
@@ -5119,7 +5110,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
               <li>
                 <p>If there is at least one <a href="#idl-def-MediaKeySession" class="idlType"><code>MediaKeySession</code></a> created by the <var>media keys</var> on which the <a href="#session-closed">Session Closed</a> algorithm has not been run, run the following steps:</p>
                 <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note97"><span>Note</span></div>
+                  <div class="note-title marker" aria-level="5" role="heading" id="h-note98"><span>Note</span></div>
                   <p class="">This check ensures the <var>cdm</var> has finished loading and is a prerequisite for a matching key being available.</p>
                 </div>
                 <ol>
@@ -5129,7 +5120,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
                   <li>
                     <p>Let the <var>block key ID</var> be the key ID of <var>block</var>.</p>
                     <div class="note">
-                      <div class="note-title marker" aria-level="5" role="heading" id="h-note98"><span>Note</span></div>
+                      <div class="note-title marker" aria-level="5" role="heading" id="h-note99"><span>Note</span></div>
                       <p class="">The key ID is generally specified by the container.</p>
                     </div>
                   </li>
@@ -5146,7 +5137,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
                         <p>If any of the <var>available keys</var> corresponds to the <var>block key ID</var> and is <a href="#usable-for-decryption">usable for decryption</a>, let <var>session</var> be a
                           <a href="#idl-def-MediaKeySession" class="idlType"><code>MediaKeySession</code></a> object containing that key and let <var>block key</var> be that key.</p>
                         <div class="note">
-                          <div class="note-title marker" aria-level="5" role="heading" id="h-note99"><span>Note</span></div>
+                          <div class="note-title marker" aria-level="5" role="heading" id="h-note100"><span>Note</span></div>
                           <p class="">If multiple sessions contain a key that is <a href="#usable-for-decryption">usable for decryption</a> for the <var>block key ID</var>, which session and key to use is <a href="#key-system">Key System</a>-dependent.</p>
                         </div>
                       </li>
@@ -5177,7 +5168,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
                               </li>
                             </ol>
                             <div class="note">
-                              <div class="note-title marker" aria-level="5" role="heading" id="h-note100"><span>Note</span></div>
+                              <div class="note-title marker" aria-level="5" role="heading" id="h-note101"><span>Note</span></div>
                               <p class="">
                                 Implementations <em class="rfc2119" title="MAY">MAY</em> optimize the times at which this step is executed provided the recorded key usage times remain accurate to within <var>key usage accuracy</var>.
                               </p>
@@ -5213,7 +5204,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
                                   <li>
                                     <p>Process the decrypted block as normal.</p>
                                     <div class="note">
-                                      <div class="note-title marker" aria-level="5" role="heading" id="h-note101"><span>Note</span></div>
+                                      <div class="note-title marker" aria-level="5" role="heading" id="h-note102"><span>Note</span></div>
                                       <p class="">In other words, decode the block.</p>
                                     </div>
                                   </li>
@@ -5225,13 +5216,13 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
                               </dd>
                             </dl>
                             <div class="note">
-                              <div class="note-title marker" aria-level="5" role="heading" id="h-note102"><span>Note</span></div>
+                              <div class="note-title marker" aria-level="5" role="heading" id="h-note103"><span>Note</span></div>
                               <p class="">Not all decryption problems (i.e. using the wrong key) will result in a decryption failure. In such cases, no error is fired here but one may be fired during decode.</p>
                             </div>
                           </li>
                         </ol>
                         <div class="note">
-                          <div class="note-title marker" aria-level="5" role="heading" id="h-note103"><span>Note</span></div>
+                          <div class="note-title marker" aria-level="5" role="heading" id="h-note104"><span>Note</span></div>
                           <p class="">Otherwise, there is no key for the <var>block key ID</var> in any session so continue.</p>
                         </div>
                       </li>
@@ -5244,7 +5235,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
           <li>
             <p>Run the following steps:</p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note104"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note105"><span>Note</span></div>
               <p class="">These steps are reached when there is no key that is <a href="#usable-for-decryption">usable for decryption</a> for <var>block</var>.</p>
             </div>
             <ol>
@@ -5256,7 +5247,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
         </ol>
 
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note105"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note106"><span>Note</span></div>
           <div class="">
             <p>For frame-based encryption, this may be implemented as follows when the media element attempts to decode a frame as part of the <a href="http://www.w3.org/TR/html5/embedded-content-0.html#concept-media-load-resource">resource fetch algorithm</a>:</p>
             <ol>
@@ -5299,7 +5290,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
           <li>
             <p>Set the <var>media element</var>'s <var>waiting for key</var> value to <code>true</code>.</p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note106"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note107"><span>Note</span></div>
               <p class="">As a result of the above step, the media element will become a <a href="http://www.w3.org/TR/html5/embedded-content-0.html#blocked-media-element">blocked media element</a> if it wasn't already. In that case, the media element will stop playback.</p>
             </div>
           </li>
@@ -5337,7 +5328,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
               <li>
                 <p>Set the <var>media element</var>'s <var>waiting for key</var> value to <code>false</code>.</p>
                 <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note107"><span>Note</span></div>
+                  <div class="note-title marker" aria-level="5" role="heading" id="h-note108"><span>Note</span></div>
                   <p class="">As a result of the above step, the media element may no longer be a <a href="http://www.w3.org/TR/html5/embedded-content-0.html#blocked-media-element">blocked media element</a> and thus playback may resume.</p>
                 </div>
               </li>
@@ -5347,7 +5338,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
                   <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#dom-media-have_enough_data">HAVE_ENOUGH_DATA</a></code> as <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#ready-states">appropriate</a></code>.
                 </p>
                 <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note108"><span>Note</span></div>
+                  <div class="note-title marker" aria-level="5" role="heading" id="h-note109"><span>Note</span></div>
                   <div class="">
                     <p>
                       States beyond <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#dom-media-have_current_data">HAVE_CURRENT_DATA</a></code> and the <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#event-media-canplaythrough">canplaythrough</a></code> event do not (or are unlikely to) consider key availability beyond the current key.
@@ -5403,7 +5394,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
       <p>The use of identifiers, especially <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">Distinctive Identifier(s) or Distinctive Permanent Identifier(s)</a>, by implementations presents a privacy concern. This section defines requirements for avoiding or at least mitigating such concerns.
       </p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note109"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note110"><span>Note</span></div>
         <div class="">
           <p>In summary:</p>
           <ul>
@@ -5437,14 +5428,14 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
           <li>
             <p>Implementations <em class="rfc2119" title="SHOULD">SHOULD</em> avoid <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">use of Distinctive Identifier(s) or Distinctive Permanent Identifier(s)</a>.</p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note110"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note111"><span>Note</span></div>
               <p class="">For example, use identifiers or other values that apply to a group of clients or devices rather than individual clients.</p>
             </div>
           </li>
           <li>
             <p>Implementations <em class="rfc2119" title="SHOULD">SHOULD</em> only <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">use Distinctive Identifier(s) or Distinctive Permanent Identifier(s)</a> when necessary to enforce the policies related to the specific CDM instance and session.</p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note111"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note112"><span>Note</span></div>
               <p class="">For example, <code><a href="#idl-def-MediaKeySessionType.temporary">"temporary"</a></code> and <code><a href="#idl-def-MediaKeySessionType.persistent-license">"persistent-license"</a></code> sessions may have different requirements.</p>
             </div>
           </li>
@@ -5456,7 +5447,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
                 -->
             </p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note112"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note113"><span>Note</span></div>
               <div class="">
                 <p>
                   When supported, applications can select for this mode using <code><a href="#widl-MediaKeySystemConfiguration-distinctiveIdentifier">distinctiveIdentifier</a></code> = <code><a href="#idl-def-MediaKeysRequirement.not-allowed">"not-allowed"</a></code>. Selecting such an option may affect the results of the <code><a href="#widl-Navigator-requestMediaKeySystemAccess-Promise-MediaKeySystemAccess--DOMString-keySystem-sequence-MediaKeySystemConfiguration--supportedConfigurations">requestMediaKeySystemAccess()</a></code> call and/or the license requests that are generated from subsequently generated sessions.
@@ -5480,7 +5471,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
           <p class=""><a href="https://github.com/w3c/encrypted-media/issues/219">Issue 219</a> - Add more specific text about ensuring the desired privacy properties when encrypting identifiers.</p>
         </div>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note113"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note114"><span>Note</span></div>
           <div class="">
             <p>Identifiers may be exposed in the following ways:</p>
             <ul>
@@ -5501,12 +5492,12 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
         </p>
         <p>The server <em class="rfc2119" title="MUST NOT">MUST NOT</em> expose a <a href="#distinctive-identifier">Distinctive Identifier</a> to any entity other than the CDM that sent it.</p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note114"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note115"><span>Note</span></div>
           <p class="">Specifically, it should not be provided to the application or included unencrypted in messages to the CDM. This can be accomplished by encrypting the identifier or message with the identifier or such that it is only decryptable by that specific CDM.
           </p>
         </div>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note115"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note116"><span>Note</span></div>
           <div class="">
             <p>Among other things, this means that:</p>
             <ul>
@@ -5534,7 +5525,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
           All potential identifiers or distinctive values that are not <a href="#permanent-identifier">Permanent Identifiers</a> <em class="rfc2119" title="MUST">MUST</em> be unique per <a href="http://www.w3.org/TR/html5/browsers.html#origin-0">origin</a>. That is, the identifier(s) used for one <a href="http://www.w3.org/TR/html5/browsers.html#origin-0">origin</a> using these APIs <em class="rfc2119" title="MUST">MUST</em> be different from those used for any other origin using the APIs.
         </p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note116"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note117"><span>Note</span></div>
           <div class="">
             <p>This includes but is not limited to <a href="#distinctive-identifier">Distinctive Identifiers</a>.</p>
             <p><a href="#permanent-identifier">Permanent Identifiers</a> <em class="rfc2119" title="MUST NOT">MUST NOT</em> be exposed to the application or origin.</p>
@@ -5567,7 +5558,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
       <h3 id="h-support-multiple-keys" resource="#h-support-multiple-keys"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.3 </span>Support Multiple Keys</span></h3>
       <p>Implementations <em class="rfc2119" title="MUST">MUST</em> support multiple keys in each <a href="#idl-def-MediaKeySession" class="idlType"><code>MediaKeySession</code></a> object.</p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note117"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note118"><span>Note</span></div>
         <p class="">The mechanics of how multiple keys are supported is an implementation detail, but it <em class="rfc2119" title="MUST">MUST</em> be transparent to the application and these APIs.</p>
       </div>
 
@@ -5582,7 +5573,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
         <h4 id="h-licenses-generated-are-independent-of-content-type" resource="#h-licenses-generated-are-independent-of-content-type"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.4.1 </span>Licenses Generated are Independent of Content Type</span></h4>
         <p>Implementations <em class="rfc2119" title="SHOULD">SHOULD</em> allow licenses generated with any <a href="#initialization-data-type">Initialization Data Type</a> they support to be used with any content type.</p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note118"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note119"><span>Note</span></div>
           <p class="">Otherwise, the <code><a href="#widl-Navigator-requestMediaKeySystemAccess-Promise-MediaKeySystemAccess--DOMString-keySystem-sequence-MediaKeySystemConfiguration--supportedConfigurations">requestMediaKeySystemAccess()</a></code> algorithm might, for example, reject a <a href="#idl-def-MediaKeySystemConfiguration" class="idlType"><code>MediaKeySystemConfiguration</code></a> because one of the <code><a href="#widl-MediaKeySystemConfiguration-initDataTypes">initDataTypes</a></code> is not supported with one of the <code><a href="#widl-MediaKeySystemConfiguration-videoCapabilities">videoCapabilities</a></code>.</p>
         </div>
       </section>
@@ -5591,7 +5582,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
         <h4 id="h-support-extraction-from-media-data" resource="#h-support-extraction-from-media-data"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.4.2 </span>Support Extraction From Media Data</span></h4>
         <p>For any supported <a href="#initialization-data-type">Initialization Data Type</a> that may appear in a supported container, the user agents <em class="rfc2119" title="MUST">MUST</em> support <a href="#initdata-encountered">extracting</a> that type of <a href="#initialization-data">Initialization Data</a> from each such supported container.</p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note119"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note120"><span>Note</span></div>
           <p class="">In other words, indicating support for an <a href="#initialization-data-type">Initialization Data Type</a> implies both CDM support for generating license requests and, for container-specific types, user agent support for extracting it from the container. This does <strong>not</strong> mean that implementations must be able to parse <em>any</em> supported <a href="#initialization-data">Initialization Data</a> from <em>any</em> supported content type.
           </p>
         </div>
@@ -5615,7 +5606,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
           <a href="http://www.w3.org/TR/html5/embedded-content-0.html#media-resource">Media resources</a>, including all tracks, <em class="rfc2119" title="MUST">MUST</em> be encrypted and packaged per a container-specific "common encryption" specification that allows the content to be decrypted in a fully specified and compatible way when a key or keys are provided.
         </p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note120"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note121"><span>Note</span></div>
           <p class="">
             The Encrypted Media Extensions Stream Format and Initialization Data Format Registry [<cite><a class="bibref" href="#bib-EME-STREAM-REGISTRY">EME-STREAM-REGISTRY</a></cite>] provides references to such stream formats.
           </p>
@@ -5628,7 +5619,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
           In-band support content, such as captions, described audio, and transcripts, <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> be encrypted.
         </p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note121"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note122"><span>Note</span></div>
           <p class="">
             Decryption of such tracks - especially such that they can be provided back the user agent - is not generally supported by implementations. Thus, encrypting such tracks would prevent them from being widely available for use with accessibility features in user agent implementations.
           </p>
@@ -5648,7 +5639,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
     <p>
     </p>
     <div class="note">
-      <div class="note-title marker" aria-level="3" role="heading" id="h-note122"><span>Note</span></div>
+      <div class="note-title marker" aria-level="3" role="heading" id="h-note123"><span>Note</span></div>
       <p class="">This ensures that there is a common baseline level of functionality that is guaranteed to be supported in all user agents, including those that are entirely open source. Thus, content providers that need only basic decryption can build simple applications that will work on all platforms without needing to work with any content protection providers.
       </p>
     </div>
@@ -5770,14 +5761,14 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
           <p><em>This section is non-normative.</em></p>
           <p>The following example is a license request for a temporary license for two key IDs. (Line breaks are for readability only.)</p>
           <div class="example">
-            <div class="example-title marker"><span>Example 1</span></div><pre class="highlight hljs json">{
-  "<span class="hljs-attribute">kids</span>":
-    <span class="hljs-value">[
+            <div class="example-title marker"><span>Example 1</span></div><pre class="highlight hljs xquery">{
+  <span class="hljs-string">"kids"</span>:
+    [
      <span class="hljs-string">"LwVHf8JLtPrv2GUXFW2v_A"</span>,
      <span class="hljs-string">"0DdtU9od-Bh5L3xbv0Xf_A"</span>
-    ]</span>,
-  "<span class="hljs-attribute">type</span>":<code><a href="#idl-def-MediaKeySessionType.temporary">"temporary"</a></code>
-<span class="hljs-value"></span>}</pre></div>
+    ],
+  <span class="hljs-string">"type"</span>:<code><a href="#idl-def-MediaKeySessionType.temporary">"temporary"</a></code>
+}</pre></div>
         </section>
       </section>
 
@@ -5808,15 +5799,15 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
           <p><em>This section is non-normative.</em></p>
           <p>The following example is a JWK Set containing a single symmetric key. (Line breaks are for readability only.)</p>
           <div class="example">
-            <div class="example-title marker"><span>Example 2</span></div><pre class="highlight hljs clojure"><span class="hljs-collection">{
+            <div class="example-title marker"><span>Example 2</span></div><pre class="highlight hljs xquery">{
   <span class="hljs-string">"keys"</span>:
-    <span class="hljs-collection">[<span class="hljs-collection">{
+    [{
       <span class="hljs-string">"kty"</span>:<span class="hljs-string">"oct"</span>,
       <span class="hljs-string">"k"</span>:<span class="hljs-string">"tQ0bJVWb6b0KPL6KtZIy_A"</span>,
       <span class="hljs-string">"kid"</span>:<span class="hljs-string">"LwVHf8JLtPrv2GUXFW2v_A"</span>
-    }</span>]</span>,
-  'type':</span><code><a href="#idl-def-MediaKeySessionType.temporary">"temporary"</a></code><span class="hljs-collection">
-}</span></pre></div>
+    }],
+  <span class="hljs-string">'type'</span>:<code><a href="#idl-def-MediaKeySessionType.temporary">"temporary"</a></code>
+}</pre></div>
         </section>
       </section>
 
@@ -5842,11 +5833,11 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
           <p><em>This section is non-normative.</em></p>
           <p>The following example is a license release for a session which contained two keys. (Line breaks are for readability only.)</p>
           <div class="example">
-            <div class="example-title marker"><span>Example 3</span></div><pre class="highlight hljs json">{
-  "<span class="hljs-attribute">kids</span>": <span class="hljs-value">[ <span class="hljs-string">"LwVHf8JLtPrv2GUXFW2v_A"</span>, <span class="hljs-string">"0DdtU9od-Bh5L3xbv0Xf_A"</span> ]</span>,
-  "<span class="hljs-attribute">tfirst</span>" : <span class="hljs-value"><span class="hljs-number">1430425323757</span></span>,
-  "<span class="hljs-attribute">tlatest</span>" : <span class="hljs-value"><span class="hljs-number">1430425383757</span>
-</span>}</pre></div>
+            <div class="example-title marker"><span>Example 3</span></div><pre class="highlight hljs xquery">{
+  <span class="hljs-string">"kids"</span>: [ <span class="hljs-string">"LwVHf8JLtPrv2GUXFW2v_A"</span>, <span class="hljs-string">"0DdtU9od-Bh5L3xbv0Xf_A"</span> ],
+  <span class="hljs-string">"tfirst"</span> : <span class="hljs-number">1430425323757</span>,
+  <span class="hljs-string">"tlatest"</span> : <span class="hljs-number">1430425383757</span>
+}</pre></div>
         </section>
       </section>
 
@@ -5868,13 +5859,13 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
           <p><em>This section is non-normative.</em></p>
           <p>The following example is a license request for a temporary license for two key IDs. (Line breaks are for readability only.)</p>
           <div class="example">
-            <div class="example-title marker"><span>Example 4</span></div><pre class="highlight hljs json">{
-  "<span class="hljs-attribute">kids</span>":
-    <span class="hljs-value">[
+            <div class="example-title marker"><span>Example 4</span></div><pre class="highlight hljs xquery">{
+  <span class="hljs-string">"kids"</span>:
+    [
      <span class="hljs-string">"LwVHf8JLtPrv2GUXFW2v_A"</span>,
      <span class="hljs-string">"0DdtU9od-Bh5L3xbv0Xf_A"</span>
     ]
-</span>}</pre></div>
+}</pre></div>
         </section>
       </section>
 
@@ -5897,13 +5888,13 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
       <p>User Agent and Key System implementations <em class="rfc2119" title="MUST">MUST</em> consider <a href="http://www.w3.org/TR/html5/embedded-content-0.html#media-data">media data</a>, <a href="#initialization-data">Initialization Data</a>, data passed to <code><a href="#widl-MediaKeySession-update-Promise-void--BufferSource-response">update()</a></code>, licenses, key data, and all other data provided by the application as untrusted content and potential attack vectors. They <em class="rfc2119" title="MUST">MUST</em> use appropriate safeguards to mitigate any associated threats and take care to safely parse, decrypt, etc. such data. User Agents <em class="rfc2119" title="SHOULD">SHOULD</em> validate data before passing it to the CDM.
       </p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note123"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note124"><span>Note</span></div>
         <p class="">Such validation is especially important if the CDM does not run in the same (sandboxed) context as, for example, the DOM.</p>
       </div>
 
       <p>Implementations <em class="rfc2119" title="MUST NOT">MUST NOT</em> return active content or passive content that affects program control flow to the application.</p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note124"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note125"><span>Note</span></div>
         <p class="">For example, it is not safe to expose URLs or other information that may have come from media data, such as is the case for the <a href="#initialization-data">Initialization Data</a> passed to <code><a href="#widl-MediaKeySession-generateRequest-Promise-void--DOMString-initDataType-BufferSource-initData">generateRequest()</a></code>. Applications must determine the URLs to use. The <code><a href="#widl-MediaKeyMessageEvent-messageType">messageType</a></code> attribute of the <code><a href="#dom-evt-message">message</a></code> event can be used by the application to select among a set of URLs if applicable.
         </p>
       </div>
@@ -5916,7 +5907,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
       <p>Exploiting a CDM implementation that is not fully sandboxed and/or uses platform features may allow an attacker to access OS or platform features, elevate privilege (e.g. to run as system or root), and/or access drivers, kernel, firmware, hardware, etc. Such features, software, and hardware may not be written to be robust against hostile software or web-based attacks and may not be updated with security fixes, especially compared to the user agent. Lack of, infrequent, or slow updates for fixes to security vulnerabilities in CDM implementations increases the risk. Such CDM implementations and UAs that expose them <em class="rfc2119" title="MUST">MUST</em> be especially careful in all areas of security, including parsing of <a href="#input-data-security">all data</a>.
       </p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note125"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note126"><span>Note</span></div>
         <p class="">User agents should be especially diligent when using a CDM or underlying mechanism that is part of or provided by the client OS, platform and/or hardware.</p>
       </div>
 
@@ -5925,7 +5916,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
         Such implementations <em class="rfc2119" title="SHOULD">SHOULD</em> only be supported on secure contexts to mitigate the potential for <a href="#network-attacks">Network Attacks</a>.
       </p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note126"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note127"><span>Note</span></div>
         <p class="">Granting permissions to unauthenticated origins is equivalent to granting the permissions to any origin in the presence of a network attacker. See also <a href="#privacy-prompts">User Alerts / Prompts</a> and <a href="#privacy-secureorigin">Use Secure Origin and Transport</a>.
         </p>
       </div>
@@ -5989,7 +5980,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
             <p>User Agents <em class="rfc2119" title="SHOULD">SHOULD</em> ensure that users are fully informed and/or give explicit consent before a Key System that presents security concerns that are greater than other user agent features (e.g. DOM content) may be accessed by an <a href="http://www.w3.org/TR/html5/browsers.html#origin-0">origin</a>. Such alerts and consent <em class="rfc2119" title="SHOULD">SHOULD</em> be per <a href="http://www.w3.org/TR/html5/browsers.html#origin-0">origin</a> to avoid valid uses enabling subsequent malicious access. (A full <a href="http://www.w3.org/TR/html5/browsers.html#origin-0">origin</a> <em class="rfc2119" title="MUST">MUST</em> be used rather than just the domain because the protocol is important for security as described above.) User agents <em class="rfc2119" title="SHOULD">SHOULD</em> only persist consent for secure origins (see <a href="#privacy-secureorigin">Secure Origin and Transport</a>), to mitigate the potential for future abuse via <a href="#network-attacks">Network Attacks</a>.
             </p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note127"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note128"><span>Note</span></div>
               <p class="">Granting permissions to unauthenticated origins is equivalent to granting the permissions to any origin in the presence of a network attacker. Alerting or prompting the user for consent on insecure origins without persisting the choice provides at least a minimum level of security because the user would be alerted to unexpected use (e.g. on a site that does not use encrypted media).
               </p>
             </div>
@@ -6025,7 +6016,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
       <p>Using these APIs on shared hosts compromises origin-based security and privacy mitigations implemented by user agents. For example, per-origin <a href="#distinctive-identifier">Distinctive Identifiers</a> are shared by all authors on one host name, and peristed data may be accessed and manipulated by any author on the host. The latter is especially important if, for example, modification or deletion of such data could erase a user's right to specific content.
       </p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note128"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note129"><span>Note</span></div>
         <p class="">Even if a path-restriction feature was made available by user agents, the usual DOM scripting security model would make it trivial to bypass this protection and access the data from any path.</p>
       </div>
       <p>Authors on shared hosts are therefore <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em> to avoid using these APIs because doing so compromises origin-based security and privacy mitigations in user agents.</p>
@@ -6093,7 +6084,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
               It is not possible to extract, derive or infer information from the CDM that is not either explicitly described in this specification or available to the page through other web platform APIs without user permission. This applies to any information that is exposed outside the client device or to the application, including, for example, in CDM messages.
             </p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note129"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note130"><span>Note</span></div>
               <div class="">
                 <p>The type of information covered by this requirement includes but is not limited to:</p>
                 <ul>
@@ -6219,7 +6210,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
           <dd>
             <p>User agents <em class="rfc2119" title="MAY">MAY</em>, possibly in a manner configured by the user, automatically delete <a href="#distinctive-identifier">Distinctive Identifiers</a> and/or other Key System data after a period of time.</p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note130"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note131"><span>Note</span></div>
               <div class="">
                 <p>For example, a user agent could be configured to store such data as session-only storage, deleting the data once the user had closed all the browsing contexts that could access it.</p>
                 <p>This can restrict the ability of a site to track a user, as the site would then only be able to track the user across multiple sessions when he authenticates with the site itself (e.g. by making a purchase or logging in to a service).</p>
@@ -6252,13 +6243,13 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
             <p>User agents <em class="rfc2119" title="MUST">MUST</em> prompt or otherwise inform the user before allowing use of a <a href="#distinctive-identifier">Distinctive Identifier</a> that is not <a href="#per-origin-identifiers">unique per-origin</a> and/or not <a href="#allow-identifiers-cleared">clearable</a> is used. User agents <em class="rfc2119" title="SHOULD">SHOULD</em> prompt or otherwise inform the user before allowing use of all other <a href="#distinctive-identifier">Distinctive Identifier</a>.
             </p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note131"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note132"><span>Note</span></div>
               <p class="">The "not unique per-origin" and "not clearable" conditions cannot be true in a compliant implementation because implementations <em class="rfc2119" title="MUST">MUST</em> <a href="#per-origin-identifiers">use per-origin identifiers</a> and <a href="#allow-identifiers-cleared">allow the user to clear identifiers</a>.</p>
             </div>
             <p>Such alerts and consent <em class="rfc2119" title="SHOULD">SHOULD</em> be per <a href="http://www.w3.org/TR/html5/browsers.html#origin-0">origin</a> to avoid valid uses enabling subsequent malicious access. User agent implementers that consider such alerts or consent appropriate for a Key System implementation <em class="rfc2119" title="SHOULD">SHOULD</em> only support such Key Systems on secure origins (see <a href="#privacy-secureorigin">Secure Origin and Transport</a>), especially if they allow such consent to be persisted.
             </p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note132"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note133"><span>Note</span></div>
               <p class="">Granting permissions to unauthenticated origins is equivalent to granting the permissions to any origin in the presence of a network attacker.</p>
             </div>
           </dd>
@@ -6271,7 +6262,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
         </dl>
 
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note133"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note134"><span>Note</span></div>
           <p class="">While these suggestions prevent trivial use of this API for user tracking, they do not block it altogether. Within a single origin, a site can continue to track the user during a session, and can then pass all this information to a third party along with any identifying information (names, credit card numbers, addresses) obtained by the site. If a third party cooperates with multiple sites to obtain such information, and if identifiers are not
             <!-- Issue #101 may affect this text. --><a href="#per-origin-identifiers">unique per-origin</a>, then a profile can still be created.
           </p>
@@ -6293,7 +6284,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
           <p>Direct Individualization is performed between the <a href="#cdm">CDM</a> and an origin- and application-independent server. The process <em class="rfc2119" title="MUST">MUST</em> be performed by the user agent and <em class="rfc2119" title="MUST NOT">MUST NOT</em> use these APIs.
           </p>
           <div class="note">
-            <div class="note-title marker" aria-level="6" role="heading" id="h-note134"><span>Note</span></div>
+            <div class="note-title marker" aria-level="6" role="heading" id="h-note135"><span>Note</span></div>
             <p class="">For example, such a process may initialize a client device and/or obtain a <a href="#per-origin-identifiers">per-origin</a> <a href="#allow-identifiers-cleared">clearable</a> identifier by communicating with a pre-determined server hosted by the user agent or CDM vendor, possibly <a href="#uses-distinctive-permanent-identifiers">using Distinctive Permanent Identifier(s)</a> or other <a href="#permanent-identifier">Permanent Identifier(s)</a> from the client device.
             </p>
           </div>
@@ -6346,7 +6337,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
               <p><em class="rfc2119" title="MUST">MUST</em> adhere to the <a href="#identifier-requirements">identifier requirements</a>.
               </p>
               <div class="note">
-                <div class="note-title marker" aria-level="6" role="heading" id="h-note135"><span>Note</span></div>
+                <div class="note-title marker" aria-level="6" role="heading" id="h-note136"><span>Note</span></div>
                 <p class="">This includes only using values that are <a href="#per-origin-identifiers">unique per origin</a> and <a href="#allow-identifiers-cleared">clearable</a> and <a href="#encrypt-identifiers">encrypting</a> them as required.</p>
               </div>
             </li>
@@ -6484,7 +6475,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
       <p class="exampledescription">In this simple example, the source file and <a href="#clear-key">clear-text license</a> are hard-coded in the page. Only one session will ever be created.</p>
 
       <div class="example">
-        <div class="example-title marker"><span>Example 5</span></div><pre class="highlight hljs xml"><span class="hljs-tag">&lt;<span class="hljs-title">script</span>&gt;</span><span class="javascript">
+        <div class="example-title marker"><span>Example 5</span></div><pre class="highlight hljs xml"><span class="hljs-tag">&lt;<span class="hljs-name">script</span>&gt;</span><span class="javascript">
   <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">onLoad</span>(<span class="hljs-params"></span>) </span>{
     <span class="hljs-keyword">var</span> video = <span class="hljs-built_in">document</span>.getElementById(<span class="hljs-string">'video'</span>);
 
@@ -6529,11 +6520,11 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
       <span class="hljs-built_in">console</span>.error.bind(<span class="hljs-built_in">console</span>, <span class="hljs-string">'update() failed'</span>)
     );
   }
-</span><span class="hljs-tag">&lt;/<span class="hljs-title">script</span>&gt;</span>
+</span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span>
 
-<span class="hljs-tag">&lt;<span class="hljs-title">body</span> <span class="hljs-attribute">onload</span>=<span class="hljs-value">'onLoad()'</span>&gt;</span>
-  <span class="hljs-tag">&lt;<span class="hljs-title">video</span> <span class="hljs-attribute">src</span>=<span class="hljs-value">'foo.webm'</span> <span class="hljs-attribute">autoplay</span> <span class="hljs-attribute">id</span>=<span class="hljs-value">'video'</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">video</span>&gt;</span>
-<span class="hljs-tag">&lt;/<span class="hljs-title">body</span>&gt;</span></pre></div>
+<span class="hljs-tag">&lt;<span class="hljs-name">body</span> <span class="hljs-attr">onload</span>=<span class="hljs-string">'onLoad()'</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">video</span> <span class="hljs-attr">src</span>=<span class="hljs-string">'foo.webm'</span> <span class="hljs-attr">autoplay</span> <span class="hljs-attr">id</span>=<span class="hljs-string">'video'</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">video</span>&gt;</span>
+<span class="hljs-tag">&lt;/<span class="hljs-name">body</span>&gt;</span></pre></div>
     </section>
 
     <section id="example-selecting-key-system" typeof="bibo:Chapter" resource="#example-selecting-key-system" property="bibo:hasPart">
@@ -6542,7 +6533,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
       </p>
 
       <div class="example">
-        <div class="example-title marker"><span>Example 6</span></div><pre class="highlight hljs xml"><span class="hljs-tag">&lt;<span class="hljs-title">script</span>&gt;</span><span class="javascript">
+        <div class="example-title marker"><span>Example 6</span></div><pre class="highlight hljs xml"><span class="hljs-tag">&lt;<span class="hljs-name">script</span>&gt;</span><span class="javascript">
   <span class="hljs-keyword">var</span> licenseUrl;
   <span class="hljs-keyword">var</span> serverCertificate;
 
@@ -6669,9 +6660,9 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
     }
     xmlhttp.send(request);
   }
-</span><span class="hljs-tag">&lt;/<span class="hljs-title">script</span>&gt;</span>
+</span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span>
 
-<span class="hljs-tag">&lt;<span class="hljs-title">video</span> <span class="hljs-attribute">autoplay</span> </span><code><a href="#widl-HTMLMediaElement-onencrypted">onencrypted</a></code><span class="hljs-tag">=<span class="hljs-value">'handleInitData(event)'</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">video</span>&gt;</span></pre></div>
+<span class="hljs-tag">&lt;<span class="hljs-name">video</span> <span class="hljs-attr">autoplay</span> </span><code><a href="#widl-HTMLMediaElement-onencrypted">onencrypted</a></code><span class="hljs-tag">=<span class="hljs-string">'handleInitData(event)'</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">video</span>&gt;</span></pre></div>
     </section>
 
     <section id="example-mediakeys-before-source" typeof="bibo:Chapter" resource="#example-mediakeys-before-source" property="bibo:hasPart">
@@ -6680,7 +6671,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
       </p>
 
       <div class="example">
-        <div class="example-title marker"><span>Example 7</span></div><pre class="highlight hljs xml"><span class="hljs-tag">&lt;<span class="hljs-title">script</span>&gt;</span><span class="javascript">
+        <div class="example-title marker"><span>Example 7</span></div><pre class="highlight hljs xml"><span class="hljs-tag">&lt;<span class="hljs-name">script</span>&gt;</span><span class="javascript">
   <span class="hljs-keyword">var</span> licenseUrl;
   <span class="hljs-keyword">var</span> serverCertificate;
   <span class="hljs-keyword">var</span> mediaKeys;
@@ -6706,9 +6697,9 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
   ).catch(
     <span class="hljs-built_in">console</span>.error.bind(<span class="hljs-built_in">console</span>, <span class="hljs-string">'Failed to create and initialize a MediaKeys object'</span>)
   );
-</span><span class="hljs-tag">&lt;/<span class="hljs-title">script</span>&gt;</span>
+</span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span>
 
-<span class="hljs-tag">&lt;<span class="hljs-title">video</span> <span class="hljs-attribute">id</span>=<span class="hljs-value">"v"</span> <span class="hljs-attribute">autoplay</span> </span><code><a href="#widl-HTMLMediaElement-onencrypted">onencrypted</a></code><span class="hljs-tag">=<span class="hljs-value">'handleInitData(event)'</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">video</span>&gt;</span></pre></div>
+<span class="hljs-tag">&lt;<span class="hljs-name">video</span> <span class="hljs-attr">id</span>=<span class="hljs-string">"v"</span> <span class="hljs-attr">autoplay</span> </span><code><a href="#widl-HTMLMediaElement-onencrypted">onencrypted</a></code><span class="hljs-tag">=<span class="hljs-string">'handleInitData(event)'</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">video</span>&gt;</span></pre></div>
     </section>
 
     <section id="example-using-all-events" typeof="bibo:Chapter" resource="#example-using-all-events" property="bibo:hasPart">
@@ -6717,7 +6708,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
       <p class="exampledescription">Note that <code>handleMessage()</code> could be called multiple times, including in response to the <code><a href="#widl-MediaKeySession-update-Promise-void--BufferSource-response">update()</a></code> call if multiple round trips are required and for any other reason the Key System might need to send a message.</p>
 
       <div class="example">
-        <div class="example-title marker"><span>Example 8</span></div><pre class="highlight hljs xml"><span class="hljs-tag">&lt;<span class="hljs-title">script</span>&gt;</span><span class="javascript">
+        <div class="example-title marker"><span>Example 8</span></div><pre class="highlight hljs xml"><span class="hljs-tag">&lt;<span class="hljs-name">script</span>&gt;</span><span class="javascript">
   <span class="hljs-keyword">var</span> licenseUrl;
   <span class="hljs-keyword">var</span> serverCertificate;
   <span class="hljs-keyword">var</span> mediaKeys;
@@ -6799,9 +6790,9 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
   ).catch(
     <span class="hljs-built_in">console</span>.error.bind(<span class="hljs-built_in">console</span>, <span class="hljs-string">'Failed to create and initialize a MediaKeys object'</span>)
   );
-</span><span class="hljs-tag">&lt;/<span class="hljs-title">script</span>&gt;</span>
+</span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span>
 
-<span class="hljs-tag">&lt;<span class="hljs-title">video</span> <span class="hljs-attribute">id</span>=<span class="hljs-value">"v"</span> <span class="hljs-attribute">autoplay</span> </span><code><a href="#widl-HTMLMediaElement-onencrypted">onencrypted</a></code><span class="hljs-tag">=<span class="hljs-value">'handleInitData(event)'</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">video</span>&gt;</span></pre></div>
+<span class="hljs-tag">&lt;<span class="hljs-name">video</span> <span class="hljs-attr">id</span>=<span class="hljs-string">"v"</span> <span class="hljs-attr">autoplay</span> </span><code><a href="#widl-HTMLMediaElement-onencrypted">onencrypted</a></code><span class="hljs-tag">=<span class="hljs-string">'handleInitData(event)'</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">video</span>&gt;</span></pre></div>
     </section>
 
     <section id="example-stored-license" typeof="bibo:Chapter" resource="#example-stored-license" property="bibo:hasPart">
@@ -6809,7 +6800,7 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
       <p class="exampledescription">This example requests a persistent license for future use and stores it. It also provides functions for later retrieving the license and for destroying it.</p>
 
       <div class="example">
-        <div class="example-title marker"><span>Example 9</span></div><pre class="highlight hljs xml"><span class="hljs-tag">&lt;<span class="hljs-title">script</span>&gt;</span><span class="javascript">
+        <div class="example-title marker"><span>Example 9</span></div><pre class="highlight hljs xml"><span class="hljs-tag">&lt;<span class="hljs-name">script</span>&gt;</span><span class="javascript">
   <span class="hljs-keyword">var</span> licenseUrl;
   <span class="hljs-keyword">var</span> serverCertificate;
   <span class="hljs-keyword">var</span> mediaKeys;
@@ -6901,9 +6892,9 @@ interface <span class="idlInterfaceID">MediaEncryptedEvent</span> : <span class=
   ).catch(
     <span class="hljs-built_in">console</span>.error.bind(<span class="hljs-built_in">console</span>, <span class="hljs-string">'Failed to create and initialize a MediaKeys object'</span>)
   );
-</span><span class="hljs-tag">&lt;/<span class="hljs-title">script</span>&gt;</span>
+</span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span>
 
-<span class="hljs-tag">&lt;<span class="hljs-title">video</span> <span class="hljs-attribute">id</span>=<span class="hljs-value">'v'</span> <span class="hljs-attribute">src</span>=<span class="hljs-value">'foo.webm'</span> <span class="hljs-attribute">autoplay</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-title">video</span>&gt;</span></pre></div>
+<span class="hljs-tag">&lt;<span class="hljs-name">video</span> <span class="hljs-attr">id</span>=<span class="hljs-string">'v'</span> <span class="hljs-attr">src</span>=<span class="hljs-string">'foo.webm'</span> <span class="hljs-attr">autoplay</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">video</span>&gt;</span></pre></div>
     </section>
   </section>
 


### PR DESCRIPTION
Adds a non-normative NOTE explaining the implications.

The changes to the normative text are just the addition of `<p>` and indentation.