### PR TITLE
Capitalize instances of Distinctive Identifier in the section that defines it

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -423,25 +423,25 @@
         <dd>
           <div class="note">
             <p>
-              A distinctive identifier is a value, including in opaque or encrypted form, for which it is possible for any entity external to the client to correlate or associate values beyond what a user may expect on the web platform (e.g. cookies and other site data).
+              A Distinctive Identifier is a value, including in opaque or encrypted form, for which it is possible for any entity external to the client to correlate or associate values beyond what a user may expect on the web platform (e.g. cookies and other site data).
               For example, values that are <a href="#associable-by-entity">associable by an entity other than the application</a> across
               a) <a def-id="origin">origins</a>,
               b) <a def-id="browsing-profile">browsing profiles</a>,
               or c) browsing sessions even after the user has attempted to protect his or her privacy by clearing browsing data
               or values for which it is not easy for a user to break such association.
-              In particular, a value is a distinctive identifier if it is possible for a <a href="#associable-by-entity">central server, such as an individualization server, to associate</a> values across origins, such as because the <a href="#privacy-individualization">individualization</a> requests contained a common value, or because values provided in individualization requests are <a href="#associable-by-entity">associable by such server</a> even after attempts to clear browsing data. 
+              In particular, a value is a Distinctive Identifier if it is possible for a <a href="#associable-by-entity">central server, such as an individualization server, to associate</a> values across origins, such as because the <a href="#privacy-individualization">individualization</a> requests contained a common value, or because values provided in individualization requests are <a href="#associable-by-entity">associable by such server</a> even after attempts to clear browsing data. 
               Possible causes of this include use of <a def-id="distinctive-permanent-identifier-maybe-plural"></a> in the individualization process.
             </p>
             <p>
-              Distinctive identifiers exposed to the application, even in encrypted form, MUST adhere to the <a href="#identifier-requirements">identifier requirements</a>,
+              Distinctive Identifiers exposed to the application, even in encrypted form, MUST adhere to the <a href="#identifier-requirements">identifier requirements</a>,
               including being <a href="#encrypt-identifiers">encrypted</a>, <a href="#per-origin-per-profile-identifiers">unique per origin and profile</a>, and <a href="#allow-identifiers-cleared">clearable</a>.
             </p>
             <p>
-              While the instantiation or use of a distinctive identifier is triggered by the application's use of these APIs, the identifier need not be provided to the application to trigger conditions related to distinctive identifiers.
+              While the instantiation or use of a Distinctive Identifier is triggered by the application's use of these APIs, the identifier need not be provided to the application to trigger conditions related to Distinctive Identifiers.
               (The <a def-id="distinctive-permanent-identifier-maybe-plural"></a> MUST NOT ever be provided to the application, even in opaque or encrypted form.) 
             </p>
           </div>
-          <p>A distinctive identifier is a value, piece of data, implication of the possession of a piece of data, or an observable behavior or timing for which all of the following criteria hold:</p>
+          <p>A Distinctive Identifier is a value, piece of data, implication of the possession of a piece of data, or an observable behavior or timing for which all of the following criteria hold:</p>
           <ul>
             <li><p>It is <em>not</em> shared across a large population of users or client devices.</p></li>
             <li>
@@ -452,7 +452,7 @@
             <li><p>It has one or more the following properties:</p>
               <ul>
                 <li><p>It is derived from one or more <a def-id="distinctive-permanent-identifier-maybe-plural"></a>.</p></li>
-                <li><p>The generation, <a href="#privacy-individualization">individualization</a>, provisioning or other process that produced the value involved, used, provided, derived from, or similarly involved one or more <a def-id="distinctive-permanent-identifier-maybe-plural"></a> or another distinctive identifier.</p></li>
+                <li><p>The generation, <a href="#privacy-individualization">individualization</a>, provisioning or other process that produced the value involved, used, provided, derived from, or similarly involved one or more <a def-id="distinctive-permanent-identifier-maybe-plural"></a> or another Distinctive Identifier.</p></li>
                 <li>
                   <p>It is <a href="#allow-identifiers-cleared">clearable</a> but not <a href="#allow-persistent-data-cleared-with-cookies">along with cookies and other site data</a>.</p>
                   <p class="note">For example, via some mechanism external to the user agent, such as an OS-level mechanism.</p>
@@ -485,39 +485,39 @@
           <p class="note">
             While <a def-id="distinctive-identifiers"></a> are usually <a href="#associable-by-entity">associable by the entity that generated them</a> they MUST be <a def-id="non-associable-by-application"></a>.
             In other words, such correlation or association is only possible by the entity, such as an <a href="#privacy-individualization">individualization</a> server, that originally generated the <a def-id="distinctive-identifier"></a> values.
-            Entities with access to the <a def-id="distinctive-permanent-identifier-maybe-plural"></a> MUST NOT expose this capability to applications, as this would make resulting distinctive identifiers <a href="#associable-by-application">associable by the application</a>, and SHOULD take care to avoid exposing such correlation to other entities or third parties.
+            Entities with access to the <a def-id="distinctive-permanent-identifier-maybe-plural"></a> MUST NOT expose this capability to applications, as this would make resulting Distinctive Identifiers <a href="#associable-by-application">associable by the application</a>, and SHOULD take care to avoid exposing such correlation to other entities or third parties.
           </p>
 
-          <p class="note">While a distinctive identifier is typically unique to a user or client device, an identifier does not need to be strictly unique to be distinctive.
+          <p class="note">While a Distinctive Identifier is typically unique to a user or client device, an identifier does not need to be strictly unique to be distinctive.
             For example, an identifier shared among a small number of users could still be distinctive.
           </p>
 
           <div class="note">
-            <p>Examples of distinctive identifiers include but are not limited to:</p>
+            <p>Examples of Distinctive Identifiers include but are not limited to:</p>
             <ul>
               <li><p>A series of bytes that is included in key requests, different from the series of bytes included by other client devices, and based on or was acquired directly or indirectly using a <a def-id="distinctive-permanent-identifier"></a>.</p></li>
               <li><p>A public key included in key requests that is different from the public keys included in the requests by other client devices and is based on or was acquired directly or indirectly using a <a def-id="distinctive-permanent-identifier"></a>.</p></li>
               <li><p>Demonstration of possession of a private key (e.g. by signing some data) that other client devices do not have and is based on or was acquired directly or indirectly using a <a def-id="distinctive-permanent-identifier"></a>.</p></li>
               <li><p>An identifier for such a key.</p></li>
               <li><p>Such a value used to derive another value that is exposed even though the first value is not directly exposed.</p></li>
-              <li><p>A value derived from another distinctive identifier.</p></li>
+              <li><p>A value derived from another Distinctive Identifier.</p></li>
               <li><p>A random value that was reported to a (i.e. <a href="#privacy-individualization">individualization</a>) server along with a <a def-id="distinctive-permanent-identifier"></a> or provided by such a server after providing a <a def-id="distinctive-permanent-identifier"></a>.</p></li>
               <li><p>A value derived from a unique value provisioned in the hardware device in the factory.</p></li>
               <li><p>A value derived from a unique hardware value (e.g. MAC address or serial number) or software value (e.g. operating system installation instance or operating system user account name) in the hardware device in the factory.</p></li>
               <li><p>A value derived from a unique value embedded in the CDM binary or other file used by the CDM.</p></li>
             </ul>
-            <p>Examples of things that are <em>not</em> distinctive identifiers:</p>
+            <p>Examples of things that are <em>not</em> Distinctive Identifiers:</p>
             <ul>
               <li><p>A public key shared among all copies of a given CDM version if the installed base is large.</p></li>
               <li><p>A nonce or ephemeral key that is unique but used in only one session.</p></li>
               <li><p>A value that is not exposed, even in derived or similar ways, outside the client, including via <a href="#privacy-individualization">individualization</a> or similar.</p></li>
-              <li><p>Device-unique keys used in attestations between, for example, the video pipeline and the CDM when the CDM does not let these attestations further flow to the application and instead makes a new attestation on its own using a key that does not constitute a distinctive identifier.</p></li>
+              <li><p>Device-unique keys used in attestations between, for example, the video pipeline and the CDM when the CDM does not let these attestations further flow to the application and instead makes a new attestation on its own using a key that does not constitute a Distinctive Identifier.</p></li>
               <li>
                 <p>A value that is fully cleared/clearable along with browsing data, such as cookies, after which it will be replaced by a value that is <a def-id="non-associable"></a> (not just <a def-id="non-associable-by-application"></a>), even by a central server such as an <a href="#privacy-individualization">individualization</a> server, AND one or more of the following:</p>
                 <ul>
-                  <li><p>No <a def-id="distinctive-permanent-identifier"></a> or distinctive identifier was involved in the generation of the value.</p></li>
+                  <li><p>No <a def-id="distinctive-permanent-identifier"></a> or Distinctive Identifier was involved in the generation of the value.</p></li>
                   <li><p>It is a random value generated <em>without</em> inputs from the system.</p></li>
-                  <li><p>It is a value provided by a server without the use of or knowledge of another distinctive identifier.</p></li>
+                  <li><p>It is a value provided by a server without the use of or knowledge of another Distinctive Identifier.</p></li>
                 </ul>
               </li>
             </ul>

--- a/index.html
+++ b/index.html
@@ -758,7 +758,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
   <link rel="stylesheet" href="eme.css">
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED">
   <!--[if lt IE 9]><script src='https://www.w3.org/2008/site/js/html5shiv.js'></script><![endif]-->
-  <meta name="generator" content="ReSpec 4.3.3">
+  <meta name="generator" content="ReSpec 4.3.4">
   <script id="initialUserConfig" type="application/json">
     {
       "specStatus": "ED",
@@ -1213,7 +1213,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <a class="logo" href="https://www.w3.org/"><img width="72" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" alt="W3C"></a>
     </p>
     <h1 class="title p-name" id="title" property="dcterms:title">Encrypted Media Extensions</h1>
-    <h2 id="w3c-editor-s-draft-03-august-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2016-08-03">03 August 2016</time></h2>
+    <h2 id="w3c-editor-s-draft-04-august-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2016-08-04">04 August 2016</time></h2>
     <dl>
       <dt>This version:</dt>
       <dd><a class="u-url" href="https://w3c.github.io/encrypted-media/">https://w3c.github.io/encrypted-media/</a></dd>
@@ -1806,17 +1806,17 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
           <div class="note-title marker" aria-level="3" role="heading" id="h-note14"><span>Note</span></div>
           <div class="">
             <p>
-              A distinctive identifier is a value, including in opaque or encrypted form, for which it is possible for any entity external to the client to correlate or associate values beyond what a user may expect on the web platform (e.g. cookies and other site data). For example, values that are <a href="#associable-by-entity">associable by an entity other than the application</a> across a) <a href="http://www.w3.org/TR/html5/browsers.html#origin-0">origins</a>, b) <a href="#browsing-profile">browsing profiles</a>, or c) browsing sessions even after the user has attempted to protect his or her privacy by clearing browsing data or values for which it is not easy for a user to break such association. In particular, a value is a distinctive identifier if it is possible for a <a href="#associable-by-entity">central server, such as an individualization server, to associate</a> values across origins, such as because the <a href="#privacy-individualization">individualization</a> requests contained a common value, or because values provided in individualization requests are <a href="#associable-by-entity">associable by such server</a> even after attempts to clear browsing data. Possible causes of this include use of <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifier(s)</a> in the individualization process.
+              A Distinctive Identifier is a value, including in opaque or encrypted form, for which it is possible for any entity external to the client to correlate or associate values beyond what a user may expect on the web platform (e.g. cookies and other site data). For example, values that are <a href="#associable-by-entity">associable by an entity other than the application</a> across a) <a href="http://www.w3.org/TR/html5/browsers.html#origin-0">origins</a>, b) <a href="#browsing-profile">browsing profiles</a>, or c) browsing sessions even after the user has attempted to protect his or her privacy by clearing browsing data or values for which it is not easy for a user to break such association. In particular, a value is a Distinctive Identifier if it is possible for a <a href="#associable-by-entity">central server, such as an individualization server, to associate</a> values across origins, such as because the <a href="#privacy-individualization">individualization</a> requests contained a common value, or because values provided in individualization requests are <a href="#associable-by-entity">associable by such server</a> even after attempts to clear browsing data. Possible causes of this include use of <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifier(s)</a> in the individualization process.
             </p>
             <p>
-              Distinctive identifiers exposed to the application, even in encrypted form, <em class="rfc2119" title="MUST">MUST</em> adhere to the <a href="#identifier-requirements">identifier requirements</a>, including being <a href="#encrypt-identifiers">encrypted</a>, <a href="#per-origin-per-profile-identifiers">unique per origin and profile</a>, and <a href="#allow-identifiers-cleared">clearable</a>.
+              Distinctive Identifiers exposed to the application, even in encrypted form, <em class="rfc2119" title="MUST">MUST</em> adhere to the <a href="#identifier-requirements">identifier requirements</a>, including being <a href="#encrypt-identifiers">encrypted</a>, <a href="#per-origin-per-profile-identifiers">unique per origin and profile</a>, and <a href="#allow-identifiers-cleared">clearable</a>.
             </p>
             <p>
-              While the instantiation or use of a distinctive identifier is triggered by the application's use of these APIs, the identifier need not be provided to the application to trigger conditions related to distinctive identifiers. (The <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifier(s)</a> <em class="rfc2119" title="MUST NOT">MUST NOT</em> ever be provided to the application, even in opaque or encrypted form.)
+              While the instantiation or use of a Distinctive Identifier is triggered by the application's use of these APIs, the identifier need not be provided to the application to trigger conditions related to Distinctive Identifiers. (The <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifier(s)</a> <em class="rfc2119" title="MUST NOT">MUST NOT</em> ever be provided to the application, even in opaque or encrypted form.)
             </p>
           </div>
         </div>
-        <p>A distinctive identifier is a value, piece of data, implication of the possession of a piece of data, or an observable behavior or timing for which all of the following criteria hold:</p>
+        <p>A Distinctive Identifier is a value, piece of data, implication of the possession of a piece of data, or an observable behavior or timing for which all of the following criteria hold:</p>
         <ul>
           <li>
             <p>It is <em>not</em> shared across a large population of users or client devices.</p>
@@ -1832,7 +1832,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                 <p>It is derived from one or more <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifier(s)</a>.</p>
               </li>
               <li>
-                <p>The generation, <a href="#privacy-individualization">individualization</a>, provisioning or other process that produced the value involved, used, provided, derived from, or similarly involved one or more <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifier(s)</a> or another distinctive identifier.</p>
+                <p>The generation, <a href="#privacy-individualization">individualization</a>, provisioning or other process that produced the value involved, used, provided, derived from, or similarly involved one or more <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifier(s)</a> or another Distinctive Identifier.</p>
               </li>
               <li>
                 <p>It is <a href="#allow-identifiers-cleared">clearable</a> but not <a href="#allow-persistent-data-cleared-with-cookies">along with cookies and other site data</a>.</p>
@@ -1898,20 +1898,20 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         <div class="note">
           <div class="note-title marker" aria-level="3" role="heading" id="h-note17"><span>Note</span></div>
           <p class="">
-            While <a href="#distinctive-identifier">Distinctive Identifiers</a> are usually <a href="#associable-by-entity">associable by the entity that generated them</a> they <em class="rfc2119" title="MUST">MUST</em> be <a href="#non-associable-by-application">non-associable by applications</a>. In other words, such correlation or association is only possible by the entity, such as an <a href="#privacy-individualization">individualization</a> server, that originally generated the <a href="#distinctive-identifier">Distinctive Identifier</a> values. Entities with access to the <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifier(s)</a> <em class="rfc2119" title="MUST NOT">MUST NOT</em> expose this capability to applications, as this would make resulting distinctive identifiers <a href="#associable-by-application">associable by the application</a>, and <em class="rfc2119" title="SHOULD">SHOULD</em> take care to avoid exposing such correlation to other entities or third parties.
+            While <a href="#distinctive-identifier">Distinctive Identifiers</a> are usually <a href="#associable-by-entity">associable by the entity that generated them</a> they <em class="rfc2119" title="MUST">MUST</em> be <a href="#non-associable-by-application">non-associable by applications</a>. In other words, such correlation or association is only possible by the entity, such as an <a href="#privacy-individualization">individualization</a> server, that originally generated the <a href="#distinctive-identifier">Distinctive Identifier</a> values. Entities with access to the <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifier(s)</a> <em class="rfc2119" title="MUST NOT">MUST NOT</em> expose this capability to applications, as this would make resulting Distinctive Identifiers <a href="#associable-by-application">associable by the application</a>, and <em class="rfc2119" title="SHOULD">SHOULD</em> take care to avoid exposing such correlation to other entities or third parties.
           </p>
         </div>
 
         <div class="note">
           <div class="note-title marker" aria-level="3" role="heading" id="h-note18"><span>Note</span></div>
-          <p class="">While a distinctive identifier is typically unique to a user or client device, an identifier does not need to be strictly unique to be distinctive. For example, an identifier shared among a small number of users could still be distinctive.
+          <p class="">While a Distinctive Identifier is typically unique to a user or client device, an identifier does not need to be strictly unique to be distinctive. For example, an identifier shared among a small number of users could still be distinctive.
           </p>
         </div>
 
         <div class="note">
           <div class="note-title marker" aria-level="3" role="heading" id="h-note19"><span>Note</span></div>
           <div class="">
-            <p>Examples of distinctive identifiers include but are not limited to:</p>
+            <p>Examples of Distinctive Identifiers include but are not limited to:</p>
             <ul>
               <li>
                 <p>A series of bytes that is included in key requests, different from the series of bytes included by other client devices, and based on or was acquired directly or indirectly using a <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifier</a>.</p>
@@ -1929,7 +1929,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                 <p>Such a value used to derive another value that is exposed even though the first value is not directly exposed.</p>
               </li>
               <li>
-                <p>A value derived from another distinctive identifier.</p>
+                <p>A value derived from another Distinctive Identifier.</p>
               </li>
               <li>
                 <p>A random value that was reported to a (i.e. <a href="#privacy-individualization">individualization</a>) server along with a <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifier</a> or provided by such a server after providing a <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifier</a>.</p>
@@ -1944,7 +1944,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                 <p>A value derived from a unique value embedded in the CDM binary or other file used by the CDM.</p>
               </li>
             </ul>
-            <p>Examples of things that are <em>not</em> distinctive identifiers:</p>
+            <p>Examples of things that are <em>not</em> Distinctive Identifiers:</p>
             <ul>
               <li>
                 <p>A public key shared among all copies of a given CDM version if the installed base is large.</p>
@@ -1956,19 +1956,19 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                 <p>A value that is not exposed, even in derived or similar ways, outside the client, including via <a href="#privacy-individualization">individualization</a> or similar.</p>
               </li>
               <li>
-                <p>Device-unique keys used in attestations between, for example, the video pipeline and the CDM when the CDM does not let these attestations further flow to the application and instead makes a new attestation on its own using a key that does not constitute a distinctive identifier.</p>
+                <p>Device-unique keys used in attestations between, for example, the video pipeline and the CDM when the CDM does not let these attestations further flow to the application and instead makes a new attestation on its own using a key that does not constitute a Distinctive Identifier.</p>
               </li>
               <li>
                 <p>A value that is fully cleared/clearable along with browsing data, such as cookies, after which it will be replaced by a value that is <a href="#non-associable">non-associable</a> (not just <a href="#non-associable-by-application">non-associable by applications</a>), even by a central server such as an <a href="#privacy-individualization">individualization</a> server, AND one or more of the following:</p>
                 <ul>
                   <li>
-                    <p>No <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifier</a> or distinctive identifier was involved in the generation of the value.</p>
+                    <p>No <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifier</a> or Distinctive Identifier was involved in the generation of the value.</p>
                   </li>
                   <li>
                     <p>It is a random value generated <em>without</em> inputs from the system.</p>
                   </li>
                   <li>
-                    <p>It is a value provided by a server without the use of or knowledge of another distinctive identifier.</p>
+                    <p>It is a value provided by a server without the use of or knowledge of another Distinctive Identifier.</p>
                   </li>
                 </ul>
               </li>


### PR DESCRIPTION
This is consistent with other uses and definitions. I don't remember why these weren't capitalized before.