### PR TITLE
Fix #289: Restrict nearly all interfaces to secure contexts

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -611,7 +611,7 @@
               Otherwise, it is resolved with a new <a>MediaKeySystemAccess</a> object.
             </p>
             <div class="note">
-              <p>This method is only exposed to <a href="https://www.w3.org/TR/secure-contexts/#secure-context">secure contexts</a> [[POWERFUL-FEATURES]] as indicated by the <code>[SecureContext]</code> IDL attribute.</p>
+              <p>This method is only exposed to <a href="https://www.w3.org/TR/secure-contexts/#secure-context">secure contexts</a> [[SECURE-CONTEXTS]] as indicated by the <code>[SecureContext]</code> IDL attribute.</p>
               <p>
                 Requiring Secure Contexts is <em>not</em> a replacement for other security- and privacy-related requirements and recommendations.
                 Implementations MUST meet all related requirements and SHOULD follow related recommendations such that the risks on in an secure context would be similar.

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -611,7 +611,7 @@
               Otherwise, it is resolved with a new <a>MediaKeySystemAccess</a> object.
             </p>
             <div class="note">
-              <p>This method is only exposed to <a href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure contexts</a> [[POWERFUL-FEATURES]] as indicated by the <code>[SecureContext]</code> IDL attribute.</p>
+              <p>This method is only exposed to <a href="https://www.w3.org/TR/secure-contexts/#secure-context">secure contexts</a> [[POWERFUL-FEATURES]] as indicated by the <code>[SecureContext]</code> IDL attribute.</p>
               <p>
                 Requiring Secure Contexts is <em>not</em> a replacement for other security- and privacy-related requirements and recommendations.
                 Implementations MUST meet all related requirements and SHOULD follow related recommendations such that the risks on in an secure context would be similar.
@@ -1187,7 +1187,7 @@
       <section>
         <h3><a>MediaKeySystemConfiguration</a> dictionary</h3>
 
-        <div><pre class="idl">enum MediaKeysRequirement {
+        <div><pre class="idl">[SecureContext] enum MediaKeysRequirement {
     "required",
     "optional",
     "not-allowed"
@@ -1214,7 +1214,7 @@
             </dl>
           </td></tr></tbody></table></div>
 
-        <div><pre class="idl">dictionary MediaKeySystemConfiguration {
+        <div><pre class="idl">[SecureContext] dictionary MediaKeySystemConfiguration {
              DOMString                               label = "";
              sequence&lt;DOMString&gt;                     initDataTypes = [];
              sequence&lt;MediaKeySystemMediaCapability&gt; audioCapabilities = [];
@@ -1266,7 +1266,7 @@
 
       <section>
         <h3><a>MediaKeySystemMediaCapability</a> dictionary</h3>
-        <div><pre class="idl">dictionary MediaKeySystemMediaCapability {
+        <div><pre class="idl">[SecureContext] dictionary MediaKeySystemMediaCapability {
              DOMString contentType = "";
              DOMString robustness = "";
 };</pre><section><h2>Dictionary <a class="idlType">MediaKeySystemMediaCapability</a> Members</h2><dl class="dictionary-members" data-dfn-for="MediaKeySystemMediaCapability" data-link-for="MediaKeySystemMediaCapability"><dt><dfn><code>contentType</code></dfn> of type <span class="idlMemberType"><a>DOMString</a></span>, defaulting to <code>""</code></dt><dd>
@@ -1302,7 +1302,7 @@
       <h2><a>MediaKeySystemAccess</a> Interface</h2>
       <p>The MediaKeySystemAccess object provides access to a <a def-id="keysystem"></a>.</p>
 
-      <div><pre class="idl">interface MediaKeySystemAccess {
+      <div><pre class="idl">[SecureContext] interface MediaKeySystemAccess {
     readonly        attribute DOMString keySystem;
     MediaKeySystemConfiguration getConfiguration ();
     Promise&lt;MediaKeys&gt;          createMediaKeys ();
@@ -1380,7 +1380,7 @@
       <p>For methods that return a promise, all errors are reported asynchronously by rejecting the returned Promise. This includes [[!WebIDL]] type mapping errors.</p>
       <p>The steps of an algorithm are always aborted when rejecting a promise.</p>
 
-      <div><pre class="idl">enum MediaKeySessionType {
+      <div><pre class="idl">[SecureContext] enum MediaKeySessionType {
     "temporary",
     "persistent-usage-record",
     "persistent-license"
@@ -1451,7 +1451,7 @@
           </p>
         </td></tr></tbody></table></div>
 
-      <div><pre class="idl">interface MediaKeys {
+      <div><pre class="idl">[SecureContext] interface MediaKeys {
     MediaKeySession  createSession (optional MediaKeySessionType sessionType = "temporary");
     Promise&lt;boolean&gt; setServerCertificate (BufferSource serverCertificate);
 };</pre><section><h2>Methods</h2><dl class="methods" data-dfn-for="MediaKeys" data-link-for="MediaKeys"><dt><dfn><code>createSession</code></dfn></dt><dd>
@@ -1616,7 +1616,7 @@
       <p>For methods that return a promise, all errors are reported asynchronously by rejecting the returned Promise. This includes [[!WebIDL]] type mapping errors.</p>
       <p>The following steps of an algorithm are always aborted when rejecting a promise.</p>
 
-      <div><pre class="idl">interface MediaKeySession : EventTarget {
+      <div><pre class="idl">[SecureContext] interface MediaKeySession : EventTarget {
     readonly        attribute DOMString           sessionId;
     readonly        attribute unrestricted double expiration;
     readonly        attribute Promise&lt;void&gt;       closed;
@@ -2177,7 +2177,7 @@
         <p>The MediaKeyStatusMap object is a read-only map of <a def-id="key-id">key IDs</a> to the current status of the associated key.</p>
         <p>A key's status is independent of whether the key is currently being used and of media data.</p>
         <p class="note">For example, if a key has output requirements that cannot currently be met, the key's status should be <a def-id="status-output-downscaled"></a> or <a def-id="status-output-restricted"></a>, as appropriate, regardless of whether that key has been or is currently needed to decrypt media data.</p>
-        <div><pre class="idl">interface MediaKeyStatusMap {
+        <div><pre class="idl">[SecureContext] interface MediaKeyStatusMap {
     iterable&lt;BufferSource,MediaKeyStatus&gt;;
     readonly        attribute unsigned long size;
     boolean has (BufferSource keyId);
@@ -2223,7 +2223,7 @@
           </section>
         </div>
 
-        <div><pre class="idl">enum MediaKeyStatus {
+        <div><pre class="idl">[SecureContext] enum MediaKeyStatus {
     "usable",
     "expired",
     "released",
@@ -2268,7 +2268,7 @@
         <p>The MediaKeyMessageEvent object is used for the <a def-id="message"></a> event.</p>
         <p>Events are constructed as defined in <a def-id="constructing-events"></a> [[!DOM]].</p>
 
-        <div><pre class="idl">enum MediaKeyMessageType {
+        <div><pre class="idl">[SecureContext] enum MediaKeyMessageType {
     "license-request",
     "license-renewal",
     "license-release",
@@ -2278,7 +2278,7 @@
             As with all other messages, any identifiers in the message MUST be <a href="#per-origin-per-profile-identifiers">distinctive per origin and profile</a> and MUST NOT be <a def-id="distinctive-permanent-identifier-maybe-plural"></a>.
           </td></tr></tbody></table></div>
 
-        <div><pre class="idl">[ Constructor (DOMString type, optional MediaKeyMessageEventInit eventInitDict)]
+        <div><pre class="idl">[SecureContext, Constructor (DOMString type, optional MediaKeyMessageEventInit eventInitDict)]
 interface MediaKeyMessageEvent : Event {
     readonly        attribute MediaKeyMessageType messageType;
     readonly        attribute ArrayBuffer         message;
@@ -2299,7 +2299,7 @@ interface MediaKeyMessageEvent : Event {
 
         <section>
           <h4><a>MediaKeyMessageEventInit</a></h4>
-          <div><pre class="idl">dictionary MediaKeyMessageEventInit : EventInit {
+          <div><pre class="idl">[SecureContext] dictionary MediaKeyMessageEventInit : EventInit {
              MediaKeyMessageType messageType = "license-request";
              ArrayBuffer         message;
 };</pre><section><h2>Dictionary <a class="idlType">MediaKeyMessageEventInit</a> Members</h2><dl class="dictionary-members" data-dfn-for="MediaKeyMessageEventInit" data-link-for="MediaKeyMessageEventInit"><dt><dfn><code>messageType</code></dfn> of type <span class="idlMemberType"><a>MediaKeyMessageType</a></span>, defaulting to <code>"license-request"</code></dt><dd>
@@ -2689,10 +2689,10 @@ interface MediaKeyMessageEvent : Event {
       <p>The steps of an algorithm are always aborted when rejecting a promise.</p>
 
       <div><pre class="idl">partial interface HTMLMediaElement {
-    readonly        attribute MediaKeys?   mediaKeys;
-                    attribute EventHandler onencrypted;
-                    attribute EventHandler onwaitingforkey;
-    Promise&lt;void&gt; setMediaKeys (MediaKeys? mediaKeys);
+    [SecureContext] readonly        attribute MediaKeys?   mediaKeys;
+                                    attribute EventHandler onencrypted;
+                                    attribute EventHandler onwaitingforkey;
+    [SecureContext] Promise&lt;void&gt; setMediaKeys (MediaKeys? mediaKeys);
 };</pre><section><h2>Attributes</h2><dl class="attributes" data-dfn-for="HTMLMediaElement" data-link-for="HTMLMediaElement"><dt><dfn><code>mediaKeys</code></dfn> of type <span class="idlAttrType"><a>MediaKeys</a></span>, readonly       , nullable</dt><dd>
           <p>The <a>MediaKeys</a> being used when decrypting encrypted <a def-id="media-data"></a> for this media element.</p>
         </dd><dt><dfn><code>onencrypted</code></dfn> of type <span class="idlAttrType"><a>EventHandler</a></span></dt><dd>

--- a/index.html
+++ b/index.html
@@ -758,7 +758,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
   <link rel="stylesheet" href="eme.css">
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED">
   <!--[if lt IE 9]><script src='https://www.w3.org/2008/site/js/html5shiv.js'></script><![endif]-->
-  <meta name="generator" content="ReSpec 4.3.2">
+  <meta name="generator" content="ReSpec 4.3.3">
   <script id="initialUserConfig" type="application/json">
     {
       "specStatus": "ED",
@@ -1207,13 +1207,13 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
     }
   </script>
 </head>
-<body class="h-entry" role="document" id="respecDocument">
+<body class="h-entry toc-inline" role="document" id="respecDocument">
   <div class="head" role="contentinfo" id="respecHeader">
     <p>
       <a class="logo" href="https://www.w3.org/"><img width="72" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" alt="W3C"></a>
     </p>
     <h1 class="title p-name" id="title" property="dcterms:title">Encrypted Media Extensions</h1>
-    <h2 id="w3c-editor-s-draft-02-august-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2016-08-02">02 August 2016</time></h2>
+    <h2 id="w3c-editor-s-draft-03-august-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2016-08-03">03 August 2016</time></h2>
     <dl>
       <dt>This version:</dt>
       <dd><a class="u-url" href="https://w3c.github.io/encrypted-media/">https://w3c.github.io/encrypted-media/</a></dd>
@@ -2062,7 +2062,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
               <div class="note">
                 <div class="note-title marker" aria-level="5" role="heading" id="h-note22"><span>Note</span></div>
                 <div class="">
-                  <p>This method is only exposed to <a href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure contexts</a> [<cite><a class="bibref" href="#bib-POWERFUL-FEATURES">POWERFUL-FEATURES</a></cite>] as indicated by the <code>[SecureContext]</code> IDL attribute.</p>
+                  <p>This method is only exposed to <a href="https://www.w3.org/TR/secure-contexts/#secure-context">secure contexts</a> [<cite><a class="bibref" href="#bib-POWERFUL-FEATURES">POWERFUL-FEATURES</a></cite>] as indicated by the <code>[SecureContext]</code> IDL attribute.</p>
                   <p>
                     Requiring Secure Contexts is <em>not</em> a replacement for other security- and privacy-related requirements and recommendations. Implementations <em class="rfc2119" title="MUST">MUST</em> meet all related requirements and <em class="rfc2119" title="SHOULD">SHOULD</em> follow related recommendations such that the risks on in an secure context would be similar.
                   </p>
@@ -2809,7 +2809,8 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
     <section id="mediakeysystemconfiguration-dictionary" typeof="bibo:Chapter" resource="#mediakeysystemconfiguration-dictionary" property="bibo:hasPart">
       <h3 id="h-mediakeysystemconfiguration-dictionary" resource="#h-mediakeysystemconfiguration-dictionary"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.2 </span><a href="#idl-def-mediakeysystemconfiguration" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemConfiguration</code></a> dictionary</span></h3>
 
-      <div><pre class="def idl"><span class="idlEnum" id="idl-def-mediakeysrequirement" data-idl="" data-title="MediaKeysRequirement">enum <span class="idlEnumID">MediaKeysRequirement</span> {
+      <div><pre class="def idl"><span class="idlEnum" id="idl-def-mediakeysrequirement" data-idl="" data-title="MediaKeysRequirement">[<span class="extAttr"><span class="extAttrName">SecureContext</span></span>]
+enum <span class="idlEnumID">MediaKeysRequirement</span> {
     "<a href="#dom-mediakeysrequirement-required" class="idlEnumItem">required</a>",
     "<a href="#dom-mediakeysrequirement-optional" class="idlEnumItem">optional</a>",
     "<a href="#dom-mediakeysrequirement-not-allowed" class="idlEnumItem">not-allowed</a>"
@@ -2856,7 +2857,8 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         </table>
       </div>
 
-      <div><pre class="def idl"><span class="idlDictionary" id="idl-def-mediakeysystemconfiguration" data-idl="" data-title="MediaKeySystemConfiguration">dictionary <span class="idlDictionaryID">MediaKeySystemConfiguration</span> {
+      <div><pre class="def idl"><span class="idlDictionary" id="idl-def-mediakeysystemconfiguration" data-idl="" data-title="MediaKeySystemConfiguration">[<span class="extAttr"><span class="extAttrName">SecureContext</span></span>]
+dictionary <span class="idlDictionaryID">MediaKeySystemConfiguration</span> {
 <span class="idlMember" id="idl-def-mediakeysystemconfiguration-label" data-idl="" data-title="label" data-dfn-for="mediakeysystemconfiguration">    <span class="idlMemberType">DOMString</span>                               <span class="idlMemberName"><a data-lt="label" href="#dom-mediakeysystemconfiguration-label" class="internalDFN" data-link-type="dfn" data-for="MediaKeySystemConfiguration"><code>label</code></a></span> = <span class="idlMemberValue">""</span>;</span>
 <span class="idlMember" id="idl-def-mediakeysystemconfiguration-initdatatypes" data-idl="" data-title="initDataTypes" data-dfn-for="mediakeysystemconfiguration">    <span class="idlMemberType">sequence&lt;DOMString&gt;</span>                     <span class="idlMemberName"><a data-lt="initDataTypes" href="#dom-mediakeysystemconfiguration-initdatatypes" class="internalDFN" data-link-type="dfn" data-for="MediaKeySystemConfiguration"><code>initDataTypes</code></a></span> = <span class="idlMemberValue">[]</span>;</span>
 <span class="idlMember" id="idl-def-mediakeysystemconfiguration-audiocapabilities" data-idl="" data-title="audioCapabilities" data-dfn-for="mediakeysystemconfiguration">    <span class="idlMemberType">sequence&lt;<a href="#idl-def-mediakeysystemmediacapability" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemMediaCapability</code></a>&gt;</span> <span class="idlMemberName"><a data-lt="audioCapabilities" href="#dom-mediakeysystemconfiguration-audiocapabilities" class="internalDFN" data-link-type="dfn" data-for="MediaKeySystemConfiguration"><code>audioCapabilities</code></a></span> = <span class="idlMemberValue">[]</span>;</span>
@@ -2925,7 +2927,8 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
     <section id="mediakeysystemmediacapability-dictionary" typeof="bibo:Chapter" resource="#mediakeysystemmediacapability-dictionary" property="bibo:hasPart">
       <h3 id="h-mediakeysystemmediacapability-dictionary" resource="#h-mediakeysystemmediacapability-dictionary"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.3 </span><a href="#idl-def-mediakeysystemmediacapability" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemMediaCapability</code></a> dictionary</span></h3>
-      <div><pre class="def idl"><span class="idlDictionary" id="idl-def-mediakeysystemmediacapability" data-idl="" data-title="MediaKeySystemMediaCapability">dictionary <span class="idlDictionaryID">MediaKeySystemMediaCapability</span> {
+      <div><pre class="def idl"><span class="idlDictionary" id="idl-def-mediakeysystemmediacapability" data-idl="" data-title="MediaKeySystemMediaCapability">[<span class="extAttr"><span class="extAttrName">SecureContext</span></span>]
+dictionary <span class="idlDictionaryID">MediaKeySystemMediaCapability</span> {
 <span class="idlMember" id="idl-def-mediakeysystemmediacapability-contenttype" data-idl="" data-title="contentType" data-dfn-for="mediakeysystemmediacapability">    <span class="idlMemberType">DOMString</span> <span class="idlMemberName"><a data-lt="contentType" href="#dom-mediakeysystemmediacapability-contenttype" class="internalDFN" data-link-type="dfn" data-for="MediaKeySystemMediaCapability"><code>contentType</code></a></span> = <span class="idlMemberValue">""</span>;</span>
 <span class="idlMember" id="idl-def-mediakeysystemmediacapability-robustness" data-idl="" data-title="robustness" data-dfn-for="mediakeysystemmediacapability">    <span class="idlMemberType">DOMString</span> <span class="idlMemberName"><a data-lt="robustness" href="#dom-mediakeysystemmediacapability-robustness" class="internalDFN" data-link-type="dfn" data-for="MediaKeySystemMediaCapability"><code>robustness</code></a></span> = <span class="idlMemberValue">""</span>;</span>
 };</span></pre>
@@ -2972,7 +2975,8 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
     <h2 id="h-mediakeysystemaccess-interface" resource="#h-mediakeysystemaccess-interface"><span property="xhv:role" resource="xhv:heading"><span class="secno">4. </span><a href="#idl-def-mediakeysystemaccess" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemAccess</code></a> Interface</span></h2>
     <p>The MediaKeySystemAccess object provides access to a <a href="#key-system">Key System</a>.</p>
 
-    <div><pre class="def idl"><span class="idlInterface" id="idl-def-mediakeysystemaccess" data-idl="" data-title="MediaKeySystemAccess">interface <span class="idlInterfaceID">MediaKeySystemAccess</span> {
+    <div><pre class="def idl"><span class="idlInterface" id="idl-def-mediakeysystemaccess" data-idl="" data-title="MediaKeySystemAccess">[<span class="extAttr"><span class="extAttrName">SecureContext</span></span>]
+interface <span class="idlInterfaceID">MediaKeySystemAccess</span> {
 <span class="idlAttribute" id="idl-def-mediakeysystemaccess-keysystem" data-idl="" data-title="keySystem" data-dfn-for="mediakeysystemaccess">    readonly attribute <span class="idlAttrType">DOMString</span> <span class="idlAttrName"><a data-lt="keySystem" href="#dom-mediakeysystemaccess-keysystem" class="internalDFN" data-link-type="dfn" data-for="MediaKeySystemAccess"><code>keySystem</code></a></span>;</span>
 <span class="idlMethod" id="idl-def-mediakeysystemaccess-getconfiguration()" data-idl="" data-title="getConfiguration" data-dfn-for="mediakeysystemaccess">    <span class="idlMethType"><a href="#idl-def-mediakeysystemconfiguration" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemConfiguration</code></a></span> <span class="idlMethName"><a data-lt="getConfiguration" href="#dom-mediakeysystemaccess-getconfiguration" class="internalDFN" data-link-type="dfn" data-for="MediaKeySystemAccess"><code>getConfiguration</code></a></span>();</span>
 <span class="idlMethod" id="idl-def-mediakeysystemaccess-createmediakeys()" data-idl="" data-title="createMediaKeys" data-dfn-for="mediakeysystemaccess">    <span class="idlMethType">Promise&lt;<a href="#dom-mediakeys" class="internalDFN" data-link-type="dfn"><code>MediaKeys</code></a>&gt;</span>          <span class="idlMethName"><a data-lt="createMediaKeys" href="#dom-mediakeysystemaccess-createmediakeys" class="internalDFN" data-link-type="dfn" data-for="MediaKeySystemAccess"><code>createMediaKeys</code></a></span>();</span>
@@ -3106,7 +3110,8 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
     <p>For methods that return a promise, all errors are reported asynchronously by rejecting the returned Promise. This includes [<cite><a class="bibref" href="#bib-WebIDL">WebIDL</a></cite>] type mapping errors.</p>
     <p>The steps of an algorithm are always aborted when rejecting a promise.</p>
 
-    <div><pre class="def idl"><span class="idlEnum" id="idl-def-mediakeysessiontype" data-idl="" data-title="MediaKeySessionType">enum <span class="idlEnumID">MediaKeySessionType</span> {
+    <div><pre class="def idl"><span class="idlEnum" id="idl-def-mediakeysessiontype" data-idl="" data-title="MediaKeySessionType">[<span class="extAttr"><span class="extAttrName">SecureContext</span></span>]
+enum <span class="idlEnumID">MediaKeySessionType</span> {
     "<a href="#dom-mediakeysessiontype-temporary" class="idlEnumItem">temporary</a>",
     "<a href="#dom-mediakeysessiontype-persistent-usage-record" class="idlEnumItem">persistent-usage-record</a>",
     "<a href="#dom-mediakeysessiontype-persistent-license" class="idlEnumItem">persistent-license</a>"
@@ -3189,7 +3194,8 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       </table>
     </div>
 
-    <div><pre class="def idl"><span class="idlInterface" id="idl-def-mediakeys" data-idl="" data-title="MediaKeys">interface <span class="idlInterfaceID"><a data-lt="MediaKeys" href="#dom-mediakeys" class="internalDFN" data-link-type="dfn" data-for=""><code>MediaKeys</code></a></span> {
+    <div><pre class="def idl"><span class="idlInterface" id="idl-def-mediakeys" data-idl="" data-title="MediaKeys">[<span class="extAttr"><span class="extAttrName">SecureContext</span></span>]
+interface <span class="idlInterfaceID"><a data-lt="MediaKeys" href="#dom-mediakeys" class="internalDFN" data-link-type="dfn" data-for=""><code>MediaKeys</code></a></span> {
 <span class="idlMethod" id="idl-def-mediakeys-createsession(optional-mediakeysessiontype)" data-idl="" data-title="createSession" data-dfn-for="mediakeys">    <span class="idlMethType"><a href="#idl-def-mediakeysession" class="internalDFN" data-link-type="dfn"><code>MediaKeySession</code></a></span>  <span class="idlMethName"><a data-lt="createSession" href="#dom-mediakeys-createsession" class="internalDFN" data-link-type="dfn" data-for="MediaKeys"><code>createSession</code></a></span>(<span class="idlParam">optional <span class="idlParamType"><a href="#idl-def-mediakeysessiontype" class="internalDFN" data-link-type="dfn"><code>MediaKeySessionType</code></a></span> <span class="idlParamName">sessionType</span> = <span class="idlDefaultValue">"temporary"</span></span>);</span>
 <span class="idlMethod" id="idl-def-mediakeys-setservercertificate(buffersource)" data-idl="" data-title="setServerCertificate" data-dfn-for="mediakeys">    <span class="idlMethType">Promise&lt;boolean&gt;</span> <span class="idlMethName"><a data-lt="setServerCertificate" href="#dom-mediakeys-setservercertificate" class="internalDFN" data-link-type="dfn" data-for="MediaKeys"><code>setServerCertificate</code></a></span>(<span class="idlParam"><span class="idlParamType">BufferSource</span> <span class="idlParamName">serverCertificate</span></span>);</span>
 };</span></pre>
@@ -3448,7 +3454,8 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
     <p>For methods that return a promise, all errors are reported asynchronously by rejecting the returned Promise. This includes [<cite><a class="bibref" href="#bib-WebIDL">WebIDL</a></cite>] type mapping errors.</p>
     <p>The following steps of an algorithm are always aborted when rejecting a promise.</p>
 
-    <div><pre class="def idl"><span class="idlInterface" id="idl-def-mediakeysession" data-idl="" data-title="MediaKeySession">interface <span class="idlInterfaceID">MediaKeySession</span> : <span class="idlSuperclass">EventTarget</span> {
+    <div><pre class="def idl"><span class="idlInterface" id="idl-def-mediakeysession" data-idl="" data-title="MediaKeySession">[<span class="extAttr"><span class="extAttrName">SecureContext</span></span>]
+interface <span class="idlInterfaceID">MediaKeySession</span> : <span class="idlSuperclass">EventTarget</span> {
 <span class="idlAttribute" id="idl-def-mediakeysession-sessionid" data-idl="" data-title="sessionId" data-dfn-for="mediakeysession">    readonly attribute <span class="idlAttrType">DOMString</span>           <span class="idlAttrName"><a data-lt="sessionId" href="#dom-mediakeysession-sessionid" class="internalDFN" data-link-type="dfn" data-for="MediaKeySession"><code>sessionId</code></a></span>;</span>
 <span class="idlAttribute" id="idl-def-mediakeysession-expiration" data-idl="" data-title="expiration" data-dfn-for="mediakeysession">    readonly attribute <span class="idlAttrType">unrestricted double</span> <span class="idlAttrName"><a data-lt="expiration" href="#dom-mediakeysession-expiration" class="internalDFN" data-link-type="dfn" data-for="MediaKeySession"><code>expiration</code></a></span>;</span>
 <span class="idlAttribute" id="idl-def-mediakeysession-closed" data-idl="" data-title="closed" data-dfn-for="mediakeysession">    readonly attribute <span class="idlAttrType">Promise&lt;void&gt;</span>       <span class="idlAttrName"><a data-lt="closed" href="#dom-mediakeysession-closed" class="internalDFN" data-link-type="dfn" data-for="MediaKeySession"><code>closed</code></a></span>;</span>
@@ -4345,7 +4352,8 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         <div class="note-title marker" aria-level="4" role="heading" id="h-note76"><span>Note</span></div>
         <p class="">For example, if a key has output requirements that cannot currently be met, the key's status should be <code><a href="#idl-def-MediaKeyStatus.output-downscaled">"output-downscaled"</a></code> or <code><a href="#idl-def-MediaKeyStatus.output-restricted">"output-restricted"</a></code>, as appropriate, regardless of whether that key has been or is currently needed to decrypt media data.</p>
       </div>
-      <div><pre class="def idl"><span class="idlInterface" id="idl-def-mediakeystatusmap" data-idl="" data-title="MediaKeyStatusMap">interface <span class="idlInterfaceID">MediaKeyStatusMap</span> {
+      <div><pre class="def idl"><span class="idlInterface" id="idl-def-mediakeystatusmap" data-idl="" data-title="MediaKeyStatusMap">[<span class="extAttr"><span class="extAttrName">SecureContext</span></span>]
+interface <span class="idlInterfaceID">MediaKeyStatusMap</span> {
 <span class="idlIterable" id="idl-def-mediakeystatusmap-iterable" data-idl="" data-title="iterable" data-dfn-for="mediakeystatusmap">    iterable&lt;BufferSource, <a href="#idl-def-mediakeystatus" class="internalDFN" data-link-type="dfn"><code>MediaKeyStatus</code></a>&gt;;</span>
 <span class="idlAttribute" id="idl-def-mediakeystatusmap-size" data-idl="" data-title="size" data-dfn-for="mediakeystatusmap">    readonly attribute <span class="idlAttrType">unsigned long</span> <span class="idlAttrName"><a data-lt="size" href="#dom-mediakeystatusmap-size" class="internalDFN" data-link-type="dfn" data-for="MediaKeyStatusMap"><code>size</code></a></span>;</span>
 <span class="idlMethod" id="idl-def-mediakeystatusmap-has(buffersource)" data-idl="" data-title="has" data-dfn-for="mediakeystatusmap">    <span class="idlMethType">boolean</span> <span class="idlMethName"><a data-lt="has" href="#dom-mediakeystatusmap-has" class="internalDFN" data-link-type="dfn" data-for="MediaKeyStatusMap"><code>has</code></a></span>(<span class="idlParam"><span class="idlParamType">BufferSource</span> <span class="idlParamName">keyId</span></span>);</span>
@@ -4422,7 +4430,8 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         </section>
       </div>
 
-      <div><pre class="def idl"><span class="idlEnum" id="idl-def-mediakeystatus" data-idl="" data-title="MediaKeyStatus">enum <span class="idlEnumID">MediaKeyStatus</span> {
+      <div><pre class="def idl"><span class="idlEnum" id="idl-def-mediakeystatus" data-idl="" data-title="MediaKeyStatus">[<span class="extAttr"><span class="extAttrName">SecureContext</span></span>]
+enum <span class="idlEnumID">MediaKeyStatus</span> {
     "<a href="#dom-mediakeystatus-usable" class="idlEnumItem">usable</a>",
     "<a href="#dom-mediakeystatus-expired" class="idlEnumItem">expired</a>",
     "<a href="#dom-mediakeystatus-released" class="idlEnumItem">released</a>",
@@ -4488,7 +4497,8 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <p>The MediaKeyMessageEvent object is used for the <code><a href="#dom-evt-message">message</a></code> event.</p>
       <p>Events are constructed as defined in <a href="https://www.w3.org/TR/dom/#constructing-events">Constructing events</a> [<cite><a class="bibref" href="#bib-DOM">DOM</a></cite>].</p>
 
-      <div><pre class="def idl"><span class="idlEnum" id="idl-def-mediakeymessagetype" data-idl="" data-title="MediaKeyMessageType">enum <span class="idlEnumID">MediaKeyMessageType</span> {
+      <div><pre class="def idl"><span class="idlEnum" id="idl-def-mediakeymessagetype" data-idl="" data-title="MediaKeyMessageType">[<span class="extAttr"><span class="extAttrName">SecureContext</span></span>]
+enum <span class="idlEnumID">MediaKeyMessageType</span> {
     "<a href="#dom-mediakeymessagetype-license-request" class="idlEnumItem">license-request</a>",
     "<a href="#dom-mediakeymessagetype-license-renewal" class="idlEnumItem">license-renewal</a>",
     "<a href="#dom-mediakeymessagetype-license-release" class="idlEnumItem">license-release</a>",
@@ -4521,7 +4531,8 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         </table>
       </div>
 
-      <div><pre class="def idl"><span class="idlInterface" id="idl-def-mediakeymessageevent" data-idl="" data-title="MediaKeyMessageEvent">[<span class="idlCtor"><span class="extAttrName">Constructor</span>(<span class="idlParam"><span class="idlParamType">DOMString</span> <span class="idlParamName">type</span></span>, <span class="idlParam">optional <span class="idlParamType"><a href="#idl-def-mediakeymessageeventinit" class="internalDFN" data-link-type="dfn"><code>MediaKeyMessageEventInit</code></a></span> <span class="idlParamName">eventInitDict</span></span>)</span>]
+      <div><pre class="def idl"><span class="idlInterface" id="idl-def-mediakeymessageevent" data-idl="" data-title="MediaKeyMessageEvent">[<span class="extAttr"><span class="extAttrName">SecureContext</span></span>,
+ <span class="idlCtor"><span class="extAttrName">Constructor</span>(<span class="idlParam"><span class="idlParamType">DOMString</span> <span class="idlParamName">type</span></span>, <span class="idlParam">optional <span class="idlParamType"><a href="#idl-def-mediakeymessageeventinit" class="internalDFN" data-link-type="dfn"><code>MediaKeyMessageEventInit</code></a></span> <span class="idlParamName">eventInitDict</span></span>)</span>]
 interface <span class="idlInterfaceID"><a data-lt="MediaKeyMessageEvent" href="#dom-mediakeymessageevent" class="internalDFN" data-link-type="dfn" data-for=""><code>MediaKeyMessageEvent</code></a></span> : <span class="idlSuperclass">Event</span> {
 <span class="idlAttribute" id="idl-def-mediakeymessageevent-messagetype" data-idl="" data-title="messageType" data-dfn-for="mediakeymessageevent">    readonly attribute <span class="idlAttrType"><a href="#idl-def-mediakeymessagetype" class="internalDFN" data-link-type="dfn"><code>MediaKeyMessageType</code></a></span> <span class="idlAttrName"><a data-lt="messageType" href="#dom-mediakeymessageevent-messagetype" class="internalDFN" data-link-type="dfn" data-for="MediaKeyMessageEvent"><code>messageType</code></a></span>;</span>
 <span class="idlAttribute" id="idl-def-mediakeymessageevent-message" data-idl="" data-title="message" data-dfn-for="mediakeymessageevent">    readonly attribute <span class="idlAttrType">ArrayBuffer</span>         <span class="idlAttrName"><a data-lt="message" href="#dom-mediakeymessageevent-message" class="internalDFN" data-link-type="dfn" data-for="MediaKeyMessageEvent"><code>message</code></a></span>;</span>
@@ -4583,7 +4594,8 @@ interface <span class="idlInterfaceID"><a data-lt="MediaKeyMessageEvent" href="#
 
       <section id="mediakeymessageeventinit" typeof="bibo:Chapter" resource="#mediakeymessageeventinit" property="bibo:hasPart">
         <h4 id="h-mediakeymessageeventinit" resource="#h-mediakeymessageeventinit"><span property="xhv:role" resource="xhv:heading"><span class="secno">6.2.1 </span><a href="#idl-def-mediakeymessageeventinit" class="internalDFN" data-link-type="dfn"><code>MediaKeyMessageEventInit</code></a></span></h4>
-        <div><pre class="def idl"><span class="idlDictionary" id="idl-def-mediakeymessageeventinit" data-idl="" data-title="MediaKeyMessageEventInit">dictionary <span class="idlDictionaryID">MediaKeyMessageEventInit</span> : <span class="idlSuperclass">EventInit</span> {
+        <div><pre class="def idl"><span class="idlDictionary" id="idl-def-mediakeymessageeventinit" data-idl="" data-title="MediaKeyMessageEventInit">[<span class="extAttr"><span class="extAttrName">SecureContext</span></span>]
+dictionary <span class="idlDictionaryID">MediaKeyMessageEventInit</span> : <span class="idlSuperclass">EventInit</span> {
 <span class="idlMember" id="idl-def-mediakeymessageeventinit-messagetype" data-idl="" data-title="messageType" data-dfn-for="mediakeymessageeventinit">    <span class="idlMemberType"><a href="#idl-def-mediakeymessagetype" class="internalDFN" data-link-type="dfn"><code>MediaKeyMessageType</code></a></span> <span class="idlMemberName"><a data-lt="messageType" href="#dom-mediakeymessageeventinit-messagetype" class="internalDFN" data-link-type="dfn" data-for="MediaKeyMessageEventInit"><code>messageType</code></a></span> = <span class="idlMemberValue">"license-request"</span>;</span>
 <span class="idlMember" id="idl-def-mediakeymessageeventinit-message" data-idl="" data-title="message" data-dfn-for="mediakeymessageeventinit">    <span class="idlMemberType">ArrayBuffer</span>         <span class="idlMemberName"><a data-lt="message" href="#dom-mediakeymessageeventinit-message" class="internalDFN" data-link-type="dfn" data-for="MediaKeyMessageEventInit"><code>message</code></a></span>;</span>
 };</span></pre>
@@ -5030,10 +5042,12 @@ interface <span class="idlInterfaceID"><a data-lt="MediaKeyMessageEvent" href="#
     <p>The steps of an algorithm are always aborted when rejecting a promise.</p>
 
     <div><pre class="def idl"><span class="idlInterface" id="idl-def-htmlmediaelement-partial-1" data-idl="" data-title="HTMLMediaElement">partial interface <span class="idlInterfaceID">HTMLMediaElement</span> {
-<span class="idlAttribute" id="idl-def-htmlmediaelement-mediakeys" data-idl="" data-title="mediaKeys" data-dfn-for="htmlmediaelement">    readonly attribute <span class="idlAttrType"><a href="#dom-mediakeys" class="internalDFN" data-link-type="dfn"><code>MediaKeys</code></a>?</span>   <span class="idlAttrName">mediaKeys</span>;</span>
+<span class="idlAttribute" id="idl-def-htmlmediaelement-mediakeys" data-idl="" data-title="mediaKeys" data-dfn-for="htmlmediaelement">    [<span class="extAttr"><span class="extAttrName">SecureContext</span></span>]
+    readonly attribute <span class="idlAttrType"><a href="#dom-mediakeys" class="internalDFN" data-link-type="dfn"><code>MediaKeys</code></a>?</span>   <span class="idlAttrName">mediaKeys</span>;</span>
 <span class="idlAttribute" id="idl-def-htmlmediaelement-onencrypted" data-idl="" data-title="onencrypted" data-dfn-for="htmlmediaelement">             attribute <span class="idlAttrType">EventHandler</span> <span class="idlAttrName"><a data-lt="onencrypted" href="#dom-htmlmediaelement-onencrypted" class="internalDFN" data-link-type="dfn" data-for="HTMLMediaElement"><code>onencrypted</code></a></span>;</span>
 <span class="idlAttribute" id="idl-def-htmlmediaelement-onwaitingforkey" data-idl="" data-title="onwaitingforkey" data-dfn-for="htmlmediaelement">             attribute <span class="idlAttrType">EventHandler</span> <span class="idlAttrName"><a data-lt="onwaitingforkey" href="#dom-htmlmediaelement-onwaitingforkey" class="internalDFN" data-link-type="dfn" data-for="HTMLMediaElement"><code>onwaitingforkey</code></a></span>;</span>
-<span class="idlMethod" id="idl-def-htmlmediaelement-setmediakeys(mediakeys?)" data-idl="" data-title="setMediaKeys" data-dfn-for="htmlmediaelement">    <span class="idlMethType">Promise&lt;void&gt;</span> <span class="idlMethName"><a data-lt="setMediaKeys" href="#dom-htmlmediaelement-setmediakeys" class="internalDFN" data-link-type="dfn" data-for="HTMLMediaElement"><code>setMediaKeys</code></a></span>(<span class="idlParam"><span class="idlParamType"><a href="#dom-mediakeys" class="internalDFN" data-link-type="dfn"><code>MediaKeys</code></a>?</span> <span class="idlParamName">mediaKeys</span></span>);</span>
+<span class="idlMethod" id="idl-def-htmlmediaelement-setmediakeys(mediakeys?)" data-idl="" data-title="setMediaKeys" data-dfn-for="htmlmediaelement">    [<span class="extAttr"><span class="extAttrName">SecureContext</span></span>]
+    <span class="idlMethType">Promise&lt;void&gt;</span> <span class="idlMethName"><a data-lt="setMediaKeys" href="#dom-htmlmediaelement-setmediakeys" class="internalDFN" data-link-type="dfn" data-for="HTMLMediaElement"><code>setMediaKeys</code></a></span>(<span class="idlParam"><span class="idlParamType"><a href="#dom-mediakeys" class="internalDFN" data-link-type="dfn"><code>MediaKeys</code></a>?</span> <span class="idlParamName">mediaKeys</span></span>);</span>
 };</span></pre>
 
       <section typeof="bibo:Chapter" resource="#attributes-4" property="bibo:hasPart">

--- a/index.html
+++ b/index.html
@@ -2062,7 +2062,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
               <div class="note">
                 <div class="note-title marker" aria-level="5" role="heading" id="h-note22"><span>Note</span></div>
                 <div class="">
-                  <p>This method is only exposed to <a href="https://www.w3.org/TR/secure-contexts/#secure-context">secure contexts</a> [<cite><a class="bibref" href="#bib-POWERFUL-FEATURES">POWERFUL-FEATURES</a></cite>] as indicated by the <code>[SecureContext]</code> IDL attribute.</p>
+                  <p>This method is only exposed to <a href="https://www.w3.org/TR/secure-contexts/#secure-context">secure contexts</a> [<cite><a class="bibref" href="#bib-SECURE-CONTEXTS">SECURE-CONTEXTS</a></cite>] as indicated by the <code>[SecureContext]</code> IDL attribute.</p>
                   <p>
                     Requiring Secure Contexts is <em>not</em> a replacement for other security- and privacy-related requirements and recommendations. Implementations <em class="rfc2119" title="MUST">MUST</em> meet all related requirements and <em class="rfc2119" title="SHOULD">SHOULD</em> follow related recommendations such that the risks on in an secure context would be similar.
                   </p>
@@ -7293,12 +7293,12 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
         <dd>David Dorwin; Adrian Bateman; Mark Watson. W3C. <a href="format-registry/stream/" property="dc:references"><cite>Encrypted Media Extensions Stream Format Registry</cite></a>. URL: <a href="format-registry/stream/" property="dc:references">format-registry/stream/</a>
         </dd><dt id="bib-MEDIA-SOURCE">[MEDIA-SOURCE]</dt>
         <dd>Matthew Wolenetz; Jerry Smith; Mark Watson; Aaron Colwell; Adrian Bateman. W3C. <a href="https://www.w3.org/TR/media-source/" property="dc:references"><cite>Media Source Extensions</cite></a>. 5 July 2016. W3C Candidate Recommendation. URL: <a href="https://www.w3.org/TR/media-source/" property="dc:references">https://www.w3.org/TR/media-source/</a>
-        </dd><dt id="bib-POWERFUL-FEATURES">[POWERFUL-FEATURES]</dt>
-        <dd>Mike West. W3C. <a href="https://www.w3.org/TR/secure-contexts/" property="dc:references"><cite>Secure Contexts</cite></a>. 19 July 2016. W3C Working Draft. URL: <a href="https://www.w3.org/TR/secure-contexts/" property="dc:references">https://www.w3.org/TR/secure-contexts/</a>
         </dd><dt id="bib-RFC6838">[RFC6838]</dt>
         <dd>N. Freed; J. Klensin; T. Hansen. IETF. <a href="https://tools.ietf.org/html/rfc6838" property="dc:references"><cite>Media Type Specifications and Registration Procedures</cite></a>. January 2013. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc6838" property="dc:references">https://tools.ietf.org/html/rfc6838</a>
         </dd><dt id="bib-RFC7515">[RFC7515]</dt>
         <dd>M. Jones; J. Bradley; N. Sakimura. IETF. <a href="https://tools.ietf.org/html/rfc7515" property="dc:references"><cite>JSON Web Signature (JWS)</cite></a>. May 2015. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7515" property="dc:references">https://tools.ietf.org/html/rfc7515</a>
+        </dd><dt id="bib-SECURE-CONTEXTS">[SECURE-CONTEXTS]</dt>
+        <dd>Mike West. W3C. <a href="https://www.w3.org/TR/secure-contexts/" property="dc:references"><cite>Secure Contexts</cite></a>. 19 July 2016. W3C Working Draft. URL: <a href="https://www.w3.org/TR/secure-contexts/" property="dc:references">https://www.w3.org/TR/secure-contexts/</a>
         </dd>
       </dl>
     </section>


### PR DESCRIPTION
Only the "encrypted" and "waitingforkey" events are exposed on insecure contexts.