### PR TITLE
Fix #153: Remove "run when" text from HTMLMediaElement algorithms

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -2352,7 +2352,7 @@ interface MediaKeyMessageEvent : Event {
           <ol>
             <li><p>Let the <var>session</var> be the specified <a>MediaKeySession</a> object.</p></li>
             <li>
-              <p><a def-id="Queue-a-task"></a> to create an event named <var>message</var> that does not bubble and is not cancellable using the <a>MediaKeyMessageEvent</a> interface with its <var>type</var> attribute set to <code>message</code> and its <var>isTrusted</var> attribute initialized to <code>true</code>, and dispatch it at the <var>session</var>.</p>
+              <p><a def-id="Queue-a-task"></a> to create an event named <a def-id="message"></a> that does not bubble and is not cancellable using the <a>MediaKeyMessageEvent</a> interface with its <var>type</var> attribute set to <code>message</code> and its <var>isTrusted</var> attribute initialized to <code>true</code>, and dispatch it at the <var>session</var>.</p>
               <p>The event interface <a>MediaKeyMessageEvent</a> has:</p>
               <ul style="list-style-type:none"><li>
                 <a def-id="message-event-messagetype-attribute"></a> = the specified <var>message type</var><br><br>
@@ -2829,8 +2829,10 @@ interface MediaEncryptedEvent : Event {
 
         <section id="initdata-encountered">
           <h4>Initialization Data Encountered</h4>
-          <p>The following steps are run when the media element encounters <a def-id="initialization-data"></a> in the <a def-id="media-data"></a> during the <a def-id="resource-fetch-algorithm"></a>:</p>
-
+          <p>
+            This algorithm queues an <a def-id="encrypted"></a> event for <a def-id="initialization-data"></a> encounterd in the <a def-id="media-data"></a>.
+          </p>
+          <p>The following steps are run:</p>
           <ol>
             <li><p>Let <var>initDataType</var> be the empty string.</p></li>
             <li><p>Let <var>initData</var> be null.</p></li>
@@ -2843,8 +2845,8 @@ interface MediaEncryptedEvent : Event {
               <p class="note">While the media element may allow loading of "Optionally-blockable Content" [[MIXED-CONTENT]], the user agent MUST NOT expose Initialization Data from such media data to the application.</p>
             </li>
             <li>
-              <p><a def-id="Queue-a-task"></a> to create an event named <var>encrypted</var> that does not bubble and is not cancellable using the <a>MediaEncryptedEvent</a> interface with its <var>type</var> attribute set to <code>message</code> and its <var>isTrusted</var> attribute initialized to <code>true</code>, and dispatch it at the <var>session</var>.
-              </p><p>The event interface <a>MediaEncryptedEvent</a> has:</p>
+              <p><a def-id="Queue-a-task"></a> to create an event named <a def-id="encrypted"></a> that does not bubble and is not cancellable using the <a>MediaEncryptedEvent</a> interface with its <var>type</var> attribute set to <code>message</code> and its <var>isTrusted</var> attribute initialized to <code>true</code>, and dispatch it at the media element.</p>
+              <p>The event interface <a>MediaEncryptedEvent</a> has:</p>
               <ul style="list-style-type:none"><li>
                 <a def-id="encrypted-event-initdatatype-attribute"></a> = <var>initDataType</var><br><br>
                 <a def-id="encrypted-event-initdata-attribute"></a> = <var>initData</var>
@@ -2870,7 +2872,8 @@ interface MediaEncryptedEvent : Event {
 
         <section id="encrypted-block-encountered">
           <h4>Encrypted Block Encountered</h4>
-          <p>This algorithm queues a block of encrypted media data for decryption and attempts to decrypt if possible. The following steps are run:</p>
+          <p>This algorithm queues a block of encrypted media data for decryption and attempts to decrypt if possible.</p>
+          <p>The following steps are run:</p>
           <ol>
             <li>
               <p>Let <var>block</var> be the block of encrypted media data.</p>
@@ -2885,7 +2888,8 @@ interface MediaEncryptedEvent : Event {
         </section>
         <section id="attempt-to-decrypt">
           <h4>Attempt to Decrypt</h4>
-          <p>This algorithm attempts to decrypt media data that is queued for decryption. The following steps are run:</p>
+          <p>This algorithm attempts to decrypt media data that is queued for decryption.</p>
+          <p>The following steps are run:</p>
           <ol>
             <li><p>If the media element's <var>encrypted block queue</var> is empty, abort these steps.</p></li>
             <li><p>If the media element's <a def-id="mediaKeys-attribute"></a> attribute is not null, run the following steps:</p>
@@ -3018,7 +3022,8 @@ interface MediaEncryptedEvent : Event {
 
         <section id="queue-waitingforkey">
           <h4>Queue a "waitingforkey" Event</h4>
-          <p>The Queue a "waitingforkey" Event algorithm is run when the CDM cannot decrypt the current block.
+          <p>
+            This algorithm queues a <a def-id="waitingforkey"></a> event and updates <a def-id="readystate"></a>.
             It should only be called when the <a def-id="htmlmediaelement"></a> object is <a def-id="potentially-playing"></a> and its <a def-id="readystate"></a> is equal to <a def-id="have-future-data"></a> or greater.
             Requests to run this algorithm include a target <a def-id="htmlmediaelement"></a> object.
           </p>
@@ -3038,11 +3043,10 @@ interface MediaEncryptedEvent : Event {
 
         <section id="resume-playback">
           <h4>Attempt to Resume Playback If Necessary</h4>
-          <p>The Attempt to Resume Playback If Necessary algorithm is run when one or more keys may be or may have become available.
-          If playback is blocked waiting for a key, it resumes playback if a necessary key has been provided.
-          Requests to run this algorithm include a target <a def-id="htmlmediaelement"></a> object.
+          <p>
+            This algorithm resumes playback if the media element is blocked waiting for a key and necessary key is currently <a def-id="usable-for-decryption"></a>
+            Requests to run this algorithm include a target <a def-id="htmlmediaelement"></a> object.
           </p>
-
           <p>The following steps are run:</p>
           <ol>
             <li><p>Let the <var>media element</var> be the specified <a def-id="htmlmediaelement"></a> object.</p></li>

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -2461,7 +2461,7 @@ interface MediaKeyMessageEvent : Event {
         <section id="media-key-session-destroyed">
           <h4>MediaKeySession Destroyed</h4>
           <p>
-            This algorithm performs steps that are necessary when a <a>MediaKeySession</a> that is not <a def-id="media-key-session-closed"></a> is destroyed.
+            The MediaKeySession Destroyed algorithm performs steps that are necessary when a <a>MediaKeySession</a> that is not <a def-id="media-key-session-closed"></a> is destroyed.
           </p>
           <p>The following steps are run in parallel to the main event loop:</p>
           <ol>
@@ -2830,7 +2830,7 @@ interface MediaEncryptedEvent : Event {
         <section id="initdata-encountered">
           <h4>Initialization Data Encountered</h4>
           <p>
-            This algorithm queues an <a def-id="encrypted"></a> event for <a def-id="initialization-data"></a> encounterd in the <a def-id="media-data"></a>.
+            The Initialization Data Encountered algorithm queues an <a def-id="encrypted"></a> event for <a def-id="initialization-data"></a> encounterd in the <a def-id="media-data"></a>.
           </p>
           <p>The following steps are run:</p>
           <ol>
@@ -2872,7 +2872,9 @@ interface MediaEncryptedEvent : Event {
 
         <section id="encrypted-block-encountered">
           <h4>Encrypted Block Encountered</h4>
-          <p>This algorithm queues a block of encrypted media data for decryption and attempts to decrypt if possible.</p>
+          <p>
+            The Encrypted Block Encountered algorithm queues a block of encrypted media data for decryption and attempts to decrypt if possible.
+          </p>
           <p>The following steps are run:</p>
           <ol>
             <li>
@@ -2888,7 +2890,9 @@ interface MediaEncryptedEvent : Event {
         </section>
         <section id="attempt-to-decrypt">
           <h4>Attempt to Decrypt</h4>
-          <p>This algorithm attempts to decrypt media data that is queued for decryption.</p>
+          <p>
+            The Attempt to Decrypt algorithm attempts to decrypt media data that is queued for decryption.
+          </p>
           <p>The following steps are run:</p>
           <ol>
             <li><p>If the media element's <var>encrypted block queue</var> is empty, abort these steps.</p></li>
@@ -3023,7 +3027,7 @@ interface MediaEncryptedEvent : Event {
         <section id="queue-waitingforkey">
           <h4>Queue a "waitingforkey" Event</h4>
           <p>
-            This algorithm queues a <a def-id="waitingforkey"></a> event and updates <a def-id="readystate"></a>.
+            The Queue a "waitingforkey" Event algorithm queues a <a def-id="waitingforkey"></a> event and updates <a def-id="readystate"></a>.
             It should only be called when the <a def-id="htmlmediaelement"></a> object is <a def-id="potentially-playing"></a> and its <a def-id="readystate"></a> is equal to <a def-id="have-future-data"></a> or greater.
             Requests to run this algorithm include a target <a def-id="htmlmediaelement"></a> object.
           </p>
@@ -3044,7 +3048,7 @@ interface MediaEncryptedEvent : Event {
         <section id="resume-playback">
           <h4>Attempt to Resume Playback If Necessary</h4>
           <p>
-            This algorithm resumes playback if the media element is blocked waiting for a key and necessary key is currently <a def-id="usable-for-decryption"></a>
+            The Attempt to Resume Playback If Necessary algorithm resumes playback if the media element is blocked waiting for a key and necessary key is currently <a def-id="usable-for-decryption"></a>
             Requests to run this algorithm include a target <a def-id="htmlmediaelement"></a> object.
           </p>
           <p>The following steps are run:</p>

--- a/index.html
+++ b/index.html
@@ -4806,7 +4806,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaKeyMessageEvent" href="#
       <section id="media-key-session-destroyed" typeof="bibo:Chapter" resource="#media-key-session-destroyed" property="bibo:hasPart">
         <h4 id="h-media-key-session-destroyed" resource="#h-media-key-session-destroyed"><span property="xhv:role" resource="xhv:heading"><span class="secno">6.4.5 </span>MediaKeySession Destroyed</span></h4>
         <p>
-          This algorithm performs steps that are necessary when a <a href="#idl-def-mediakeysession" class="internalDFN" data-link-type="dfn"><code>MediaKeySession</code></a> that is not <a href="#media-key-session-closed">closed</a> is destroyed.
+          The MediaKeySession Destroyed algorithm performs steps that are necessary when a <a href="#idl-def-mediakeysession" class="internalDFN" data-link-type="dfn"><code>MediaKeySession</code></a> that is not <a href="#media-key-session-closed">closed</a> is destroyed.
         </p>
         <p>The following steps are run in parallel to the main event loop:</p>
         <ol>
@@ -5314,7 +5314,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
       <section id="initdata-encountered" typeof="bibo:Chapter" resource="#initdata-encountered" property="bibo:hasPart">
         <h4 id="h-initdata-encountered" resource="#h-initdata-encountered"><span property="xhv:role" resource="xhv:heading"><span class="secno">7.3.1 </span>Initialization Data Encountered</span></h4>
         <p>
-          This algorithm queues an <code><a href="#dom-evt-encrypted">encrypted</a></code> event for <a href="#initialization-data">Initialization Data</a> encounterd in the <a href="http://www.w3.org/TR/html5/embedded-content-0.html#media-data">media data</a>.
+          The Initialization Data Encountered algorithm queues an <code><a href="#dom-evt-encrypted">encrypted</a></code> event for <a href="#initialization-data">Initialization Data</a> encounterd in the <a href="http://www.w3.org/TR/html5/embedded-content-0.html#media-data">media data</a>.
         </p>
         <p>The following steps are run:</p>
         <ol>
@@ -5382,7 +5382,9 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
 
       <section id="encrypted-block-encountered" typeof="bibo:Chapter" resource="#encrypted-block-encountered" property="bibo:hasPart">
         <h4 id="h-encrypted-block-encountered" resource="#h-encrypted-block-encountered"><span property="xhv:role" resource="xhv:heading"><span class="secno">7.3.2 </span>Encrypted Block Encountered</span></h4>
-        <p>This algorithm queues a block of encrypted media data for decryption and attempts to decrypt if possible.</p>
+        <p>
+          The Encrypted Block Encountered algorithm queues a block of encrypted media data for decryption and attempts to decrypt if possible.
+        </p>
         <p>The following steps are run:</p>
         <ol>
           <li>
@@ -5400,7 +5402,9 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
 
       <section id="attempt-to-decrypt" typeof="bibo:Chapter" resource="#attempt-to-decrypt" property="bibo:hasPart">
         <h4 id="h-attempt-to-decrypt" resource="#h-attempt-to-decrypt"><span property="xhv:role" resource="xhv:heading"><span class="secno">7.3.3 </span>Attempt to Decrypt</span></h4>
-        <p>This algorithm attempts to decrypt media data that is queued for decryption.</p>
+        <p>
+          The Attempt to Decrypt algorithm attempts to decrypt media data that is queued for decryption.
+        </p>
         <p>The following steps are run:</p>
         <ol>
           <li>
@@ -5603,7 +5607,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
       <section id="queue-waitingforkey" typeof="bibo:Chapter" resource="#queue-waitingforkey" property="bibo:hasPart">
         <h4 id="h-queue-waitingforkey" resource="#h-queue-waitingforkey"><span property="xhv:role" resource="xhv:heading"><span class="secno">7.3.4 </span>Queue a "waitingforkey" Event</span></h4>
         <p>
-          This algorithm queues a <code><a href="#dom-evt-waitingforkey">waitingforkey</a></code> event and updates <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#dom-media-readystate">readyState</a></code>. It should only be called when the <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#htmlmediaelement">HTMLMediaElement</a></code> object is <a href="http://www.w3.org/TR/html5/embedded-content-0.html#potentially-playing">potentially playing</a> and its <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#dom-media-readystate">readyState</a></code> is equal to <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#dom-media-have_future_data">HAVE_FUTURE_DATA</a></code> or greater. Requests to run this algorithm include a target <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#htmlmediaelement">HTMLMediaElement</a></code> object.
+          The Queue a "waitingforkey" Event algorithm queues a <code><a href="#dom-evt-waitingforkey">waitingforkey</a></code> event and updates <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#dom-media-readystate">readyState</a></code>. It should only be called when the <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#htmlmediaelement">HTMLMediaElement</a></code> object is <a href="http://www.w3.org/TR/html5/embedded-content-0.html#potentially-playing">potentially playing</a> and its <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#dom-media-readystate">readyState</a></code> is equal to <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#dom-media-have_future_data">HAVE_FUTURE_DATA</a></code> or greater. Requests to run this algorithm include a target <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#htmlmediaelement">HTMLMediaElement</a></code> object.
         </p>
         <p>The following steps are run:</p>
         <ol>
@@ -5636,7 +5640,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
       <section id="resume-playback" typeof="bibo:Chapter" resource="#resume-playback" property="bibo:hasPart">
         <h4 id="h-resume-playback" resource="#h-resume-playback"><span property="xhv:role" resource="xhv:heading"><span class="secno">7.3.5 </span>Attempt to Resume Playback If Necessary</span></h4>
         <p>
-          This algorithm resumes playback if the media element is blocked waiting for a key and necessary key is currently <a href="#usable-for-decryption">usable for decryption</a> Requests to run this algorithm include a target <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#htmlmediaelement">HTMLMediaElement</a></code> object.
+          The Attempt to Resume Playback If Necessary algorithm resumes playback if the media element is blocked waiting for a key and necessary key is currently <a href="#usable-for-decryption">usable for decryption</a> Requests to run this algorithm include a target <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#htmlmediaelement">HTMLMediaElement</a></code> object.
         </p>
         <p>The following steps are run:</p>
         <ol>

--- a/index.html
+++ b/index.html
@@ -4647,7 +4647,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaKeyMessageEvent" href="#
             <p>Let the <var>session</var> be the specified <a href="#idl-def-mediakeysession" class="internalDFN" data-link-type="dfn"><code>MediaKeySession</code></a> object.</p>
           </li>
           <li>
-            <p><a href="http://www.w3.org/TR/html5/webappapis.html#queue-a-task">Queue a task</a> to create an event named <var>message</var> that does not bubble and is not cancellable using the <a href="#dom-mediakeymessageevent" class="internalDFN" data-link-type="dfn"><code>MediaKeyMessageEvent</code></a> interface with its <var>type</var> attribute set to <code>message</code> and its <var>isTrusted</var> attribute initialized to <code>true</code>, and dispatch it at the <var>session</var>.</p>
+            <p><a href="http://www.w3.org/TR/html5/webappapis.html#queue-a-task">Queue a task</a> to create an event named <code><a href="#dom-evt-message">message</a></code> that does not bubble and is not cancellable using the <a href="#dom-mediakeymessageevent" class="internalDFN" data-link-type="dfn"><code>MediaKeyMessageEvent</code></a> interface with its <var>type</var> attribute set to <code>message</code> and its <var>isTrusted</var> attribute initialized to <code>true</code>, and dispatch it at the <var>session</var>.</p>
             <p>The event interface <a href="#dom-mediakeymessageevent" class="internalDFN" data-link-type="dfn"><code>MediaKeyMessageEvent</code></a> has:</p>
             <ul style="list-style-type:none">
               <li>
@@ -5313,8 +5313,10 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
 
       <section id="initdata-encountered" typeof="bibo:Chapter" resource="#initdata-encountered" property="bibo:hasPart">
         <h4 id="h-initdata-encountered" resource="#h-initdata-encountered"><span property="xhv:role" resource="xhv:heading"><span class="secno">7.3.1 </span>Initialization Data Encountered</span></h4>
-        <p>The following steps are run when the media element encounters <a href="#initialization-data">Initialization Data</a> in the <a href="http://www.w3.org/TR/html5/embedded-content-0.html#media-data">media data</a> during the <a href="http://www.w3.org/TR/html5/embedded-content-0.html#concept-media-load-resource">resource fetch algorithm</a>:</p>
-
+        <p>
+          This algorithm queues an <code><a href="#dom-evt-encrypted">encrypted</a></code> event for <a href="#initialization-data">Initialization Data</a> encounterd in the <a href="http://www.w3.org/TR/html5/embedded-content-0.html#media-data">media data</a>.
+        </p>
+        <p>The following steps are run:</p>
         <ol>
           <li>
             <p>Let <var>initDataType</var> be the empty string.</p>
@@ -5338,8 +5340,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
             </div>
           </li>
           <li>
-            <p><a href="http://www.w3.org/TR/html5/webappapis.html#queue-a-task">Queue a task</a> to create an event named <var>encrypted</var> that does not bubble and is not cancellable using the <a href="#dom-mediaencryptedevent" class="internalDFN" data-link-type="dfn"><code>MediaEncryptedEvent</code></a> interface with its <var>type</var> attribute set to <code>message</code> and its <var>isTrusted</var> attribute initialized to <code>true</code>, and dispatch it at the <var>session</var>.
-            </p>
+            <p><a href="http://www.w3.org/TR/html5/webappapis.html#queue-a-task">Queue a task</a> to create an event named <code><a href="#dom-evt-encrypted">encrypted</a></code> that does not bubble and is not cancellable using the <a href="#dom-mediaencryptedevent" class="internalDFN" data-link-type="dfn"><code>MediaEncryptedEvent</code></a> interface with its <var>type</var> attribute set to <code>message</code> and its <var>isTrusted</var> attribute initialized to <code>true</code>, and dispatch it at the media element.</p>
             <p>The event interface <a href="#dom-mediaencryptedevent" class="internalDFN" data-link-type="dfn"><code>MediaEncryptedEvent</code></a> has:</p>
             <ul style="list-style-type:none">
               <li>
@@ -5381,7 +5382,8 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
 
       <section id="encrypted-block-encountered" typeof="bibo:Chapter" resource="#encrypted-block-encountered" property="bibo:hasPart">
         <h4 id="h-encrypted-block-encountered" resource="#h-encrypted-block-encountered"><span property="xhv:role" resource="xhv:heading"><span class="secno">7.3.2 </span>Encrypted Block Encountered</span></h4>
-        <p>This algorithm queues a block of encrypted media data for decryption and attempts to decrypt if possible. The following steps are run:</p>
+        <p>This algorithm queues a block of encrypted media data for decryption and attempts to decrypt if possible.</p>
+        <p>The following steps are run:</p>
         <ol>
           <li>
             <p>Let <var>block</var> be the block of encrypted media data.</p>
@@ -5398,7 +5400,8 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
 
       <section id="attempt-to-decrypt" typeof="bibo:Chapter" resource="#attempt-to-decrypt" property="bibo:hasPart">
         <h4 id="h-attempt-to-decrypt" resource="#h-attempt-to-decrypt"><span property="xhv:role" resource="xhv:heading"><span class="secno">7.3.3 </span>Attempt to Decrypt</span></h4>
-        <p>This algorithm attempts to decrypt media data that is queued for decryption. The following steps are run:</p>
+        <p>This algorithm attempts to decrypt media data that is queued for decryption.</p>
+        <p>The following steps are run:</p>
         <ol>
           <li>
             <p>If the media element's <var>encrypted block queue</var> is empty, abort these steps.</p>
@@ -5599,7 +5602,8 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
 
       <section id="queue-waitingforkey" typeof="bibo:Chapter" resource="#queue-waitingforkey" property="bibo:hasPart">
         <h4 id="h-queue-waitingforkey" resource="#h-queue-waitingforkey"><span property="xhv:role" resource="xhv:heading"><span class="secno">7.3.4 </span>Queue a "waitingforkey" Event</span></h4>
-        <p>The Queue a "waitingforkey" Event algorithm is run when the CDM cannot decrypt the current block. It should only be called when the <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#htmlmediaelement">HTMLMediaElement</a></code> object is <a href="http://www.w3.org/TR/html5/embedded-content-0.html#potentially-playing">potentially playing</a> and its <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#dom-media-readystate">readyState</a></code> is equal to <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#dom-media-have_future_data">HAVE_FUTURE_DATA</a></code> or greater. Requests to run this algorithm include a target <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#htmlmediaelement">HTMLMediaElement</a></code> object.
+        <p>
+          This algorithm queues a <code><a href="#dom-evt-waitingforkey">waitingforkey</a></code> event and updates <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#dom-media-readystate">readyState</a></code>. It should only be called when the <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#htmlmediaelement">HTMLMediaElement</a></code> object is <a href="http://www.w3.org/TR/html5/embedded-content-0.html#potentially-playing">potentially playing</a> and its <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#dom-media-readystate">readyState</a></code> is equal to <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#dom-media-have_future_data">HAVE_FUTURE_DATA</a></code> or greater. Requests to run this algorithm include a target <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#htmlmediaelement">HTMLMediaElement</a></code> object.
         </p>
         <p>The following steps are run:</p>
         <ol>
@@ -5631,9 +5635,9 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
 
       <section id="resume-playback" typeof="bibo:Chapter" resource="#resume-playback" property="bibo:hasPart">
         <h4 id="h-resume-playback" resource="#h-resume-playback"><span property="xhv:role" resource="xhv:heading"><span class="secno">7.3.5 </span>Attempt to Resume Playback If Necessary</span></h4>
-        <p>The Attempt to Resume Playback If Necessary algorithm is run when one or more keys may be or may have become available. If playback is blocked waiting for a key, it resumes playback if a necessary key has been provided. Requests to run this algorithm include a target <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#htmlmediaelement">HTMLMediaElement</a></code> object.
+        <p>
+          This algorithm resumes playback if the media element is blocked waiting for a key and necessary key is currently <a href="#usable-for-decryption">usable for decryption</a> Requests to run this algorithm include a target <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#htmlmediaelement">HTMLMediaElement</a></code> object.
         </p>
-
         <p>The following steps are run:</p>
         <ol>
           <li>


### PR DESCRIPTION
Also fixed up text related to queueing of "encrypted" and "message" events.