### PR TITLE
Fix length of pssh box in example

### DIFF
--- a/format-registry/initdata/cenc.html
+++ b/format-registry/initdata/cenc.html
@@ -471,7 +471,7 @@ table.simple {
         <h3 id="h-example" resource="#h-example"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.2 </span>Example</span></h3><p><em>This section is non-normative.</em></p>
         <p>The following example contains two key IDs.</p>
           <div class="example"><div class="example-title marker"><span>Example 1</span></div><pre class="">var pssh = [
-    0x00, 0x00, 0x00, 0x4c, 0x70, 0x73, 0x73, 0x68, // BMFF box header (76 bytes, 'pssh')
+    0x00, 0x00, 0x00, 0x44, 0x70, 0x73, 0x73, 0x68, // BMFF box header (68 bytes, 'pssh')
     0x01, 0x00, 0x00, 0x00,                         // Full box header (version = 1, flags = 0)
     0x10, 0x77, 0xef, 0xec, 0xc0, 0xb2, 0x4d, 0x02, // SystemID
     0xac, 0xe3, 0x3c, 0x1e, 0x52, 0xe2, 0xfb, 0x4b,


### PR DESCRIPTION
The example pssh box is listed as having a length of 76, but the entire structure is actually 68 bytes.