### PR TITLE
Fix #333: Explicitly handle potentially-encrypted media data that does not contain Initialization Data

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -2704,7 +2704,19 @@ interface MediaKeyMessageEvent : Event {
           <p>In addition to the criteria specified in [[!HTML5]], an <a def-id="htmlmediaelement"></a> SHALL be considered a <a def-id="blocked-media-element"></a> if its <var>waiting for key</var> value is <code>true</code>.</p>
         </li>
         <li>
+          <p>When the user agent is ready to begin playback and has encountered an indication that the <a def-id="media-data"></a> may contain encrypted blocks during the <a def-id="resource-fetch-algorithm"></a>, the user agent SHALL run the <a href="#media-may-contain-encrypted-blocks">Media Data May Contain Encrypted Blocks</a> algorithm.</p>
+          <p class="note">
+            For some container formats, such indication is separate from <a def-id="initialization-data"></a>.
+          </p>
+          <p class="note">
+            The algorithm is to be run after parsing the relevant container data, including running the <a def-id="initdata-encountered-algorithm"></a> algorithm, but before decoding starts.
+          </p>
+        </li>
+        <li>
           <p>When the user agent encounters <a def-id="initialization-data"></a> in the <a def-id="media-data"></a> during the <a def-id="resource-fetch-algorithm"></a>, the user agent SHALL run the <a def-id="initdata-encountered-algorithm"></a> algorithm.</p>
+          <p class="note">
+            Some container formats may support encrypted media data that does not contain <a def-id="initialization-data"></a> and thus support media data that does not trigger this algorithm.
+          </p>
         </li>
         <li>
           <p>For each block of encrypted <a def-id="media-data"></a> encountered during the <a def-id="resource-fetch-algorithm"></a>, the user agent SHALL run the <a def-id="encrypted-block-encountered-algorithm"></a> algorithm in the order the encrypted blocks were encountered.</p>
@@ -2859,6 +2871,26 @@ interface MediaEncryptedEvent : Event {
       <section id="htmlmediaelement-algorithms">
         <h3>Algorithms</h3>
 
+        <section id="media-may-contain-encrypted-blocks">
+          <h4>Media Data May Contain Encrypted Blocks</h4>
+          <p>
+            The Potentially Encrypted Media Encountered algorithm pauses playback if the user agent requires specification of a <a>MediaKeys</a> object before playing the media data.
+          </p>
+          <p>The following steps are run:</p>
+          <ol>
+            <li>
+              <p>If the media element's <a def-id="mediaKeys-attribute"></a> attribute is null and the implementation requires specification of a <a>MediaKeys</a> object before decoding potentially-encrypted <a def-id="media-data"></a>, run the following steps:</p>
+              <p class="note">These steps may be reached when the application provides <a def-id="media-data"></a> before calling <a def-id="setMediaKeys"></a> to provide a <a>MediaKeys</a> object.
+                Selecting a <a def-id="cdm"></a> may affect the pipeline and/or decoders used, so some implementations may delay playback of media data that may contain encrypted blocks until a CDM is specified by passing a <a>MediaKeys</a> object to <a def-id="setMediaKeys"></a>.
+              </p>
+              <ol>
+                <li><p>Run the <a def-id="wait-for-key-algorithm"></a> algorithm on the media element.</p></li>
+                <li><p>Wait for a signal to resume playback.</p></li>
+              </ol>
+            </li>
+          </ol>
+        </section>
+
         <section id="initdata-encountered">
           <h4>Initialization Data Encountered</h4>
           <p>
@@ -2888,17 +2920,6 @@ interface MediaEncryptedEvent : Event {
                 Applications may retrieve the Initialization Data from an alternate source.
               </p>
             </li>
-            <li>
-              <p>If the media element's <a def-id="mediaKeys-attribute"></a> attribute is null and the implementation requires specification of a <a>MediaKeys</a> object before decoding potentially-encrypted <a def-id="media-data"></a>, run the following steps:</p>
-              <p class="note">These steps may be reached when the application provides <a def-id="media-data"></a> before calling <a def-id="setMediaKeys"></a> to provide a <a>MediaKeys</a> object.
-                Selecting a <a def-id="cdm"></a> may affect the pipeline and/or decoders used, so some implementations may delay playback of media data that may contain encrypted blocks until a CDM is specified by passing a <a>MediaKeys</a> object to <a def-id="setMediaKeys"></a>.
-              </p>
-              <ol>
-                <li><p>Run the <a def-id="wait-for-key-algorithm"></a> algorithm on the media element.</p></li>
-                <li><p>Wait for a signal to resume playback.</p></li>
-              </ol>
-            </li>
-            <li><p><i>Continue Normal Flow</i>: Continue with the existing media element's <a def-id="resource-fetch-algorithm"></a>.</p></li>
           </ol>
         </section>
 

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -2872,7 +2872,7 @@ interface MediaEncryptedEvent : Event {
         <section id="media-may-contain-encrypted-blocks">
           <h4>Media Data May Contain Encrypted Blocks</h4>
           <p>
-            The Potentially Encrypted Media Encountered algorithm pauses playback if the user agent requires specification of a <a>MediaKeys</a> object before playing the media data.
+            The Media Data May Contain Encrypted Blocks algorithm pauses playback if the user agent requires specification of a <a>MediaKeys</a> object before playing the media data.
           </p>
           <p>The following steps are run:</p>
           <ol>

--- a/index.html
+++ b/index.html
@@ -5621,7 +5621,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
         <h4 id="h-media-may-contain-encrypted-blocks" resource="#h-media-may-contain-encrypted-blocks"><span property="xhv:role" resource="xhv:heading"><span class="secno">7.3.1 </span>Media Data May Contain Encrypted Blocks</span>
         </h4>
         <p>
-          The Potentially Encrypted Media Encountered algorithm pauses playback if the user agent requires specification of a <a href="#idl-def-mediakeys" class="internalDFN" data-link-type="dfn"><code>MediaKeys</code></a> object before playing the media data.
+          The Media Data May Contain Encrypted Blocks algorithm pauses playback if the user agent requires specification of a <a href="#idl-def-mediakeys" class="internalDFN" data-link-type="dfn"><code>MediaKeys</code></a> object before playing the media data.
         </p>
         <p>The following steps are run:</p>
         <ol>

--- a/index.html
+++ b/index.html
@@ -1396,7 +1396,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <a class="logo" href="https://www.w3.org/"><img width="72" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" alt="W3C"></a>
     </p>
     <h1 class="title p-name" id="title" property="dcterms:title">Encrypted Media Extensions</h1>
-    <h2 id="w3c-editor-s-draft-17-october-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2016-10-17">17 October 2016</time></h2>
+    <h2 id="w3c-editor-s-draft-24-october-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2016-10-24">24 October 2016</time></h2>
     <dl>
       <dt>This version:</dt>
       <dd><a class="u-url" href="https://w3c.github.io/encrypted-media/">https://w3c.github.io/encrypted-media/</a></dd>
@@ -1567,11 +1567,12 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
           <li class="tocline"><a href="#htmlmediaelement-events" class="tocxref"><span class="secno">7.2 </span>Event Summary</a></li>
           <li class="tocline"><a href="#htmlmediaelement-algorithms" class="tocxref"><span class="secno">7.3 </span>Algorithms</a>
             <ol class="toc">
-              <li class="tocline"><a href="#initdata-encountered" class="tocxref"><span class="secno">7.3.1 </span>Initialization Data Encountered</a></li>
-              <li class="tocline"><a href="#encrypted-block-encountered" class="tocxref"><span class="secno">7.3.2 </span>Encrypted Block Encountered</a></li>
-              <li class="tocline"><a href="#attempt-to-decrypt" class="tocxref"><span class="secno">7.3.3 </span>Attempt to Decrypt</a></li>
-              <li class="tocline"><a href="#wait-for-key" class="tocxref"><span class="secno">7.3.4 </span>Wait for Key</a></li>
-              <li class="tocline"><a href="#resume-playback" class="tocxref"><span class="secno">7.3.5 </span>Attempt to Resume Playback If Necessary</a></li>
+              <li class="tocline"><a href="#media-may-contain-encrypted-blocks" class="tocxref"><span class="secno">7.3.1 </span>Media Data May Contain Encrypted Blocks</a></li>
+              <li class="tocline"><a href="#initdata-encountered" class="tocxref"><span class="secno">7.3.2 </span>Initialization Data Encountered</a></li>
+              <li class="tocline"><a href="#encrypted-block-encountered" class="tocxref"><span class="secno">7.3.3 </span>Encrypted Block Encountered</a></li>
+              <li class="tocline"><a href="#attempt-to-decrypt" class="tocxref"><span class="secno">7.3.4 </span>Attempt to Decrypt</a></li>
+              <li class="tocline"><a href="#wait-for-key" class="tocxref"><span class="secno">7.3.5 </span>Wait for Key</a></li>
+              <li class="tocline"><a href="#resume-playback" class="tocxref"><span class="secno">7.3.6 </span>Attempt to Resume Playback If Necessary</a></li>
             </ol>
           </li>
           <li class="tocline"><a href="#media-element-restictions" class="tocxref"><span class="secno">7.4 </span>Media Element Restrictions</a></li>
@@ -5284,12 +5285,33 @@ dictionary <span class="idlDictionaryID">MediaKeyMessageEventInit</span> : <span
         <p>In addition to the criteria specified in [<cite><a class="bibref" href="#bib-HTML5">HTML5</a></cite>], an <code><a href="https://www.w3.org/TR/html5/embedded-content-0.html#htmlmediaelement">HTMLMediaElement</a></code> <em class="rfc2119" title="SHALL">SHALL</em> be considered a <a href="https://www.w3.org/TR/html5/embedded-content-0.html#blocked-media-element">blocked media element</a> if its <var>waiting for key</var> value is <code>true</code>.</p>
       </li>
       <li>
+        <p>When the user agent is ready to begin playback and has encountered an indication that the <a href="https://www.w3.org/TR/html5/embedded-content-0.html#media-data">media data</a> may contain encrypted blocks during the <a href="https://www.w3.org/TR/html5/embedded-content-0.html#concept-media-load-resource">resource fetch algorithm</a>, the user agent <em class="rfc2119" title="SHALL">SHALL</em> run the <a href="#media-may-contain-encrypted-blocks">Media Data May Contain Encrypted Blocks</a> algorithm.</p>
+        <div class="note">
+          <div class="note-title marker" aria-level="3" role="heading" id="h-note91"><span>Note</span></div>
+          <p class="">
+            For some container formats, such indication is separate from <a href="#initialization-data">Initialization Data</a>.
+          </p>
+        </div>
+        <div class="note">
+          <div class="note-title marker" aria-level="3" role="heading" id="h-note92"><span>Note</span></div>
+          <p class="">
+            The algorithm is to be run after parsing the relevant container data, including running the <a href="#initdata-encountered">Initialization Data Encountered</a> algorithm, but before decoding starts.
+          </p>
+        </div>
+      </li>
+      <li>
         <p>When the user agent encounters <a href="#initialization-data">Initialization Data</a> in the <a href="https://www.w3.org/TR/html5/embedded-content-0.html#media-data">media data</a> during the <a href="https://www.w3.org/TR/html5/embedded-content-0.html#concept-media-load-resource">resource fetch algorithm</a>, the user agent <em class="rfc2119" title="SHALL">SHALL</em> run the <a href="#initdata-encountered">Initialization Data Encountered</a> algorithm.</p>
+        <div class="note">
+          <div class="note-title marker" aria-level="3" role="heading" id="h-note93"><span>Note</span></div>
+          <p class="">
+            Some container formats may support encrypted media data that does not contain <a href="#initialization-data">Initialization Data</a> and thus support media data that does not trigger this algorithm.
+          </p>
+        </div>
       </li>
       <li>
         <p>For each block of encrypted <a href="https://www.w3.org/TR/html5/embedded-content-0.html#media-data">media data</a> encountered during the <a href="https://www.w3.org/TR/html5/embedded-content-0.html#concept-media-load-resource">resource fetch algorithm</a>, the user agent <em class="rfc2119" title="SHALL">SHALL</em> run the <a href="#encrypted-block-encountered">Encrypted Block Encountered</a> algorithm in the order the encrypted blocks were encountered.</p>
         <div class="note">
-          <div class="note-title marker" aria-level="3" role="heading" id="h-note91"><span>Note</span></div>
+          <div class="note-title marker" aria-level="3" role="heading" id="h-note94"><span>Note</span></div>
           <p class="">The above step provides flexibility for user agent implementations to perform decryption at any time after an encrypted block is encountered before it is needed for playback.</p>
         </div>
       </li>
@@ -5336,13 +5358,13 @@ dictionary <span class="idlDictionaryID">MediaKeyMessageEventInit</span> : <span
               <!-- </a> -->to use when decrypting media data during playback.</p>
 
             <div class="note">
-              <div class="note-title marker" aria-level="4" role="heading" id="h-note92"><span>Note</span></div>
+              <div class="note-title marker" aria-level="4" role="heading" id="h-note95"><span>Note</span></div>
               <p class="">Support for clearing or replacing the associated
                 <!-- Restore when https://github.com/w3c/respec/issues/893 is fixed. <a> -->MediaKeys
                 <!-- </a> -->object during playback is a quality of implementation issue. In many cases it will result in a bad user experience or rejected promise.</p>
             </div>
             <div class="note">
-              <div class="note-title marker" aria-level="4" role="heading" id="h-note93"><span>Note</span></div>
+              <div class="note-title marker" aria-level="4" role="heading" id="h-note96"><span>Note</span></div>
               <p class="">Some implementations may only support decrypting media data provided via Media Source Extensions [<cite><a class="bibref" href="#bib-MEDIA-SOURCE">MEDIA-SOURCE</a></cite>]. This is not reflected in the results of calling <code><a href="#dom-navigator-requestmediakeysystemaccess">requestMediaKeySystemAccess()</a></code>.
               </p>
             </div>
@@ -5417,7 +5439,7 @@ dictionary <span class="idlDictionaryID">MediaKeyMessageEventInit</span> : <span
                       <li>
                         <p>If the association cannot currently be removed, let this object's <var>attaching media keys</var> value be false and reject <var>promise</var> with an <code><a href="#dfn-InvalidStateError">InvalidStateError</a></code>.</p>
                         <div class="note">
-                          <div class="note-title marker" aria-level="4" role="heading" id="h-note94"><span>Note</span></div>
+                          <div class="note-title marker" aria-level="4" role="heading" id="h-note97"><span>Note</span></div>
                           <p class="">For example, some implementations may not allow removal during playback.</p>
                         </div>
                       </li>
@@ -5578,7 +5600,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
             <td>The user agent encounters <a href="#initialization-data">Initialization Data</a> in the <a href="https://www.w3.org/TR/html5/embedded-content-0.html#media-data">media data</a>.</td>
             <td>The element's <code><a href="https://www.w3.org/TR/html5/embedded-content-0.html#dom-media-readystate">readyState</a></code> is equal to <code><a href="https://www.w3.org/TR/html5/embedded-content-0.html#dom-media-have_metadata">HAVE_METADATA</a></code> or greater.
               <div class="note">
-                <div class="note-title marker" aria-level="4" role="heading" id="h-note95"><span>Note</span></div>
+                <div class="note-title marker" aria-level="4" role="heading" id="h-note98"><span>Note</span></div>
                 <p class="">It is possible that the element is playing or has played.</p>
               </div>
             </td>
@@ -5597,8 +5619,35 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
       <h3 id="h-htmlmediaelement-algorithms" resource="#h-htmlmediaelement-algorithms"><span property="xhv:role" resource="xhv:heading"><span class="secno">7.3 </span>Algorithms</span>
       </h3>
 
+      <section id="media-may-contain-encrypted-blocks" typeof="bibo:Chapter" resource="#media-may-contain-encrypted-blocks" property="bibo:hasPart">
+        <h4 id="h-media-may-contain-encrypted-blocks" resource="#h-media-may-contain-encrypted-blocks"><span property="xhv:role" resource="xhv:heading"><span class="secno">7.3.1 </span>Media Data May Contain Encrypted Blocks</span>
+        </h4>
+        <p>
+          The Potentially Encrypted Media Encountered algorithm pauses playback if the user agent requires specification of a <a href="#idl-def-mediakeys" class="internalDFN" data-link-type="dfn"><code>MediaKeys</code></a> object before playing the media data.
+        </p>
+        <p>The following steps are run:</p>
+        <ol>
+          <li>
+            <p>If the media element's <code><a href="#dom-mediakeys">mediaKeys</a></code> attribute is null and the implementation requires specification of a <a href="#idl-def-mediakeys" class="internalDFN" data-link-type="dfn"><code>MediaKeys</code></a> object before decoding potentially-encrypted <a href="https://www.w3.org/TR/html5/embedded-content-0.html#media-data">media data</a>, run the following steps:</p>
+            <div class="note">
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note99"><span>Note</span></div>
+              <p class="">These steps may be reached when the application provides <a href="https://www.w3.org/TR/html5/embedded-content-0.html#media-data">media data</a> before calling <code><a href="#dom-htmlmediaelement-setmediakeys">setMediaKeys()</a></code> to provide a <a href="#idl-def-mediakeys" class="internalDFN" data-link-type="dfn"><code>MediaKeys</code></a> object. Selecting a <a href="#cdm">CDM</a> may affect the pipeline and/or decoders used, so some implementations may delay playback of media data that may contain encrypted blocks until a CDM is specified by passing a <a href="#idl-def-mediakeys" class="internalDFN" data-link-type="dfn"><code>MediaKeys</code></a> object to <code><a href="#dom-htmlmediaelement-setmediakeys">setMediaKeys()</a></code>.
+              </p>
+            </div>
+            <ol>
+              <li>
+                <p>Run the <a href="#wait-for-key">Wait for Key</a> algorithm on the media element.</p>
+              </li>
+              <li>
+                <p>Wait for a signal to resume playback.</p>
+              </li>
+            </ol>
+          </li>
+        </ol>
+      </section>
+
       <section id="initdata-encountered" typeof="bibo:Chapter" resource="#initdata-encountered" property="bibo:hasPart">
-        <h4 id="h-initdata-encountered" resource="#h-initdata-encountered"><span property="xhv:role" resource="xhv:heading"><span class="secno">7.3.1 </span>Initialization Data Encountered</span>
+        <h4 id="h-initdata-encountered" resource="#h-initdata-encountered"><span property="xhv:role" resource="xhv:heading"><span class="secno">7.3.2 </span>Initialization Data Encountered</span>
         </h4>
         <p>
           The Initialization Data Encountered algorithm queues an <code><a href="#dom-evt-encrypted">encrypted</a></code> event for <a href="#initialization-data">Initialization Data</a> encounterd in the <a href="https://www.w3.org/TR/html5/embedded-content-0.html#media-data">media data</a>.
@@ -5622,7 +5671,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
               </li>
             </ol>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note96"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note100"><span>Note</span></div>
               <p class="">While the media element may allow loading of "Optionally-blockable Content" [<cite><a class="bibref" href="#bib-MIXED-CONTENT">MIXED-CONTENT</a></cite>], the user agent <em class="rfc2119" title="MUST NOT">MUST NOT</em> expose Initialization Data from such media data to the application.</p>
             </div>
           </li>
@@ -5636,39 +5685,20 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
               </li>
             </ul>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note97"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note101"><span>Note</span></div>
               <p class=""><code><a href="https://www.w3.org/TR/html5/embedded-content-0.html#dom-media-readystate">readyState</a></code> is <em>not</em> changed and no algorithms are aborted. This event merely provides information.</p>
             </div>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note98"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note102"><span>Note</span></div>
               <p class="">The <code><a href="#dom-mediaencryptedevent-initdata">initData</a></code> attribute will be null if the media data is <em>not</em> <a href="https://www.w3.org/TR/html5/infrastructure.html#cors-same-origin">CORS-same-origin</a> or is <a href="#mixed-content">mixed content</a>. Applications may retrieve the Initialization Data from an alternate source.
               </p>
             </div>
-          </li>
-          <li>
-            <p>If the media element's <code><a href="#dom-mediakeys">mediaKeys</a></code> attribute is null and the implementation requires specification of a <a href="#idl-def-mediakeys" class="internalDFN" data-link-type="dfn"><code>MediaKeys</code></a> object before decoding potentially-encrypted <a href="https://www.w3.org/TR/html5/embedded-content-0.html#media-data">media data</a>, run the following steps:</p>
-            <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note99"><span>Note</span></div>
-              <p class="">These steps may be reached when the application provides <a href="https://www.w3.org/TR/html5/embedded-content-0.html#media-data">media data</a> before calling <code><a href="#dom-htmlmediaelement-setmediakeys">setMediaKeys()</a></code> to provide a <a href="#idl-def-mediakeys" class="internalDFN" data-link-type="dfn"><code>MediaKeys</code></a> object. Selecting a <a href="#cdm">CDM</a> may affect the pipeline and/or decoders used, so some implementations may delay playback of media data that may contain encrypted blocks until a CDM is specified by passing a <a href="#idl-def-mediakeys" class="internalDFN" data-link-type="dfn"><code>MediaKeys</code></a> object to <code><a href="#dom-htmlmediaelement-setmediakeys">setMediaKeys()</a></code>.
-              </p>
-            </div>
-            <ol>
-              <li>
-                <p>Run the <a href="#wait-for-key">Wait for Key</a> algorithm on the media element.</p>
-              </li>
-              <li>
-                <p>Wait for a signal to resume playback.</p>
-              </li>
-            </ol>
-          </li>
-          <li>
-            <p><i>Continue Normal Flow</i>: Continue with the existing media element's <a href="https://www.w3.org/TR/html5/embedded-content-0.html#concept-media-load-resource">resource fetch algorithm</a>.</p>
           </li>
         </ol>
       </section>
 
       <section id="encrypted-block-encountered" typeof="bibo:Chapter" resource="#encrypted-block-encountered" property="bibo:hasPart">
-        <h4 id="h-encrypted-block-encountered" resource="#h-encrypted-block-encountered"><span property="xhv:role" resource="xhv:heading"><span class="secno">7.3.2 </span>Encrypted Block Encountered</span>
+        <h4 id="h-encrypted-block-encountered" resource="#h-encrypted-block-encountered"><span property="xhv:role" resource="xhv:heading"><span class="secno">7.3.3 </span>Encrypted Block Encountered</span>
         </h4>
         <p>
           The Encrypted Block Encountered algorithm queues a block of encrypted media data for decryption and attempts to decrypt if possible.
@@ -5688,7 +5718,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
       </section>
 
       <section id="attempt-to-decrypt" typeof="bibo:Chapter" resource="#attempt-to-decrypt" property="bibo:hasPart">
-        <h4 id="h-attempt-to-decrypt" resource="#h-attempt-to-decrypt"><span property="xhv:role" resource="xhv:heading"><span class="secno">7.3.3 </span>Attempt to Decrypt</span>
+        <h4 id="h-attempt-to-decrypt" resource="#h-attempt-to-decrypt"><span property="xhv:role" resource="xhv:heading"><span class="secno">7.3.4 </span>Attempt to Decrypt</span>
         </h4>
         <p>
           The Attempt to Decrypt algorithm attempts to decrypt media data that is queued for decryption.
@@ -5710,7 +5740,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
               <li>
                 <p>If <var>cdm</var> is no longer usable for any reason, run the following steps:</p>
                 <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note100"><span>Note</span></div>
+                  <div class="note-title marker" aria-level="5" role="heading" id="h-note103"><span>Note</span></div>
                   <p class="">These steps are intended to be run on unrecoverable failures of the CDM.</p>
                 </div>
                 <ol>
@@ -5728,7 +5758,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
               <li>
                 <p>If there is at least one <a href="#idl-def-mediakeysession" class="internalDFN" data-link-type="dfn"><code>MediaKeySession</code></a> created by the <var>media keys</var> that is not <a href="#media-key-session-closed">closed</a>, run the following steps:</p>
                 <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note101"><span>Note</span></div>
+                  <div class="note-title marker" aria-level="5" role="heading" id="h-note104"><span>Note</span></div>
                   <p class="">This check ensures the <var>cdm</var> has finished loading and is a prerequisite for a matching key being available.</p>
                 </div>
                 <ol>
@@ -5738,7 +5768,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
                   <li>
                     <p>Let the <var>block key ID</var> be the key ID of <var>block</var>.</p>
                     <div class="note">
-                      <div class="note-title marker" aria-level="5" role="heading" id="h-note102"><span>Note</span></div>
+                      <div class="note-title marker" aria-level="5" role="heading" id="h-note105"><span>Note</span></div>
                       <p class="">The key ID is generally specified by the container.</p>
                     </div>
                   </li>
@@ -5755,7 +5785,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
                         <p>If any of the <var>available keys</var> corresponds to the <var>block key ID</var> and is <a href="#usable-for-decryption">usable for decryption</a>, let <var>session</var> be a
                           <a href="#idl-def-mediakeysession" class="internalDFN" data-link-type="dfn"><code>MediaKeySession</code></a> object containing that key and let <var>block key</var> be that key.</p>
                         <div class="note">
-                          <div class="note-title marker" aria-level="5" role="heading" id="h-note103"><span>Note</span></div>
+                          <div class="note-title marker" aria-level="5" role="heading" id="h-note106"><span>Note</span></div>
                           <p class="">If multiple sessions contain a key that is <a href="#usable-for-decryption">usable for decryption</a> for the <var>block key ID</var>, which session and key to use is <a href="#key-system">Key System</a>-dependent.</p>
                         </div>
                       </li>
@@ -5783,7 +5813,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
                               </li>
                             </ol>
                             <div class="note">
-                              <div class="note-title marker" aria-level="5" role="heading" id="h-note104"><span>Note</span></div>
+                              <div class="note-title marker" aria-level="5" role="heading" id="h-note107"><span>Note</span></div>
                               <p class="">
                                 Implementations <em class="rfc2119" title="MAY">MAY</em> optimize the times at which this step is executed provided the recorded key usage times remain accurate to within <var>key usage accuracy</var>.
                               </p>
@@ -5818,7 +5848,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
                                   <li>
                                     <p>Process the decrypted block as normal.</p>
                                     <div class="note">
-                                      <div class="note-title marker" aria-level="5" role="heading" id="h-note105"><span>Note</span></div>
+                                      <div class="note-title marker" aria-level="5" role="heading" id="h-note108"><span>Note</span></div>
                                       <p class="">In other words, decode the block.</p>
                                     </div>
                                   </li>
@@ -5830,13 +5860,13 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
                               </dd>
                             </dl>
                             <div class="note">
-                              <div class="note-title marker" aria-level="5" role="heading" id="h-note106"><span>Note</span></div>
+                              <div class="note-title marker" aria-level="5" role="heading" id="h-note109"><span>Note</span></div>
                               <p class="">Not all decryption problems (i.e. using the wrong key) will result in a decryption failure. In such cases, no error is fired here but one may be fired during decode.</p>
                             </div>
                           </li>
                         </ol>
                         <div class="note">
-                          <div class="note-title marker" aria-level="5" role="heading" id="h-note107"><span>Note</span></div>
+                          <div class="note-title marker" aria-level="5" role="heading" id="h-note110"><span>Note</span></div>
                           <p class="">Otherwise, there is no key for the <var>block key ID</var> in any session so continue.</p>
                         </div>
                       </li>
@@ -5849,7 +5879,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
           <li>
             <p>Run the following steps:</p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note108"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note111"><span>Note</span></div>
               <p class="">These steps are reached when there is no key that is <a href="#usable-for-decryption">usable for decryption</a> for <var>block</var>.</p>
             </div>
             <ol>
@@ -5861,7 +5891,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
         </ol>
 
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note109"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note112"><span>Note</span></div>
           <div class="">
             <p>For frame-based encryption, this may be implemented as follows when the media element attempts to decode a frame as part of the <a href="https://www.w3.org/TR/html5/embedded-content-0.html#concept-media-load-resource">resource fetch algorithm</a>:</p>
             <ol>
@@ -5889,7 +5919,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
       </section>
 
       <section id="wait-for-key" typeof="bibo:Chapter" resource="#wait-for-key" property="bibo:hasPart">
-        <h4 id="h-wait-for-key" resource="#h-wait-for-key"><span property="xhv:role" resource="xhv:heading"><span class="secno">7.3.4 </span>Wait for Key</span>
+        <h4 id="h-wait-for-key" resource="#h-wait-for-key"><span property="xhv:role" resource="xhv:heading"><span class="secno">7.3.5 </span>Wait for Key</span>
         </h4>
         <p>
           The Wait for Key algorithm queues a <code><a href="#dom-evt-waitingforkey">waitingforkey</a></code> event and updates <code><a href="https://www.w3.org/TR/html5/embedded-content-0.html#dom-media-readystate">readyState</a></code>. It should only be called when the <code><a href="https://www.w3.org/TR/html5/embedded-content-0.html#htmlmediaelement">HTMLMediaElement</a></code> object is <a href="https://www.w3.org/TR/html5/embedded-content-0.html#potentially-playing">potentially playing</a> and its <code><a href="https://www.w3.org/TR/html5/embedded-content-0.html#dom-media-readystate">readyState</a></code> is equal to <code><a href="https://www.w3.org/TR/html5/embedded-content-0.html#dom-media-have_future_data">HAVE_FUTURE_DATA</a></code> or greater. Requests to run this algorithm include a target <code><a href="https://www.w3.org/TR/html5/embedded-content-0.html#htmlmediaelement">HTMLMediaElement</a></code> object.
@@ -5905,7 +5935,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
           <li>
             <p>Set the <var>media element</var>'s <var>waiting for key</var> value to <code>true</code>.</p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note110"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note113"><span>Note</span></div>
               <p class="">As a result of the above step, the media element will become a <a href="https://www.w3.org/TR/html5/embedded-content-0.html#blocked-media-element">blocked media element</a> if it wasn't already. In that case, the media element will stop playback.</p>
             </div>
           </li>
@@ -5922,7 +5952,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
       </section>
 
       <section id="resume-playback" typeof="bibo:Chapter" resource="#resume-playback" property="bibo:hasPart">
-        <h4 id="h-resume-playback" resource="#h-resume-playback"><span property="xhv:role" resource="xhv:heading"><span class="secno">7.3.5 </span>Attempt to Resume Playback If Necessary</span>
+        <h4 id="h-resume-playback" resource="#h-resume-playback"><span property="xhv:role" resource="xhv:heading"><span class="secno">7.3.6 </span>Attempt to Resume Playback If Necessary</span>
         </h4>
         <p>
           The Attempt to Resume Playback If Necessary algorithm resumes playback if the media element is blocked waiting for a key and necessary key is currently <a href="#usable-for-decryption">usable for decryption</a> Requests to run this algorithm include a target <code><a href="https://www.w3.org/TR/html5/embedded-content-0.html#htmlmediaelement">HTMLMediaElement</a></code> object.
@@ -5944,7 +5974,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
               <li>
                 <p>Set the <var>media element</var>'s <var>waiting for key</var> value to <code>false</code>.</p>
                 <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note111"><span>Note</span></div>
+                  <div class="note-title marker" aria-level="5" role="heading" id="h-note114"><span>Note</span></div>
                   <p class="">As a result of the above step, the media element may no longer be a <a href="https://www.w3.org/TR/html5/embedded-content-0.html#blocked-media-element">blocked media element</a> and thus playback may resume.</p>
                 </div>
               </li>
@@ -5954,7 +5984,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
                   <code><a href="https://www.w3.org/TR/html5/embedded-content-0.html#dom-media-have_enough_data">HAVE_ENOUGH_DATA</a></code> as <code><a href="https://www.w3.org/TR/html5/embedded-content-0.html#ready-states">appropriate</a></code>.
                 </p>
                 <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note112"><span>Note</span></div>
+                  <div class="note-title marker" aria-level="5" role="heading" id="h-note115"><span>Note</span></div>
                   <div class="">
                     <p>
                       States beyond <code><a href="https://www.w3.org/TR/html5/embedded-content-0.html#dom-media-have_current_data">HAVE_CURRENT_DATA</a></code> and the <code><a href="https://www.w3.org/TR/html5/embedded-content-0.html#event-media-canplaythrough">canplaythrough</a></code> event do not (or are unlikely to) consider key availability beyond the current key.
@@ -6113,7 +6143,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
       <p>The use of identifiers, especially <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">Distinctive Identifier(s) or Distinctive Permanent Identifier(s)</a>, by implementations presents a privacy concern. This section defines requirements for avoiding or at least mitigating such concerns. The requirements for <a href="#exposed-value-requirements">Values Exposed to the Application</a> also apply to identifiers exposed to the application.
       </p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note113"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note116"><span>Note</span></div>
         <div class="">
           <p>In summary:</p>
           <ul>
@@ -6152,14 +6182,14 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
           <li>
             <p>Implementations <em class="rfc2119" title="SHOULD">SHOULD</em> avoid <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">use of Distinctive Identifier(s) or Distinctive Permanent Identifier(s)</a>.</p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note114"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note117"><span>Note</span></div>
               <p class="">For example, use identifiers or other values that apply to a group of clients or devices rather than individual clients.</p>
             </div>
           </li>
           <li>
             <p>Implementations <em class="rfc2119" title="SHOULD">SHOULD</em> only <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">use Distinctive Identifier(s) or Distinctive Permanent Identifier(s)</a> when necessary to enforce the policies related to the specific CDM instance and session.</p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note115"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note118"><span>Note</span></div>
               <p class="">For example, <code><a href="#idl-def-MediaKeySessionType.temporary">"temporary"</a></code> and <code><a href="#idl-def-MediaKeySessionType.persistent-license">"persistent-license"</a></code> sessions may have different requirements.</p>
             </div>
           </li>
@@ -6168,7 +6198,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
               Implementations that <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">use Distinctive Identifier(s) or Distinctive Permanent Identifier(s)</a> <em class="rfc2119" title="SHOULD">SHOULD</em> support the option to not use them. Implementations with such support <em class="rfc2119" title="SHOULD">SHOULD</em> expose the ability for the user to select this option.
             </p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note116"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note119"><span>Note</span></div>
               <div class="">
                 <p>
                   When supported, applications can select for this mode using <code><a href="#dom-mediakeysystemconfiguration-distinctiveidentifier">distinctiveIdentifier</a></code> = <code><a href="#idl-def-MediaKeysRequirement.not-allowed">"not-allowed"</a></code>. Selecting such an option may affect the results of the <code><a href="#dom-navigator-requestmediakeysystemaccess">requestMediaKeySystemAccess()</a></code> call and/or the license requests that are generated from subsequently generated sessions.
@@ -6189,7 +6219,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
           <a href="#distinctive-identifier">Distinctive Identifiers</a> and <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifiers</a> <em class="rfc2119" title="MUST">MUST</em> be encrypted at the message exchange level when exposed outside the client. All other identifiers <em class="rfc2119" title="SHOULD">SHOULD</em> be encrypted at the message exchange level when exposed outside the client. The encryption <em class="rfc2119" title="MUST">MUST</em> ensure that any two instances of the identifier ciphertext are <a href="#associable-by-entity">associable</a> only by an entity in possession of the decryption key.
         </p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note117"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note120"><span>Note</span></div>
           <div class="">
             <p>Identifiers may be exposed in the following ways:</p>
             <ul>
@@ -6210,12 +6240,12 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
         </p>
         <p>The server <em class="rfc2119" title="MUST NOT">MUST NOT</em> expose a <a href="#distinctive-identifier">Distinctive Identifier</a> to any entity other than the CDM that sent it.</p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note118"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note121"><span>Note</span></div>
           <p class="">Specifically, it should not be provided to the application or included unencrypted in messages to the CDM. This can be accomplished by encrypting the identifier or message with the identifier or such that it is only decryptable by that specific CDM.
           </p>
         </div>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note119"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note122"><span>Note</span></div>
           <div class="">
             <p>Among other things, this means that:</p>
             <ul>
@@ -6240,7 +6270,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
           All identifiers except <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifiers</a> <em class="rfc2119" title="MUST">MUST</em> be unique per <a href="https://www.w3.org/TR/html5/browsers.html#origin-0">origin</a> and <a href="#browsing-profile">browsing profile</a>. See <a href="#per-origin-per-profile-values" class="sec-ref"><span class="secno">8.2.1</span> <span class="sec-title">Use Per-Origin Per-Profile Values</span></a>.
         </p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note120"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note123"><span>Note</span></div>
           <div class="">
             <p>This includes but is not limited to <a href="#distinctive-identifier">Distinctive Identifiers</a>.</p>
             <p><a href="#distinctive-permanent-identifier">Distinctive Permanent Identifiers</a> <em class="rfc2119" title="MUST NOT">MUST NOT</em> be exposed to the application or origin.</p>
@@ -6255,7 +6285,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
           All identifiers, including <a href="#distinctive-identifier">Distinctive Identifiers</a>, exposed by the implementation to applications, even in encrypted form, <em class="rfc2119" title="MUST">MUST</em> be <a href="#non-associable-by-application">non-associable by application(s)</a> across <a href="https://www.w3.org/TR/html5/browsers.html#origin-0">origins</a>, <a href="#browsing-profile">browsing profiles</a>, and <a href="#allow-identifiers-cleared">clearing of identifiers</a>.
         </p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note121"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note124"><span>Note</span></div>
           <p class="">
             For all such identifiers, it <em class="rfc2119" title="MUST NOT">MUST NOT</em> be possible for one or more applications, including related license or other servers to achieve such correlation or association.
           </p>
@@ -6286,7 +6316,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
       <p>This process <em class="rfc2119" title="MUST">MUST</em> be performed either <a href="#direct-individualization">directly by the user agent</a> or <a href="#app-assisted-individualization">through the application</a>. The mechanisms, flow, and restrictions for the two types of individualization are different, as described in the following sections. Which method is used depends on the CDM implementation and application of the requirements of this specification, especially those below.
       </p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note122"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note125"><span>Note</span></div>
         <p class="">
           <code><a href="#dom-mediakeysystemconfiguration-distinctiveidentifier">distinctiveIdentifier</a></code> controls whether <a href="#distinctive-identifier">Distinctive Identifiers</a> and <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifiers</a> may be <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">used</a>, including for individualization. Specifically, such identifiers may only be <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">used</a> when the value of the <code><a href="#dom-mediakeysystemconfiguration-distinctiveidentifier">distinctiveIdentifier</a></code> member of the <a href="#idl-def-mediakeysystemaccess" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemAccess</code></a> used to create the <a href="#idl-def-mediakeys" class="internalDFN" data-link-type="dfn"><code>MediaKeys</code></a> object is <code><a href="#idl-def-MediaKeysRequirement.required">"required"</a></code>.
         </p>
@@ -6299,7 +6329,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
           Direct Individualization is performed between the <a href="#cdm">CDM</a> and an origin- and application-independent server. Although the server is origin-independent, the result of the individualization enables the CDM to provide origin-specific identifiers per the other requirements of this specification. The process <em class="rfc2119" title="MUST">MUST</em> be performed by the user agent and <em class="rfc2119" title="MUST NOT">MUST NOT</em> use the APIs defined in this specification.
         </p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note123"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note126"><span>Note</span></div>
           <p class="">For example, such a process may initialize a client device and/or obtain a <a href="#per-origin-per-profile-identifiers">per-origin</a> <a href="#allow-identifiers-cleared">clearable</a> identifier for <a href="#per-origin-per-profile-identifiers">a single browsing profile</a> by communicating with a pre-determined server hosted by the user agent or CDM vendor, possibly <a href="#uses-distinctive-permanent-identifiers">using Distinctive Permanent Identifier(s)</a> or other <a href="#permanent-identifier">Permanent Identifier(s)</a> from the client device.
           </p>
         </div>
@@ -6357,7 +6387,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
           <li>
             <p><em class="rfc2119" title="MUST">MUST</em> adhere to the <a href="#identifier-requirements">identifier requirements</a>.</p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note124"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note127"><span>Note</span></div>
               <p class="">This includes only using values that are <a href="#per-origin-per-profile-identifiers">unique per origin and profile</a> and <a href="#allow-identifiers-cleared">clearable</a> and <a href="#encrypt-identifiers">encrypting</a> them as required.</p>
             </div>
           </li>
@@ -6378,7 +6408,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
       </h3>
       <p>Implementations <em class="rfc2119" title="MUST">MUST</em> support multiple keys in each <a href="#idl-def-mediakeysession" class="internalDFN" data-link-type="dfn"><code>MediaKeySession</code></a> object.</p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note125"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note128"><span>Note</span></div>
         <p class="">The mechanics of how multiple keys are supported is an implementation detail, but it <em class="rfc2119" title="MUST">MUST</em> be transparent to the application and the APIs defined in this specification.</p>
       </div>
 
@@ -6395,7 +6425,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
         </h4>
         <p>Implementations <em class="rfc2119" title="SHOULD">SHOULD</em> allow licenses generated with any <a href="#initialization-data-type">Initialization Data Type</a> they support to be used with any content type.</p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note126"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note129"><span>Note</span></div>
           <p class="">Otherwise, the <code><a href="#dom-navigator-requestmediakeysystemaccess">requestMediaKeySystemAccess()</a></code> algorithm might, for example, reject a <a href="#idl-def-mediakeysystemconfiguration" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemConfiguration</code></a> because one of the <code><a href="#dom-mediakeysystemconfiguration-initdatatypes">initDataTypes</a></code> is not supported with one of the <code><a href="#dom-mediakeysystemconfiguration-videocapabilities">videoCapabilities</a></code>.</p>
         </div>
       </section>
@@ -6405,7 +6435,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
         </h4>
         <p>For any supported <a href="#initialization-data-type">Initialization Data Type</a> that may appear in a supported container, the user agents <em class="rfc2119" title="MUST">MUST</em> support <a href="#initdata-encountered">extracting</a> that type of <a href="#initialization-data">Initialization Data</a> from each such supported container.</p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note127"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note130"><span>Note</span></div>
           <p class="">In other words, indicating support for an <a href="#initialization-data-type">Initialization Data Type</a> implies both CDM support for generating license requests and, for container-specific types, user agent support for extracting it from the container. This does <strong>not</strong> mean that implementations must be able to parse <em>any</em> supported <a href="#initialization-data">Initialization Data</a> from <em>any</em> supported content type.
           </p>
         </div>
@@ -6432,7 +6462,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
           <a href="https://www.w3.org/TR/html5/embedded-content-0.html#media-resource">Media resources</a>, including all tracks, <em class="rfc2119" title="MUST">MUST</em> be encrypted and packaged per a container-specific "common encryption" specification that allows the content to be decrypted in a fully specified and compatible way when a key or keys are provided.
         </p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note128"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note131"><span>Note</span></div>
           <p class="">
             The Encrypted Media Extensions Stream Format and Initialization Data Format Registry [<cite><a class="bibref" href="#bib-EME-STREAM-REGISTRY">EME-STREAM-REGISTRY</a></cite>] provides references to such stream formats.
           </p>
@@ -6446,7 +6476,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
           In-band support content, such as captions, described audio, and transcripts, <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> be encrypted.
         </p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note129"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note132"><span>Note</span></div>
           <p class="">
             Decryption of such tracks - especially such that they can be provided back the user agent - is not generally supported by implementations. Thus, encrypting such tracks would prevent them from being widely available for use with accessibility features in user agent implementations.
           </p>
@@ -6465,7 +6495,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
     </h2>
     <p>All user agents <em class="rfc2119" title="MUST">MUST</em> support the common key systems described in this section.</p>
     <div class="note">
-      <div class="note-title marker" aria-level="3" role="heading" id="h-note130"><span>Note</span></div>
+      <div class="note-title marker" aria-level="3" role="heading" id="h-note133"><span>Note</span></div>
       <p class="">This ensures that there is a common baseline level of functionality that is guaranteed to be supported in all user agents, including those that are entirely open source. Thus, content providers that need only basic decryption can build simple applications that will work on all platforms without needing to work with any content protection providers.
       </p>
     </div>
@@ -6754,13 +6784,13 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
       <p>User Agent and Key System implementations <em class="rfc2119" title="MUST">MUST</em> consider <a href="https://www.w3.org/TR/html5/embedded-content-0.html#media-data">media data</a>, <a href="#initialization-data">Initialization Data</a>, data passed to <code><a href="#dom-mediakeysession-update">update()</a></code>, licenses, key data, and all other data provided by the application as untrusted content and potential attack vectors. They <em class="rfc2119" title="MUST">MUST</em> use appropriate safeguards to mitigate any associated threats and take care to safely parse, decrypt, etc. such data. User Agents <em class="rfc2119" title="SHOULD">SHOULD</em> validate data before passing it to the CDM.
       </p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note131"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note134"><span>Note</span></div>
         <p class="">Such validation is especially important if the CDM does not run in the same (sandboxed) context as, for example, the DOM.</p>
       </div>
 
       <p>Implementations <em class="rfc2119" title="MUST NOT">MUST NOT</em> return active content or passive content that affects program control flow to the application.</p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note132"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note135"><span>Note</span></div>
         <p class="">For example, it is not safe to expose URLs or other information that may have come from media data, such as is the case for the <a href="#initialization-data">Initialization Data</a> passed to <code><a href="#dom-mediakeysession-generaterequest">generateRequest()</a></code>. Applications must determine the URLs to use. The <code><a href="#dom-mediakeymessageevent-messagetype">messageType</a></code> attribute of the <code><a href="#dom-evt-message">message</a></code> event can be used by the application to select among a set of URLs if applicable.
         </p>
       </div>
@@ -6774,14 +6804,14 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
       <p>Exploiting a CDM implementation that is not fully sandboxed and/or uses platform features may allow an attacker to access OS or platform features, elevate privilege (e.g. to run as system or root), and/or access drivers, kernel, firmware, hardware, etc. Such features, software, and hardware may not be written to be robust against hostile software or web-based attacks and may not be updated with security fixes, especially compared to the user agent. Lack of, infrequent, or slow updates for fixes to security vulnerabilities in CDM implementations increases the risk. Such CDM implementations and UAs that expose them <em class="rfc2119" title="MUST">MUST</em> be especially careful in all areas of security, including parsing of <a href="#input-data-security">all data</a>.
       </p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note133"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note136"><span>Note</span></div>
         <p class="">User agents should be especially diligent when using a CDM or underlying mechanism that is part of or provided by the client OS, platform and/or hardware.</p>
       </div>
 
       <p>If a user agent chooses to support a Key System implementation that cannot be sufficiently sandboxed or otherwise secured, the user agent <em class="rfc2119" title="SHOULD">SHOULD</em> <a href="#security-consent">ensure that users are fully informed and/or give explicit consent</a> before loading or invoking it.
       </p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note134"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note137"><span>Note</span></div>
         <p class="">Granting permissions to unauthenticated origins is equivalent to granting the permissions to any origin in the presence of a network attacker. See <a href="#persisted-consent-abuse">abuse of persisted consent</a>.
         </p>
       </div>
@@ -6853,7 +6883,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
             <p>Such mechanisms <em class="rfc2119" title="MUST">MUST</em> be per <a href="https://www.w3.org/TR/html5/browsers.html#origin-0">origin</a> to avoid valid uses enabling subsequent malicious access and <em class="rfc2119" title="MUST">MUST</em> be per <a href="#browsing-profile">browsing profile</a>.
             </p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note135"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note138"><span>Note</span></div>
               <p class="">The restriction of the APIs defined in this specification to secure contexts ensures that a <a href="#network-attacks">network attacker</a> cannot exploit permissions granted to an unauthenticated origin. See <a href="#persisted-consent-abuse">abuse of persisted consent</a>.
               </p>
             </div>
@@ -6894,7 +6924,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
       <p>Using the APIs defined in this specification on shared hosts compromises origin-based security and privacy mitigations implemented by user agents. For example, per-origin <a href="#distinctive-identifier">Distinctive Identifiers</a> are shared by all authors on one host name, and peristed data may be accessed and manipulated by any author on the host. The latter is especially important if, for example, modification or deletion of such data could erase a user's right to specific content.
       </p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note136"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note139"><span>Note</span></div>
         <p class="">Even if a path-restriction feature was made available by user agents, the usual DOM scripting security model would make it trivial to bypass this protection and access the data from any path.</p>
       </div>
       <p>Authors on shared hosts are therefore <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em> to avoid using the APIs defined in this specification because doing so compromises origin-based security and privacy mitigations in user agents.</p>
@@ -6969,7 +6999,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
               It is not possible to extract, derive or infer information from the CDM that is not either explicitly described in this specification or available to the page through other web platform APIs without user permission. This applies to any information that is exposed outside the client device or to the application, including, for example, in CDM messages.
             </p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note137"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note140"><span>Note</span></div>
               <div class="">
                 <p>The type of information covered by this requirement includes but is not limited to:</p>
                 <ul>
@@ -7131,7 +7161,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
           <dd>
             <p>User agents <em class="rfc2119" title="MAY">MAY</em>, possibly in a manner configured by the user, automatically delete <a href="#distinctive-identifier">Distinctive Identifiers</a> and/or other Key System data after a period of time.</p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note138"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note141"><span>Note</span></div>
               <div class="">
                 <p>For example, a user agent could be configured to store such data as session-only storage, deleting the data once the user had closed all the browsing contexts that could access it.</p>
                 <p>This can restrict the ability of a site to track a user, as the site would then only be able to track the user across multiple sessions when he authenticates with the site itself (e.g. by making a purchase or logging in to a service).</p>
@@ -7154,7 +7184,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
             <p>Such mechanisms <em class="rfc2119" title="MUST">MUST</em> be per <a href="https://www.w3.org/TR/html5/browsers.html#origin-0">origin</a> to avoid valid uses enabling subsequent malicious access and <em class="rfc2119" title="MUST">MUST</em> be per <a href="#browsing-profile">browsing profile</a>.
             </p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note139"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note142"><span>Note</span></div>
               <p class="">The restriction of the APIs defined in this specification to secure contexts ensures that a <a href="#network-attacks">network attacker</a> cannot exploit permissions granted to an unauthenticated origin. See <a href="#persisted-consent-abuse">abuse of persisted consent</a>.
               </p>
             </div>
@@ -7180,7 +7210,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
         </dl>
 
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note140"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note143"><span>Note</span></div>
           <p class="">While these suggestions prevent trivial use of the APIs defined in this specification for user tracking, they do not block it altogether. Within a single origin, a site can continue to track the user during a session, and can then pass all this information to a third party along with any identifying information (names, credit card numbers, addresses) obtained by the site. If a third party cooperates with multiple sites to obtain such information, and if identifiers are not
             <!-- Issue #101 may affect this text. --><a href="#per-origin-per-profile-identifiers">unique per origin and profile</a>, then a profile can still be created.
           </p>


### PR DESCRIPTION
Separates the relevant steps from the Initialization Data Encountered algorithm and specifies when to call them.