### PR TITLE
Fix #251: Specify mixed clear and encrypted streams

### DIFF
--- a/switch.md
+++ b/switch.md
@@ -1,0 +1,10 @@
+If MediaKeys is set before playback starts, the implementation **MUST** support switching between clear and encrypted streams.
+
+_NOTE_: Whether the clear and encrypted streams - or even multiple streams of either type - may use different contentTypes is left to other specifications related to media sources and capability detection.
+
+_NOTE_: Applications are advised that at the time of this writing, at least some major browser do not support this.
+
+Support of switching when MediaKeys is set after the playback starts, or when the clear stream uses a different contentType, is a quality of implementation issue.
+
+_NOTE_: Applications are advised that at the time of this writing, at least some major browser do not support this. Applications that need this functionality SHOULD set MediaKeys before loading the media resource.
+

--- a/switch.md
+++ b/switch.md
@@ -6,5 +6,5 @@ _NOTE_: Applications are advised that at the time of this writing, at least some
 
 Support of switching when MediaKeys is set after the playback starts, or when the clear stream uses a different contentType, is a quality of implementation issue.
 
-_NOTE_: Applications are advised that at the time of this writing, at least some major browser do not support this. Applications that need this functionality SHOULD set MediaKeys before loading the media resource.
+_NOTE_: Applications are advised that at the time of this writing, at least some major browser do not support this. Applications that need this functionality **SHOULD** set MediaKeys before loading the media resource.
 


### PR DESCRIPTION
Add a section to specify the support of switching between clear and encrypted streams. This is related to issue 251.