### PR TITLE
Clarify the summary in the identifier requirements section

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -3204,9 +3204,13 @@ interface MediaEncryptedEvent : Event {
             <li><p><a href="#limit-or-avoid-use-of-distinctive-identifiers-and-permanent-identifiers">Limit or Avoid use of Distinctive Identifiers and Permanent Identifiers</a>.</p></li>
             <li>
               <p>
-                All identifers that are not <a href="#permanent-identifier">Permanent Identifiers</a> MUST be <a href="#per-origin-per-profile-identifiers">unique per origin and profile</a> and <a href="#allow-identifiers-cleared">clearable</a>.</p>
-                They SHOULD be <a href="#encrypt-identifiers">encrypted</a> when exposed outside the client.
-              <p></p>
+                All identifers that are not <a href="#permanent-identifier">Permanent Identifiers</a> MUST be <a href="#per-origin-per-profile-identifiers">unique per origin and profile</a> and <a href="#allow-identifiers-cleared">clearable</a>.
+              </p>
+            </li>
+            <li>
+              <p>
+                All identifers SHOULD be <a href="#encrypt-identifiers">encrypted</a> when exposed outside the client.
+              </p>
             </li>
             <li><p><a def-id="distinctive-identifiers"></a> MUST be <a href="#encrypt-identifiers">encrypted</a> when exposed outside the client, <a href="#per-origin-per-profile-identifiers">unique per origin and profile</a>, and <a href="#allow-identifiers-cleared">clearable</a>.</p></li>
             <li><p><a def-id="distinctive-permanent-identifiers"></a> MUST be <a href="#encrypt-identifiers">encrypted</a> when exposed outside the client and MUST NOT be exposed to the application.</p></li>

--- a/index.html
+++ b/index.html
@@ -5903,9 +5903,13 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
             </li>
             <li>
               <p>
-                All identifers that are not <a href="#permanent-identifier">Permanent Identifiers</a> <em class="rfc2119" title="MUST">MUST</em> be <a href="#per-origin-per-profile-identifiers">unique per origin and profile</a> and <a href="#allow-identifiers-cleared">clearable</a>.</p>
-              They <em class="rfc2119" title="SHOULD">SHOULD</em> be <a href="#encrypt-identifiers">encrypted</a> when exposed outside the client.
-              <p></p>
+                All identifers that are not <a href="#permanent-identifier">Permanent Identifiers</a> <em class="rfc2119" title="MUST">MUST</em> be <a href="#per-origin-per-profile-identifiers">unique per origin and profile</a> and <a href="#allow-identifiers-cleared">clearable</a>.
+              </p>
+            </li>
+            <li>
+              <p>
+                All identifers <em class="rfc2119" title="SHOULD">SHOULD</em> be <a href="#encrypt-identifiers">encrypted</a> when exposed outside the client.
+              </p>
             </li>
             <li>
               <p><a href="#distinctive-identifier">Distinctive Identifiers</a> <em class="rfc2119" title="MUST">MUST</em> be <a href="#encrypt-identifiers">encrypted</a> when exposed outside the client, <a href="#per-origin-per-profile-identifiers">unique per origin and profile</a>, and <a href="#allow-identifiers-cleared">clearable</a>.</p>


### PR DESCRIPTION
The markup was incorrect, and "They" was ambiguous.
The new text is consistent with the referenced subsection.