### PR TITLE
Remove explanation of why domain is insufficient

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -3794,7 +3794,6 @@ interface MediaEncryptedEvent : Event {
               <p>User agents SHOULD ensure that users are fully informed and/or give explicit consent before a Key System that presents security concerns that are greater than other user agent features (e.g. DOM content) may be accessed by an <a def-id="origin"></a>.
               </p>
               <p>Such alerts and consent MUST be per <a def-id="origin"></a> to avoid valid uses enabling subsequent malicious access and MUST be per <a def-id="browsing-profile"></a>.
-                (A full <a def-id="origin"></a> MUST be used rather than just the domain because the protocol is important for security as described above.)
               </p>
               <p class="note">The restriction of the APIs defined in this specification to secure contexts ensures that a <a href="#network-attacks">network attacker</a> cannot exploit permissions granted to an unauthenticated origin.</p>
             </dd>
@@ -4063,7 +4062,6 @@ interface MediaEncryptedEvent : Event {
               <p>User agents MUST ensure that users are fully informed and/or give explicit consent before <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">using Distinctive Identifier(s) and Distinctive Permanent Identifier(s)</a>.
               </p>
               <p>Such alerts and consent MUST be per <a def-id="origin"></a> to avoid valid uses enabling subsequent malicious access and MUST be per <a def-id="browsing-profile"></a>.
-                (A full <a def-id="origin"></a> MUST be used rather than just the domain because the protocol is important for security as described above.)
               </p>
               <p class="note">The restriction of the APIs defined in this specification to secure contexts ensures that a <a href="#network-attacks">network attacker</a> cannot exploit permissions granted to an unauthenticated origin.</p>
             </dd>

--- a/index.html
+++ b/index.html
@@ -1271,7 +1271,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <a class="logo" href="https://www.w3.org/"><img width="72" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" alt="W3C"></a>
     </p>
     <h1 class="title p-name" id="title" property="dcterms:title">Encrypted Media Extensions</h1>
-    <h2 id="w3c-editor-s-draft-08-september-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2016-09-08">08 September 2016</time></h2>
+    <h2 id="w3c-editor-s-draft-09-september-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2016-09-09">09 September 2016</time></h2>
     <dl>
       <dt>This version:</dt>
       <dd><a class="u-url" href="https://w3c.github.io/encrypted-media/">https://w3c.github.io/encrypted-media/</a></dd>
@@ -6590,7 +6590,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
           <dd>
             <p>User agents <em class="rfc2119" title="SHOULD">SHOULD</em> ensure that users are fully informed and/or give explicit consent before a Key System that presents security concerns that are greater than other user agent features (e.g. DOM content) may be accessed by an <a href="https://www.w3.org/TR/html5/browsers.html#origin-0">origin</a>.
             </p>
-            <p>Such alerts and consent <em class="rfc2119" title="MUST">MUST</em> be per <a href="https://www.w3.org/TR/html5/browsers.html#origin-0">origin</a> to avoid valid uses enabling subsequent malicious access and <em class="rfc2119" title="MUST">MUST</em> be per <a href="#browsing-profile">browsing profile</a>. (A full <a href="https://www.w3.org/TR/html5/browsers.html#origin-0">origin</a> <em class="rfc2119" title="MUST">MUST</em> be used rather than just the domain because the protocol is important for security as described above.)
+            <p>Such alerts and consent <em class="rfc2119" title="MUST">MUST</em> be per <a href="https://www.w3.org/TR/html5/browsers.html#origin-0">origin</a> to avoid valid uses enabling subsequent malicious access and <em class="rfc2119" title="MUST">MUST</em> be per <a href="#browsing-profile">browsing profile</a>.
             </p>
             <div class="note">
               <div class="note-title marker" aria-level="5" role="heading" id="h-note133"><span>Note</span></div>
@@ -6885,7 +6885,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
           <dd>
             <p>User agents <em class="rfc2119" title="MUST">MUST</em> ensure that users are fully informed and/or give explicit consent before <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">using Distinctive Identifier(s) and Distinctive Permanent Identifier(s)</a>.
             </p>
-            <p>Such alerts and consent <em class="rfc2119" title="MUST">MUST</em> be per <a href="https://www.w3.org/TR/html5/browsers.html#origin-0">origin</a> to avoid valid uses enabling subsequent malicious access and <em class="rfc2119" title="MUST">MUST</em> be per <a href="#browsing-profile">browsing profile</a>. (A full <a href="https://www.w3.org/TR/html5/browsers.html#origin-0">origin</a> <em class="rfc2119" title="MUST">MUST</em> be used rather than just the domain because the protocol is important for security as described above.)
+            <p>Such alerts and consent <em class="rfc2119" title="MUST">MUST</em> be per <a href="https://www.w3.org/TR/html5/browsers.html#origin-0">origin</a> to avoid valid uses enabling subsequent malicious access and <em class="rfc2119" title="MUST">MUST</em> be per <a href="#browsing-profile">browsing profile</a>.
             </p>
             <div class="note">
               <div class="note-title marker" aria-level="5" role="heading" id="h-note137"><span>Note</span></div>


### PR DESCRIPTION
The "above" reference is unclear but probably referred to the TLS section for
the Security instance. While the "above" reference could be replaced, this
statement is probably unnecessary since secure origins are required and origin
is explicitly used in the requirement.