### PR TITLE
Fix an incorrect markup correction

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -2942,12 +2942,12 @@ interface MediaEncryptedEvent : Event {
                 <dt>Otherwise</dt>
                 <dd>
                   <p>Set the <a def-id="readystate"></a> of <var>media element</var> to <a def-id="have-metadata"></a>.</p>
-                <p class="note">
-                  In other words, if the video frame and audio data for the <a def-id="current-playback-position"></a> have been decoded because they were unencrypted and/or successfully decrypted, set <a def-id="readystate"></a> to <a def-id="have-current-data"></a>.
-                  Otherwise, including if this was previously the case but the data is no longer available, set <a def-id="readystate"></a> to <a def-id="have-metadata"></a>.
-                </p>
                 </dd>
               </dl>                  
+              <p class="note">
+                In other words, if the video frame and audio data for the <a def-id="current-playback-position"></a> have been decoded because they were unencrypted and/or successfully decrypted, set <a def-id="readystate"></a> to <a def-id="have-current-data"></a>.
+                Otherwise, including if this was previously the case but the data is no longer available, set <a def-id="readystate"></a> to <a def-id="have-metadata"></a>.
+              </p>
             </li>
             <li><p><a def-id="queue-a-task-to-fire-an-event-named"></a> <a def-id="waitingforkey"></a> at the <var>media element</var>.</p></li>
             <li><p>Suspend playback.</p></li>


### PR DESCRIPTION
 https://github.com/w3c/encrypted-media/commit/1f112baec28a70b4c472902c57d9856fb552288b#diff-f72607e47a6f74e53dc90eab8ee094e2 made the NOTE apply to only one branch of the step. If the previous markup was incorrect, the note should have been moved outside the `</dl>`.
