### PR TITLE
Fix #407 and #408: Add CDM Constraints and move Definitions text

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -199,15 +199,6 @@
         <dt id="cdm">Content Decryption Module (CDM)</dt>
         <dd>
           <p>Content Decryption Module (CDM) is the client component that provides the functionality, including decryption, for one or more <a def-id="keysystems"></a>.</p>
-          <p class="note">Implementations may or may not separate the implementations of CDMs or treat them as separate from the user agent.
-          This is transparent to the API and application.</p>
-
-          <p>All messages and communication to and from the CDM, such as between the CDM and a license server, MUST be passed through the user agent.
-            The CDM MUST NOT make direct out-of band network requests.
-            All messages and communication other than those described in <a href="#direct-individualization">Direct Individualization</a> MUST be passed through the application via the APIs defined in this specification.
-            Specifically, all communication that contains application-, <a def-id="origin"></a>-, or content-specific information or is sent to a URL specified by the application or based on its origin, MUST pass through the APIs.
-            This includes all license exchange messages.
-          </p>
         </dd>
 
         <dt id="key-system">Key System</dt>
@@ -3025,6 +3016,53 @@ interface MediaEncryptedEvent : Event {
       <h3>Implementation Requirements</h3>
       <p>This section defines implementation requirements - for both user agents and <a def-id="keysystems"></a>, including the <a def-id="cdm"></a> and server - that may not be explicitly addressed in the algorithms.</p>
 
+	    <section id="cdm-constraint-requirements">
+        <h3>CDM Constraints</h3>
+        <p>
+          User agent implementers MUST ensure that CDMs do not access any information, storage or system capabilities that are not reasonably required for playback of protected media using the features of this specification. 
+          Specifically, the CDM SHALL NOT:
+        </p>
+        <ul>
+          <li>
+            <p>
+              Access network resources, either local or remote, except via the user agent, or as part of the user agent, as explicitly permitted by this specification.
+            </p>
+          </li>
+          <li>
+            <p>
+              Access storage (disk or memory), except where reasonably required for playback of protected media using the features of this specification.
+            </p>
+          </li>
+          <li>
+            <p>
+              Access user data other than CDM state and persistent data.
+            </p>
+          </li>
+          <li>
+            <p>
+              Access hardware components or devices, except where reasonably required for playback of protected media using the features of this specification.
+            </p>
+          </li>
+        </ul>
+        <p>
+          User Agent implementers may use various techniques to meet the above requirements. For example, a User Agent implementer also implementing their own CDM may include the above as design requirements for that component. 
+          A User Agent implementer making use of a third party CDM may ensure that it executes in a constrained environment (e.g., "sandbox") without access to the prohibited information and components.
+        </p>
+      </section>  
+
+	    <section id="messaging-requirements">
+        <h3>Messaging</h3>
+        <p>
+          All messages and communication to and from the CDM, such as between the CDM and a license server, MUST be passed through the user agent.
+          The CDM MUST NOT make direct out-of band network requests.
+          All messages and communication other than those described in <a href="#direct-individualization">Direct Individualization</a> MUST be passed through the application via the APIs defined in this specification.
+          Specifically, all communication that contains application-, <a def-id="origin"></a>-, or content-specific information or is sent to a URL specified by the application or based on its origin, MUST pass through the APIs.
+          This includes all license exchange messages.
+        </p>
+ 
+        <p class="note">Implementations may or may not separate the implementations of CDMs or treat them as separate from the user agent. This is transparent to the API and application.</p>
+      </section>
+        
       <section id="persistent-state-requirements">
         <h3>Persistent Data</h3>
         <p>

--- a/index.html
+++ b/index.html
@@ -1,16 +1,16 @@
 <!DOCTYPE html>
-<html dir="ltr" typeof="bibo:Document " prefix="bibo: http://purl.org/ontology/bibo/ w3p: http://www.w3.org/2001/02pd/rec54#" lang="en">
+<html lang="en" dir="ltr" typeof="bibo:Document " prefix="bibo: http://purl.org/ontology/bibo/ w3p: http://www.w3.org/2001/02pd/rec54#">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <meta property="dc:language" content="en" lang="">
+  <meta lang="" property="dc:language" content="en">
   <style>
     /*
 
 github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
 */
-    
+
     .hljs {
       display: block;
       overflow-x: auto;
@@ -18,20 +18,20 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       color: #333;
       background: #f8f8f8;
     }
-    
+
     .hljs-comment,
     .hljs-quote {
       color: #998;
       font-style: italic;
     }
-    
+
     .hljs-keyword,
     .hljs-selector-tag,
     .hljs-subst {
       color: #333;
       font-weight: bold;
     }
-    
+
     .hljs-number,
     .hljs-literal,
     .hljs-variable,
@@ -39,84 +39,84 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
     .hljs-tag .hljs-attr {
       color: #008080;
     }
-    
+
     .hljs-string,
     .hljs-doctag {
       color: #d14;
     }
-    
+
     .hljs-title,
     .hljs-section,
     .hljs-selector-id {
       color: #900;
       font-weight: bold;
     }
-    
+
     .hljs-subst {
       font-weight: normal;
     }
-    
+
     .hljs-type,
     .hljs-class .hljs-title {
       color: #458;
       font-weight: bold;
     }
-    
+
     .hljs-tag,
     .hljs-name,
     .hljs-attribute {
       color: #000080;
       font-weight: normal;
     }
-    
+
     .hljs-regexp,
     .hljs-link {
       color: #009926;
     }
-    
+
     .hljs-symbol,
     .hljs-bullet {
       color: #990073;
     }
-    
+
     .hljs-built_in,
     .hljs-builtin-name {
       color: #0086b3;
     }
-    
+
     .hljs-meta {
       color: #999;
       font-weight: bold;
     }
-    
+
     .hljs-deletion {
       background: #fdd;
     }
-    
+
     .hljs-addition {
       background: #dfd;
     }
-    
+
     .hljs-emphasis {
       font-style: italic;
     }
-    
+
     .hljs-strong {
       font-weight: bold;
     }
   </style>
   <style>
     /* --- EXAMPLES --- */
-    
+
     div.example-title {
       min-width: 7.5em;
       color: #b9ab2d;
     }
-    
+
     div.example-title span {
       text-transform: uppercase;
     }
-    
+
     aside.example,
     div.example,
     div.illegal-example {
@@ -125,15 +125,15 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       position: relative;
       clear: both;
     }
-    
+
     div.illegal-example {
       color: red
     }
-    
+
     div.illegal-example p {
       color: black
     }
-    
+
     aside.example,
     div.example {
       padding: .5em;
@@ -142,20 +142,20 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       border-color: #e0cb52;
       background: #fcfaee;
     }
-    
+
     aside.example div.example {
       border-left-width: .1em;
       border-color: #999;
       background: #fff;
     }
-    
+
     aside.example div.example div.example-title {
       color: #999;
     }
   </style>
   <style>
     /* --- ISSUES/NOTES --- */
-    
+
     div.issue-title,
     div.note-title,
     div.ednote-title,
@@ -164,27 +164,27 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       min-width: 7.5em;
       color: #b9ab2d;
     }
-    
+
     div.issue-title {
       color: #e05252;
     }
-    
+
     div.note-title,
     div.ednote-title {
       color: #2b2;
     }
-    
+
     div.warning-title {
       color: #f22;
     }
-    
+
     div.issue-title span,
     div.note-title span,
     div.ednote-title span,
     div.warning-title span {
       text-transform: uppercase;
     }
-    
+
     div.note,
     div.issue,
     div.ednote,
@@ -192,14 +192,14 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       margin-top: 1em;
       margin-bottom: 1em;
     }
-    
+
     .note>p:first-child,
     .ednote>p:first-child,
     .issue>p:first-child,
     .warning>p:first-child {
       margin-top: 0
     }
-    
+
     .issue,
     .note,
     .ednote,
@@ -208,7 +208,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       border-left-width: .5em;
       border-left-style: solid;
     }
-    
+
     div.issue,
     div.note,
     div.ednote,
@@ -218,32 +218,32 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       position: relative;
       clear: both;
     }
-    
+
     span.note,
     span.ednote,
     span.issue,
     span.warning {
       padding: .1em .5em .15em;
     }
-    
+
     .issue {
       border-color: #e05252;
       background: #fbe9e9;
     }
-    
+
     .note,
     .ednote {
       border-color: #52e052;
       background: #e9fbe9;
     }
-    
+
     .warning {
       border-color: #f11;
       border-width: .2em;
       border-style: solid;
       background: #fbe9e9;
     }
-    
+
     .warning-title:before {
       content: "⚠";
       /*U+26A0 WARNING SIGN*/
@@ -254,11 +254,11 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       vertical-align: top;
       margin-top: -0.5em;
     }
-    
+
     li.task-list-item {
       list-style: none;
     }
-    
+
     input.task-list-item-checkbox {
       margin: 0 0.35em 0.25em -1.6em;
       vertical-align: middle;
@@ -266,29 +266,25 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
   </style>
   <style>
     /* --- WEB IDL --- */
-    
+
     pre.idl {
-      border-top: 1px solid #90b8de;
-      border-bottom: 1px solid #90b8de;
       padding: 1em;
-      line-height: 120%;
     }
-    
+
     .respec-idl-separator {
-      display: block;
       padding: 0 0 0.4cm 0;
     }
-    
+
     .respec-idl-separator:last-child {
       padding: 0;
     }
-    
+
     @media print {
       pre.idl {
         white-space: pre-wrap;
       }
     }
-    
+
     pre.idl::before {
       content: "WebIDL";
       display: block;
@@ -296,11 +292,12 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       background: #90b8de;
       color: #fff;
       font-family: sans-serif;
-      padding: 3px;
       font-weight: bold;
       margin: -1em 0 1em -1em;
+      height: 28px;
+      line-height: 28px;
     }
-    
+
     .idlType {
       color: #ff4500;
       font-weight: bold;
@@ -309,7 +306,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
     /*.idlModule*/
     /*.idlModuleID*/
     /*.idlInterface*/
-    
+
     .idlInterfaceID,
     .idlDictionaryID,
     .idlCallbackID,
@@ -317,31 +314,31 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       font-weight: bold;
       color: #005a9c;
     }
-    
+
     a.idlEnumItem {
       color: #000;
       border-bottom: 1px dotted #ccc;
       text-decoration: none;
     }
-    
+
     .idlSuperclass {
       font-style: italic;
       color: #005a9c;
     }
     /*.idlAttribute*/
-    
+
     .idlAttrType,
     .idlFieldType,
     .idlMemberType {
       color: #005a9c;
     }
-    
+
     .idlAttrName,
     .idlFieldName,
     .idlMemberName {
       color: #ff4500;
     }
-    
+
     .idlAttrName a,
     .idlFieldName a,
     .idlMemberName a {
@@ -350,90 +347,90 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       text-decoration: none;
     }
     /*.idlMethod*/
-    
+
     .idlMethType,
     .idlCallbackType {
       color: #005a9c;
     }
-    
+
     .idlMethName {
       color: #ff4500;
     }
-    
+
     .idlMethName a {
       color: #ff4500;
       border-bottom: 1px dotted #ff4500;
       text-decoration: none;
     }
     /*.idlCtor*/
-    
+
     .idlCtorName {
       color: #ff4500;
     }
-    
+
     .idlCtorName a {
       color: #ff4500;
       border-bottom: 1px dotted #ff4500;
       text-decoration: none;
     }
     /*.idlParam*/
-    
+
     .idlParamType {
       color: #005a9c;
     }
-    
+
     .idlParamName,
     .idlDefaultValue {
       font-style: italic;
     }
-    
+
     .extAttr {
       color: #666;
     }
     /*.idlSectionComment*/
-    
+
     .idlSectionComment {
       color: gray;
     }
     /*.idlIterable*/
-    
+
     .idlIterableKeyType,
     .idlIterableValueType {
       color: #005a9c;
     }
     /*.idlMaplike*/
-    
+
     .idlMaplikeKeyType,
     .idlMaplikeValueType {
       color: #005a9c;
     }
     /*.idlConst*/
-    
+
     .idlConstType {
       color: #005a9c;
     }
-    
+
     .idlConstName {
       color: #ff4500;
     }
-    
+
     .idlConstName a {
       color: #ff4500;
       border-bottom: 1px dotted #ff4500;
       text-decoration: none;
     }
     /*.idlException*/
-    
+
     .idlExceptionID {
       font-weight: bold;
       color: #c00;
     }
-    
+
     .idlTypedefID,
     .idlTypedefType {
       color: #005a9c;
     }
-    
+
     .idlRaises,
     .idlRaises a.idlType,
     .idlRaises a.idlType code,
@@ -442,16 +439,16 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       color: #c00;
       font-weight: normal;
     }
-    
+
     .excName a {
       font-family: monospace;
     }
-    
+
     .idlRaises a.idlType,
     .excName a.idlType {
       border-bottom: 1px dotted #c00;
     }
-    
+
     .excGetSetTrue,
     .excGetSetFalse,
     .prmNullTrue,
@@ -461,23 +458,23 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       width: 45px;
       text-align: center;
     }
-    
+
     .excGetSetTrue,
     .prmNullTrue,
     .prmOptTrue {
       color: #0c0;
     }
-    
+
     .excGetSetFalse,
     .prmNullFalse,
     .prmOptFalse {
       color: #c00;
     }
-    
+
     .idlImplements a {
       font-weight: bold;
     }
-    
+
     dl.attributes,
     dl.methods,
     dl.constants,
@@ -486,7 +483,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
     dl.dictionary-members {
       margin-left: 2em;
     }
-    
+
     .attributes dt,
     .methods dt,
     .constants dt,
@@ -495,7 +492,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
     .dictionary-members dt {
       font-weight: normal;
     }
-    
+
     .attributes dt code,
     .methods dt code,
     .constants dt code,
@@ -506,13 +503,13 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       color: #000;
       font-family: monospace;
     }
-    
+
     .attributes dt code,
     .fields dt code,
     .dictionary-members dt code {
       background: #ffffd2;
     }
-    
+
     .attributes dt .idlAttrType code,
     .fields dt .idlFieldType code,
     .dictionary-members dt .idlMemberType code {
@@ -522,19 +519,19 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       font-weight: normal;
       font-style: italic;
     }
-    
+
     .methods dt code {
       background: #d9e6f8;
     }
-    
+
     .constants dt code {
       background: #ddffd2;
     }
-    
+
     .constructors dt code {
       background: #cfc;
     }
-    
+
     .attributes dd,
     .methods dd,
     .constants dd,
@@ -543,7 +540,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
     .dictionary-members dd {
       margin-bottom: 1em;
     }
-    
+
     table.parameters,
     table.exceptions {
       border-spacing: 0;
@@ -551,15 +548,15 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       margin: 0.5em 0;
       width: 100%;
     }
-    
+
     table.parameters {
       border-bottom: 1px solid #90b8de;
     }
-    
+
     table.exceptions {
       border-bottom: 1px solid #deb890;
     }
-    
+
     .parameters th,
     .exceptions th {
       color: inherit;
@@ -567,42 +564,89 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       text-align: left;
       font-weight: normal;
     }
-    
+
     .parameters th {
       color: #fff;
       background: #005a9c;
     }
-    
+
     .exceptions th {
       background: #deb890;
     }
-    
+
     .parameters td,
     .exceptions td {
       padding: 3px 10px;
       border-top: 1px solid #ddd;
       vertical-align: top;
     }
-    
+
     .parameters tr:first-child td,
     .exceptions tr:first-child td {
       border-top: none;
     }
-    
+
     .parameters td.prmName,
     .exceptions td.excName,
     .exceptions td.excCodeName {
       width: 100px;
     }
-    
+
     .parameters td.prmType {
       width: 120px;
     }
-    
+
     table.exceptions table {
       border-spacing: 0;
       border-collapse: collapse;
       width: 100%;
+    }
+
+    .respec-button-copy-paste:focus {
+      text-decoration: none;
+      border-color: #51a7e8;
+      outline: none;
+      box-shadow: 0 0 5px rgba(81, 167, 232, 0.5);
+    }
+
+    .respec-button-copy-paste:focus:hover,
+    .respec-button-copy-paste.selected:focus {
+      border-color: #51a7e8;
+    }
+
+    .respec-button-copy-paste:hover,
+    .respec-button-copy-paste:active,
+    .respec-button-copy-paste.zeroclipboard-is-hover,
+    .respec-button-copy-paste.zeroclipboard-is-active {
+      text-decoration: none;
+      background-color: #ddd;
+      background-image: linear-gradient(#eee, #ddd);
+      border-color: #ccc;
+    }
+
+    .respec-button-copy-paste:active,
+    .respec-button-copy-paste.selected,
+    .respec-button-copy-paste.zeroclipboard-is-active {
+      background-color: #dcdcdc;
+      background-image: none;
+      border-color: #b5b5b5;
+      box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.15)
+    }
+
+    .respec-button-copy-paste.selected:hover {
+      background-color: #cfcfcf;
+    }
+
+    .respec-button-copy-paste:disabled,
+    .respec-button-copy-paste:disabled:hover,
+    .respec-button-copy-paste.disabled,
+    .respec-button-copy-paste.disabled:hover {
+      color: rgba(102, 102, 102, 0.5);
+      cursor: default;
+      background-color: rgba(229, 229, 229, 0.5);
+      background-image: none;
+      border-color: rgba(197, 197, 197, 0.5);
+      box-shadow: none;
     }
   </style>
 
@@ -626,25 +670,18 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
  * Robin Berjon - http://berjon.com/
  *****************************************************************/
     /* Override code highlighter background */
-    
+
     .hljs {
       background: transparent !important;
     }
     /* --- INLINES --- */
-    
+
     em.rfc2119 {
       text-transform: lowercase;
       font-style: normal;
       color: #900;
     }
-    
-    h1 acronym,
-    h2 acronym,
-    h3 acronym,
-    h4 acronym,
-    h5 acronym,
-    h6 acronym,
-    a acronym,
+
     h1 abbr,
     h2 abbr,
     h3 abbr,
@@ -654,363 +691,117 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
     a abbr {
       border: none;
     }
-    
+
     dfn {
       font-weight: bold;
     }
-    
+
     a.internalDFN {
       color: inherit;
       border-bottom: 1px solid #99c;
       text-decoration: none;
     }
-    
+
     a.externalDFN {
       color: inherit;
       border-bottom: 1px dotted #ccc;
       text-decoration: none;
     }
-    
+
     a.bibref {
       text-decoration: none;
     }
-    
+
     cite .bibref {
       font-style: normal;
     }
-    
+
     code {
       color: #C83500;
     }
-    
+
     th code {
       color: inherit;
     }
     /* --- TOC --- */
-    
+
     .toc a,
     .tof a {
       text-decoration: none;
     }
-    
+
     a .secno,
     a .figno {
       color: #000;
     }
-    
+
     ul.tof,
     ol.tof {
       list-style: none outside none;
     }
-    
+
     .caption {
       margin-top: 0.5em;
       font-style: italic;
     }
     /* --- TABLE --- */
-    
+
     table.simple {
       border-spacing: 0;
       border-collapse: collapse;
       border-bottom: 3px solid #005a9c;
     }
-    
+
     .simple th {
       background: #005a9c;
       color: #fff;
       padding: 3px 5px;
       text-align: left;
     }
-    
+
     .simple th[scope="row"] {
       background: inherit;
       color: inherit;
       border-top: 1px solid #ddd;
     }
-    
+
     .simple td {
       padding: 3px 10px;
       border-top: 1px solid #ddd;
     }
-    
+
     .simple tr:nth-child(even) {
       background: #f0f6ff;
     }
     /* --- DL --- */
-    
+
     .section dd>p:first-child {
       margin-top: 0;
     }
-    
+
     .section dd>p:last-child {
       margin-bottom: 0;
     }
-    
+
     .section dd {
       margin-bottom: 1em;
     }
-    
+
     .section dl.attrs dd,
     .section dl.eldef dd {
       margin-bottom: 0;
     }
-    
-    #respec-ui {
-      position: fixed;
-      display: flex;
-      flex-direction: row-reverse;
-      top: 20px;
-      right: 20px;
-      width: 202px;
-      text-align: right;
-    }
-    
-    #respec-pill,
-    .respec-info-button {
-      background: #fff;
-      height: 2.5em;
-      color: rgb(120, 120, 120);
-      border: 1px solid #ccc;
-      box-shadow: 1px 1px 8px 0 rgba(100, 100, 100, .5);
-    }
-    
-    .respec-info-button {
-      border: none;
-      opacity: .5;
-      border-radius: 2em;
-      margin-right: 1em;
-      min-width: 3.5em;
-    }
-    
-    .respec-info-button:focus {
-      opacity: 1;
-      transition: opacity .2s;
-    }
-    
-    #respec-pill:disabled {
-      font-size: 2.8px;
-      text-indent: -9999em;
-      border-top: 1.1em solid rgba(40, 40, 40, 0.2);
-      border-right: 1.1em solid rgba(40, 40, 40, 0.2);
-      border-bottom: 1.1em solid rgba(40, 40, 40, 0.2);
-      border-left: 1.1em solid #ffffff;
-      transform: translateZ(0);
-      animation: respec-spin .5s infinite linear;
-      box-shadow: none;
-    }
-    
-    #respec-pill:disabled,
-    #respec-pill:disabled:after {
-      border-radius: 50%;
-      width: 10em;
-      height: 10em;
-    }
-    
-    @keyframes respec-spin {
-      0% {
-        transform: rotate(0deg);
-      }
-      100% {
-        transform: rotate(360deg);
-      }
-    }
-    
-    #respec-pill:hover,
-    #respec-pill:focus {
-      color: rgb(0, 0, 0);
-      background-color: rgb(245, 245, 245);
-      transition: color .2s;
-    }
-    
-    #respec-menu {
-      position: absolute;
-      margin: 0;
-      padding: 0;
-      font-family: sans-serif;
-      background: #fff;
-      box-shadow: 1px 1px 8px 0 rgba(100, 100, 100, .5);
-      width: 200px;
-      display: none;
-      text-align: left;
-      margin-top: 32px;
-      font-size: .8em;
-    }
-    
-    #respec-menu li {
-      list-style-type: none;
-      margin: 0;
-      padding: 0;
-    }
-    
-    .respec-save-button {
-      background: #fff;
-      border: 1px solid #000;
-      border-radius: 5px;
-      padding: 5px;
-      margin: 5px;
-      display: block;
-      width: 100%;
-      color: #000;
-      text-decoration: none;
-      text-align: center;
-      font-size: inherit;
-    }
-    
-    #respec-ui button:focus,
-    #respec-pill:focus,
-    .respec-option:focus {
-      outline: 0;
-      outline-style: none;
-    }
-    
-    #respec-pill-error {
-      background-color: red;
-      color: white;
-    }
-    
-    #respec-pill-warning {
-      background-color: orange;
-      color: white;
-    }
-    
-    .respec-warning-list,
-    .respec-error-list {
-      margin: 0;
-      padding: 0;
-      list-style: none;
-      font-family: sans-serif;
-      background-color: rgb(255, 251, 230);
-      font-size: .9em;
-    }
-    
-    .respec-warning-list li,
-    .respec-error-list li {
-      padding: 0.4em 0.7em;
-    }
-    
-    .respec-warning-list li::before {
-      content: "⚠️";
-      padding-right: .5em;
-    }
-    
-    .respec-warning-list li {
-      color: rgb(92, 59, 0);
-      border-bottom: thin solid rgb(255, 245, 194);
-    }
-    
-    .respec-error-list,
-    .respec-error-list li {
-      background-color: rgb(255, 240, 240);
-    }
-    
-    .respec-error-list li::before {
-      content: "💥";
-      padding-right: .5em;
-    }
-    
-    .respec-error-list li {
-      padding: 0.4em 0.7em;
-      color: rgb(92, 59, 0);
-      border-bottom: thin solid rgb(255, 215, 215);
-    }
-    
-    #respec-overlay {
-      display: block;
-      opacity: 0;
-      position: fixed;
-      z-index: 10000;
-      top: 0px;
-      left: 0px;
-      height: 100%;
-      width: 100%;
-      background: #000;
-    }
-    
-    .respec-modal {
-      display: block;
-      position: fixed;
-      opacity: 0;
-      z-index: 11000;
-      margin: auto;
-      top: 10%;
-      background: #fff;
-      border: 5px solid #666;
-      min-width: 20%;
-      width: 85%;
-      padding: 0;
-      max-height: 80%;
-      overflow-y: auto;
-      margin: 0 -.5cm
-    }
-    
-    @media screen and (min-width: 78em) {
-      .respec-modal {
-        width: 64%;
-      }
-    }
-    
-    .respec-modal h3 {
-      margin: 0;
-      padding: .2em;
-      text-align: center;
-      color: black;
-      background: linear-gradient(to bottom, rgba(238, 238, 238, 1) 0%, rgba(238, 238, 238, 1) 50%, rgba(204, 204, 204, 1) 100%);
-      font-size: 1em;
-    }
-    
-    .respec-modal .inside p {
-      padding-left: 1cm;
-    }
-    
-    #respec-menu button.respec-option {
-      background: white;
-      padding: 0 .2cm;
-      border: none;
-      width: 100%;
-      text-align: left;
-      font-size: inherit;
-      padding: 1.2em 1.2em;
-    }
-    
-    #respec-menu button.respec-option:hover,
-    #respec-menu button:focus {
-      background-color: #eeeeee;
-    }
-    
-    .respec-cmd-icon {
-      padding-right: .5em;
-    }
-    
-    #respec-ui button.respec-option:last-child {
-      border: none;
-      border-radius: inherit;
-    }
-    
-    .respec-offending-element {
-      display: inline-block;
-      position: relative;
-      background: url(data:image/gif;base64,R0lGODdhBAADAPEAANv///8AAP///wAAACwAAAAABAADAEACBZQjmIAFADs=) bottom repeat-x;
-    }
-    
-    @supports (text-decoration-style: wavy) {
-      .respec-offending-element {
-        background: none;
-        text-decoration-line: underline;
-        text-decoration-style: wavy;
-        text-decoration-color: red;
-      }
-    }
-    
+
     #issue-summary>ul,
     .respec-dfn-list {
       column-count: 2;
     }
-    
+
     #issue-summary li,
     .respec-dfn-list li {
       list-style: none;
     }
-    
+
     @media print {
       .removeOnSave {
         display: none;
@@ -1019,7 +810,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
   </style>
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED">
   <link rel="canonical" href="https://www.w3.org/TR/encrypted-media/">
-  <meta name="generator" content="ReSpec 11.2.1">
+  <meta name="generator" content="ReSpec 13.1.0">
   <script id="initialUserConfig" type="application/json">
     {
       "specStatus": "ED",
@@ -1205,13 +996,13 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
     }
   </script>
 </head>
-<body aria-busy="false" class="h-entry toc-inline" id="respecDocument">
+<body aria-busy="false" class="h-entry" id="respecDocument">
   <div class="head" role="contentinfo" id="respecHeader">
     <p>
-      <a class="logo" href="https://www.w3.org/"><img src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" alt="W3C" width="72" height="48"></a>
+      <a class="logo" href="https://www.w3.org/"><img width="72" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" alt="W3C"></a>
     </p>
     <h1 class="title p-name" id="title" property="dcterms:title">Encrypted Media Extensions</h1>
-    <h2 id="w3c-editor-s-draft-16-march-2017"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2017-03-16">16 March 2017</time></h2>
+    <h2 id="w3c-editor-s-draft-08-june-2017"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2017-06-08">08 June 2017</time></h2>
     <dl>
       <dt>This version:</dt>
       <dd><a class="u-url" href="https://w3c.github.io/encrypted-media/">https://w3c.github.io/encrypted-media/</a></dd>
@@ -1282,13 +1073,13 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
     <p>The <code>"persistent-usage-record"</code> session type and the related <em>MediaKeySession destroyed</em> algorithm were removed since the previous version.</p>
 
     <p>
-      This document was published by the <a href="https://www.w3.org/html/wg/">HTML Media Extensions Working Group</a> as an Editor's Draft. If you wish to make comments regarding this document, please send them to
+      This document was published by the <a href="https://www.w3.org/html/wg/">HTML Media Extensions Working Group</a> as an Editor's Draft. Comments regarding this document are welcome. Please send them to
       <a href="mailto:public-html-media@w3.org">public-html-media@w3.org</a> (<a href="mailto:public-html-media-request@w3.org?subject=subscribe">subscribe</a>,
-      <a href="https://lists.w3.org/Archives/Public/public-html-media/">archives</a>). All comments are welcome.
+      <a href="https://lists.w3.org/Archives/Public/public-html-media/">archives</a>).
     </p>
     <p>
       Please see the Working Group's <a href="https://w3c.github.io/test-results/encrypted-media/all.html">implementation
-              report</a>.
+            report</a>.
     </p>
     <p>
       Publication as an Editor's Draft does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr> Membership. This is a draft document and may be updated, replaced or obsoleted by other documents at any time. It is inappropriate to cite this document as other than work in progress.
@@ -1296,16 +1087,17 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
     <p>
       This document was produced by a group operating under the
       <a id="sotd_patent" property="w3p:patentRules" href="https://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 <abbr title="World Wide Web Consortium">W3C</abbr> Patent
-              Policy</a>.
+            Policy</a>.
       <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="https://www.w3.org/2004/01/pp-impl/40318/status" rel="disclosure">public list of any patent
-                disclosures</a> made in connection with the deliverables of the group; that page also includes instructions for disclosing a patent. An individual who has actual knowledge of a patent which the individual believes contains
+              disclosures</a> made in connection with the deliverables of the group; that page also includes instructions for disclosing a patent. An individual who has actual knowledge of a patent which the individual believes contains
       <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
-              Claim(s)</a> must disclose the information in accordance with
+            Claim(s)</a> must disclose the information in accordance with
       <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section
-              6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+            6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
     </p>
     <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2017/Process-20170301/">1 March 2017 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
     </p>
+
 
   </section>
   <nav id="toc">
@@ -1383,51 +1175,53 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
               <li class="tocline"><a href="#resume-playback" class="tocxref"><span class="secno">7.3.6 </span>Attempt to Resume Playback If Necessary</a></li>
             </ol>
           </li>
-          <li class="tocline"><a href="#media-element-restictions" class="tocxref"><span class="secno">7.4 </span>Media Element Restrictions</a></li>
+          <li class="tocline"><a href="#media-element-restrictions" class="tocxref"><span class="secno">7.4 </span>Media Element Restrictions</a></li>
         </ol>
       </li>
       <li class="tocline"><a href="#implementation-requirements" class="tocxref"><span class="secno">8. </span>Implementation Requirements</a>
         <ol class="toc">
-          <li class="tocline"><a href="#persistent-state-requirements" class="tocxref"><span class="secno">8.1 </span>Persistent Data</a>
+          <li class="tocline"><a href="#cdm-constraint-requirements" class="tocxref"><span class="secno">8.1 </span>CDM Constraints</a></li>
+          <li class="tocline"><a href="#messaging-requirements" class="tocxref"><span class="secno">8.2 </span>Messaging</a></li>
+          <li class="tocline"><a href="#persistent-state-requirements" class="tocxref"><span class="secno">8.3 </span>Persistent Data</a>
             <ol class="toc">
-              <li class="tocline"><a href="#use-origin-specific-key-system-storage" class="tocxref"><span class="secno">8.1.1 </span>Use origin-specific and browsing profile-specific Key System storage</a></li>
-              <li class="tocline"><a href="#allow-persistent-data-cleared" class="tocxref"><span class="secno">8.1.2 </span>Allow Persistent Data to Be Cleared</a></li>
-              <li class="tocline"><a href="#encrypt-or-obfuscate-persistent-data" class="tocxref"><span class="secno">8.1.3 </span>Encrypt or obfuscate Persistent Data</a></li>
+              <li class="tocline"><a href="#use-origin-specific-key-system-storage" class="tocxref"><span class="secno">8.3.1 </span>Use origin-specific and browsing profile-specific Key System storage</a></li>
+              <li class="tocline"><a href="#allow-persistent-data-cleared" class="tocxref"><span class="secno">8.3.2 </span>Allow Persistent Data to Be Cleared</a></li>
+              <li class="tocline"><a href="#encrypt-or-obfuscate-persistent-data" class="tocxref"><span class="secno">8.3.3 </span>Encrypt or obfuscate Persistent Data</a></li>
             </ol>
           </li>
-          <li class="tocline"><a href="#exposed-value-requirements" class="tocxref"><span class="secno">8.2 </span>Values Exposed to the Application</a>
+          <li class="tocline"><a href="#exposed-value-requirements" class="tocxref"><span class="secno">8.4 </span>Values Exposed to the Application</a>
             <ol class="toc">
-              <li class="tocline"><a href="#per-origin-per-profile-values" class="tocxref"><span class="secno">8.2.1 </span>Use Per-Origin Per-Profile Values</a></li>
-              <li class="tocline"><a href="#allow-values-to-be-cleared" class="tocxref"><span class="secno">8.2.2 </span>Allow Values to Be Cleared</a></li>
+              <li class="tocline"><a href="#per-origin-per-profile-values" class="tocxref"><span class="secno">8.4.1 </span>Use Per-Origin Per-Profile Values</a></li>
+              <li class="tocline"><a href="#allow-values-to-be-cleared" class="tocxref"><span class="secno">8.4.2 </span>Allow Values to Be Cleared</a></li>
             </ol>
           </li>
-          <li class="tocline"><a href="#identifier-requirements" class="tocxref"><span class="secno">8.3 </span>Identifiers</a>
+          <li class="tocline"><a href="#identifier-requirements" class="tocxref"><span class="secno">8.5 </span>Identifiers</a>
             <ol class="toc">
-              <li class="tocline"><a href="#limit-or-avoid-use-of-distinctive-identifiers-and-permanent-identifiers" class="tocxref"><span class="secno">8.3.1 </span>Limit or Avoid use of Distinctive Identifiers and Permanent Identifiers</a></li>
-              <li class="tocline"><a href="#encrypt-identifiers" class="tocxref"><span class="secno">8.3.2 </span>Encrypt Identifiers</a></li>
-              <li class="tocline"><a href="#per-origin-per-profile-identifiers" class="tocxref"><span class="secno">8.3.3 </span>Use Per-Origin Per-Profile Identifiers</a></li>
-              <li class="tocline"><a href="#non-associable-identifiers" class="tocxref"><span class="secno">8.3.4 </span>Use Non-Associable Identifiers</a></li>
-              <li class="tocline"><a href="#allow-identifiers-cleared" class="tocxref"><span class="secno">8.3.5 </span>Allow Identifiers to Be Cleared</a></li>
+              <li class="tocline"><a href="#limit-or-avoid-use-of-distinctive-identifiers-and-permanent-identifiers" class="tocxref"><span class="secno">8.5.1 </span>Limit or Avoid use of Distinctive Identifiers and Permanent Identifiers</a></li>
+              <li class="tocline"><a href="#encrypt-identifiers" class="tocxref"><span class="secno">8.5.2 </span>Encrypt Identifiers</a></li>
+              <li class="tocline"><a href="#per-origin-per-profile-identifiers" class="tocxref"><span class="secno">8.5.3 </span>Use Per-Origin Per-Profile Identifiers</a></li>
+              <li class="tocline"><a href="#non-associable-identifiers" class="tocxref"><span class="secno">8.5.4 </span>Use Non-Associable Identifiers</a></li>
+              <li class="tocline"><a href="#allow-identifiers-cleared" class="tocxref"><span class="secno">8.5.5 </span>Allow Identifiers to Be Cleared</a></li>
             </ol>
           </li>
-          <li class="tocline"><a href="#individualization" class="tocxref"><span class="secno">8.4 </span>Individualization</a>
+          <li class="tocline"><a href="#individualization" class="tocxref"><span class="secno">8.6 </span>Individualization</a>
             <ol class="toc">
-              <li class="tocline"><a href="#direct-individualization" class="tocxref"><span class="secno">8.4.1 </span>Direct Individualization</a></li>
-              <li class="tocline"><a href="#app-assisted-individualization" class="tocxref"><span class="secno">8.4.2 </span>App-Assisted Individualization</a></li>
+              <li class="tocline"><a href="#direct-individualization" class="tocxref"><span class="secno">8.6.1 </span>Direct Individualization</a></li>
+              <li class="tocline"><a href="#app-assisted-individualization" class="tocxref"><span class="secno">8.6.2 </span>App-Assisted Individualization</a></li>
             </ol>
           </li>
-          <li class="tocline"><a href="#support-multiple-keys" class="tocxref"><span class="secno">8.5 </span>Support Multiple Keys</a></li>
-          <li class="tocline"><a href="#initialization-data-type-support-requirements" class="tocxref"><span class="secno">8.6 </span>Initialization Data Type Support</a>
+          <li class="tocline"><a href="#support-multiple-keys" class="tocxref"><span class="secno">8.7 </span>Support Multiple Keys</a></li>
+          <li class="tocline"><a href="#initialization-data-type-support-requirements" class="tocxref"><span class="secno">8.8 </span>Initialization Data Type Support</a>
             <ol class="toc">
-              <li class="tocline"><a href="#licenses-generated-are-independent-of-content-type" class="tocxref"><span class="secno">8.6.1 </span>Licenses Generated are Independent of Content Type</a></li>
-              <li class="tocline"><a href="#support-extraction-from-media-data" class="tocxref"><span class="secno">8.6.2 </span>Support Extraction From Media Data</a></li>
+              <li class="tocline"><a href="#licenses-generated-are-independent-of-content-type" class="tocxref"><span class="secno">8.8.1 </span>Licenses Generated are Independent of Content Type</a></li>
+              <li class="tocline"><a href="#support-extraction-from-media-data" class="tocxref"><span class="secno">8.8.2 </span>Support Extraction From Media Data</a></li>
             </ol>
           </li>
-          <li class="tocline"><a href="#media-requirements" class="tocxref"><span class="secno">8.7 </span>Supported Media</a>
+          <li class="tocline"><a href="#media-requirements" class="tocxref"><span class="secno">8.9 </span>Supported Media</a>
             <ol class="toc">
-              <li class="tocline"><a href="#unencrypted-container" class="tocxref"><span class="secno">8.7.1 </span>Unencrypted Container</a></li>
-              <li class="tocline"><a href="#interoperably-encrypted" class="tocxref"><span class="secno">8.7.2 </span>Interoperably Encrypted</a></li>
-              <li class="tocline"><a href="#unencrypted-in-band-support-content" class="tocxref"><span class="secno">8.7.3 </span>Unencrypted In-band Support Content</a></li>
+              <li class="tocline"><a href="#unencrypted-container" class="tocxref"><span class="secno">8.9.1 </span>Unencrypted Container</a></li>
+              <li class="tocline"><a href="#interoperably-encrypted" class="tocxref"><span class="secno">8.9.2 </span>Interoperably Encrypted</a></li>
+              <li class="tocline"><a href="#unencrypted-in-band-support-content" class="tocxref"><span class="secno">8.9.3 </span>Unencrypted In-band Support Content</a></li>
             </ol>
           </li>
         </ol>
@@ -1534,8 +1328,6 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
     </ol>
   </nav>
 
-
-
   <section id="introduction" class="informative" typeof="bibo:Chapter" resource="#introduction" property="bibo:hasPart">
     <!--OddPage-->
     <h2 id="h-introduction" resource="#h-introduction"><span property="xhv:role" resource="xhv:heading"><span class="secno">1. </span>Introduction</span>
@@ -1546,6 +1338,9 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
     </p>
     <p>
       Supported content is encrypted per container-specific "common encryption" specifications, enabling use across key systems. Supported content has an unencrypted container, enabling metadata to be provided to the application and maintaining compatibility with other <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#htmlmediaelement-htmlmediaelement">HTMLMediaElement</a></code> features.
+    </p>
+    <p>
+      Implementers should pay attention to the mitigations for the security and privacy threats and concerns described in this specification. In particular, the specification requirements for security and privacy cannot be met without knowledge of the security and privacy properties of the <a href="#key-system">Key System</a> and its implementation(s). The section on <a href="#implementation-requirements">Implementation requirements</a> contains security and privacy provisions related to the integration and use of underlying <a href="#key-system">Key System</a> implementations. The <a href="#security">Security</a> section focuses on external threats, such as input data or network attacks. The <a href="#privacy">Privacy</a> section focuses on the handling of user-specific information and providing users with adequate control over their own privacy.
     </p>
     <div class="note">
       <div class="note-title marker" aria-level="3" role="heading" id="h-note1"><span>Note</span></div>
@@ -1568,13 +1363,6 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <dt id="cdm">Content Decryption Module (CDM)</dt>
       <dd>
         <p>Content Decryption Module (CDM) is the client component that provides the functionality, including decryption, for one or more <a href="#key-system">Key Systems</a>.</p>
-        <div class="note">
-          <div class="note-title marker" aria-level="3" role="heading" id="h-note2"><span>Note</span></div>
-          <p class="">Implementations may or may not separate the implementations of CDMs or treat them as separate from the user agent. This is transparent to the API and application.</p>
-        </div>
-
-        <p>All messages and communication to and from the CDM, such as between the CDM and a license server, <em class="rfc2119" title="MUST">MUST</em> be passed through the user agent. The CDM <em class="rfc2119" title="MUST NOT">MUST NOT</em> make direct out-of band network requests. All messages and communication other than those described in <a href="#direct-individualization">Direct Individualization</a> <em class="rfc2119" title="MUST">MUST</em> be passed through the application via the APIs defined in this specification. Specifically, all communication that contains application-, <a href="https://www.w3.org/TR/html51/browsers.html#concept-cross-origin">origin</a>-, or content-specific information or is sent to a URL specified by the application or based on its origin, <em class="rfc2119" title="MUST">MUST</em> pass through the APIs. This includes all license exchange messages.
-        </p>
       </dd>
 
       <dt id="key-system">Key System</dt>
@@ -1584,12 +1372,12 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
         <p>A Key System string is always a reverse domain name. Key System strings are compared using case-sensitive matching. It is <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em> that CDMs use simple lower-case ASCII key system strings.</p>
         <div class="note">
-          <div class="note-title marker" aria-level="3" role="heading" id="h-note3"><span>Note</span></div>
+          <div class="note-title marker" aria-level="3" role="heading" id="h-note2"><span>Note</span></div>
           <p class="">For example, "com.example.somesystem".</p>
         </div>
 
         <div class="note">
-          <div class="note-title marker" aria-level="3" role="heading" id="h-note4"><span>Note</span></div>
+          <div class="note-title marker" aria-level="3" role="heading" id="h-note3"><span>Note</span></div>
           <p class="">
             Within a given system ("somesystem" in the example), subsystems may be defined as determined by the key system provider. For example, "com.example.somesystem.1" and "com.example.somesystem.1_5". Key System providers should keep in mind that these will be used for comparison and discovery, so they should be easy to compare and the structure should remain reasonably simple.
           </p>
@@ -1618,7 +1406,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         </p>
 
         <div class="note">
-          <div class="note-title marker" aria-level="3" role="heading" id="h-note5"><span>Note</span></div>
+          <div class="note-title marker" aria-level="3" role="heading" id="h-note4"><span>Note</span></div>
           <p class="">The underlying content protection protocol does not necessarily need to support Session IDs.</p>
         </div>
       </dd>
@@ -1629,7 +1417,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         </p>
 
         <div class="note">
-          <div class="note-title marker" aria-level="3" role="heading" id="h-note6"><span>Note</span></div>
+          <div class="note-title marker" aria-level="3" role="heading" id="h-note5"><span>Note</span></div>
           <p class="">Authors <em class="rfc2119" title="SHOULD">SHOULD</em> encrypt each set of stream(s) that requires enforcement of a meaningfully different policy with a distinct key (and key ID). For example, if policies may differ between two video resolutions, stream(s) containing one resolution should not be encrypted with the key used to encrypt stream(s) containing the other resolution. When encrypted, audio streams <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> use the same key as any video stream. This is the only way to ensure enforcement and compatibility across clients.
           </p>
         </div>
@@ -1639,7 +1427,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <dd>
         <p>A key is considered usable for decryption if the CDM is certain the key is currently usable to decrypt one or more blocks of <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#media-data">media data</a>.</p>
         <div class="note">
-          <div class="note-title marker" aria-level="3" role="heading" id="h-note7"><span>Note</span></div>
+          <div class="note-title marker" aria-level="3" role="heading" id="h-note6"><span>Note</span></div>
           <p class="">For example, a key is not usable for decryption if its license has expired. Even if its license has not expired, a key is not usable for decryption if other conditions (e.g., output protection) for its use are not currently satisfied.</p>
         </div>
       </dd>
@@ -1661,7 +1449,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         </p>
 
         <div class="note">
-          <div class="note-title marker" aria-level="3" role="heading" id="h-note8"><span>Note</span></div>
+          <div class="note-title marker" aria-level="3" role="heading" id="h-note7"><span>Note</span></div>
           <p class="">For example, a key could become unknown if an <code><a href="#dom-mediakeysession-update">update()</a></code> call provides a new license that does not include the key and includes instructions to replace the license(s) that previously contained the key.</p>
         </div>
       </dd>
@@ -1674,7 +1462,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <dt id="initialization-data">Initialization Data</dt>
       <dd>
         <div class="note">
-          <div class="note-title marker" aria-level="3" role="heading" id="h-note9"><span>Note</span></div>
+          <div class="note-title marker" aria-level="3" role="heading" id="h-note8"><span>Note</span></div>
           <p class="">
             <a href="#key-system">Key Systems</a> usually require a block of initialization data containing information about the stream to be decrypted before they can construct a license request message. This block could be a simple key or content ID or a more complex structure containing such information. It <em class="rfc2119" title="SHOULD">SHOULD</em> always allow unique identification of the <a href="#decryption-key">key(s)</a> needed to decrypt the content. This initialization information <em class="rfc2119" title="MAY">MAY</em> be obtained in some application-specific way or provided with the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#media-data">media data</a>.
           </p>
@@ -1703,7 +1491,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         <p>Initialization Data <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> contain Key System-specific data or values. Implementations <em class="rfc2119" title="MUST">MUST</em> support the common formats defined in [<cite><a class="bibref" href="#bib-EME-INITDATA-REGISTRY">EME-INITDATA-REGISTRY</a></cite>] for each <a href="#initialization-data-type">Initialization Data Type</a> they support.
         </p>
         <div class="note">
-          <div class="note-title marker" aria-level="3" role="heading" id="h-note10"><span>Note</span></div>
+          <div class="note-title marker" aria-level="3" role="heading" id="h-note9"><span>Note</span></div>
           <p class="">
             Use of proprietary formats/contents is discouraged, and supporting or using <em>only</em> proprietary formats is strongly discouraged. Proprietary formats should only be used with pre-existing content or on pre-existing client devices that do not support the common formats.
           </p>
@@ -1716,7 +1504,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
           Two or more identifiers or other values are said to be <dfn id="associable" data-dfn-type="dfn">associable</dfn> if they are identical <em>or</em> it is possible - with a reasonable amount of time and effort - to correlate or associate them. Otherwise, the values are <dfn id="non-associable" data-dfn-type="dfn">non-associable</dfn>.
         </p>
         <div class="note">
-          <div class="note-title marker" aria-level="3" role="heading" id="h-note11"><span>Note</span></div>
+          <div class="note-title marker" aria-level="3" role="heading" id="h-note10"><span>Note</span></div>
           <div class="">
             <p>For example, values created in the following ways are <a href="#associable">associable</a>:</p>
             <ul>
@@ -1748,7 +1536,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
           A Distinctive Value is a value, piece of data, implication of the possession of a piece of data, or an observable behavior or timing that is <em>not</em> shared across a large population of users or client devices. A Distinctive Value may be in memory or persisted.
         </p>
         <div class="note">
-          <div class="note-title marker" aria-level="3" role="heading" id="h-note12"><span>Note</span></div>
+          <div class="note-title marker" aria-level="3" role="heading" id="h-note11"><span>Note</span></div>
           <div class="">
             <p>Examples of Distinctive Values include but are not limited to:</p>
             <ul>
@@ -1774,7 +1562,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
           </div>
         </div>
         <div class="note">
-          <div class="note-title marker" aria-level="3" role="heading" id="h-note13"><span>Note</span></div>
+          <div class="note-title marker" aria-level="3" role="heading" id="h-note12"><span>Note</span></div>
           <p class="">While a Distinctive Value is typically unique to a user or client device, a value does not need to be strictly unique to be distinctive. For example, a value shared among a small number of users could still be distinctive.
           </p>
         </div>
@@ -1816,18 +1604,18 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
           When exposed outside the client, Distinctive Permanent Identifiers and values derived from or otherwise related to them <em class="rfc2119" title="MUST">MUST</em> be <a href="#encrypt-identifiers">encrypted</a>. Distinctive Permanent Identifiers <em class="rfc2119" title="MUST NOT">MUST NOT</em> ever be exposed to the application, even in encrypted form.
         </p>
         <div class="note">
-          <div class="note-title marker" aria-level="3" role="heading" id="h-note14"><span>Note</span></div>
+          <div class="note-title marker" aria-level="3" role="heading" id="h-note13"><span>Note</span></div>
           <p class="">While a Distinctive Permanent Identifier is typically unique to a user or client device, a Distinctive Permanent Identifier does not need to be strictly unique to be distinctive. For example, a Distinctive Permanent Identifier shared among a small number of users could still be distinctive.
           </p>
         </div>
         <div class="note">
-          <div class="note-title marker" aria-level="3" role="heading" id="h-note15"><span>Note</span></div>
+          <div class="note-title marker" aria-level="3" role="heading" id="h-note14"><span>Note</span></div>
           <p class="">
             A Distinctive Permanent Identifier is <em>not</em> a <a href="#distinctive-identifier">Distinctive Identifier</a> because it is not derived or generated (within the scope of this specification).
           </p>
         </div>
         <div class="note">
-          <div class="note-title marker" aria-level="3" role="heading" id="h-note16"><span>Note</span></div>
+          <div class="note-title marker" aria-level="3" role="heading" id="h-note15"><span>Note</span></div>
           <p class="">
             <code><a href="#dom-mediakeysystemconfiguration-distinctiveidentifier">distinctiveIdentifier</a></code> controls whether Distinctive Permanent Identifiers may be used. Specifically, Distinctive Permanent Identifiers may only be used when the value of the <code><a href="#dom-mediakeysystemconfiguration-distinctiveidentifier">distinctiveIdentifier</a></code> member of the <a href="#idl-def-mediakeysystemaccess" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemAccess</code></a> used to create the <a href="#idl-def-mediakeys" class="internalDFN" data-link-type="dfn"><code>MediaKeys</code></a> object is <code><a href="#idl-def-MediaKeysRequirement.required">"required"</a></code>.
           </p>
@@ -1837,7 +1625,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <dt id="distinctive-identifier">Distinctive Identifier</dt>
       <dd>
         <div class="note">
-          <div class="note-title marker" aria-level="3" role="heading" id="h-note17"><span>Note</span></div>
+          <div class="note-title marker" aria-level="3" role="heading" id="h-note16"><span>Note</span></div>
           <div class="">
             <p>
               A Distinctive Identifier is a value, including in opaque or encrypted form, for which it is possible for any entity external to the client to correlate or associate values beyond what a user may expect on the web platform (e.g., cookies and other site data). For example, values that are <a href="#associable-by-entity">associable by an entity other than the application</a> across a) <a href="https://www.w3.org/TR/html51/browsers.html#concept-cross-origin">origins</a>, b) <a href="#browsing-profile">browsing profiles</a>, or c) browsing sessions even after the user has attempted to protect his or her privacy by clearing browsing data or values for which it is not easy for a user to break such association. In particular, a value is a Distinctive Identifier if it is possible for a <a href="#associable-by-entity">central server, such as an individualization server, to associate</a> values across origins, such as because the <a href="#individualization">individualization</a> requests contained a common value, or because values provided in individualization requests are <a href="#associable-by-entity">associable by such server</a> even after attempts to clear browsing data. Possible causes of this include use of <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifier(s)</a> in the individualization process.
@@ -1851,7 +1639,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
           </div>
         </div>
         <div class="note">
-          <div class="note-title marker" aria-level="3" role="heading" id="h-note18"><span>Note</span></div>
+          <div class="note-title marker" aria-level="3" role="heading" id="h-note17"><span>Note</span></div>
           <p class="">
             <code><a href="#dom-mediakeysystemconfiguration-distinctiveidentifier">distinctiveIdentifier</a></code> controls whether Distinctive Identifiers may be used. Specifically, Distinctive Identifiers may only be used when the value of the <code><a href="#dom-mediakeysystemconfiguration-distinctiveidentifier">distinctiveIdentifier</a></code> member of the <a href="#idl-def-mediakeysystemaccess" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemAccess</code></a> used to create the <a href="#idl-def-mediakeys" class="internalDFN" data-link-type="dfn"><code>MediaKeys</code></a> object is <code><a href="#idl-def-MediaKeysRequirement.required">"required"</a></code>.
           </p>
@@ -1861,7 +1649,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
           <li>
             <p>It is <a href="#distinctive-value">distinctive</a>.</p>
             <div class="note">
-              <div class="note-title marker" aria-level="3" role="heading" id="h-note19"><span>Note</span></div>
+              <div class="note-title marker" aria-level="3" role="heading" id="h-note18"><span>Note</span></div>
               <p class="">While a Distinctive Identifier is typically unique to a user or client device, an identifier does not need to be strictly unique to be distinctive. For example, an identifier shared among a small number of users could still be distinctive.
               </p>
             </div>
@@ -1882,13 +1670,13 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
               <li>
                 <p>It is <a href="#allow-identifiers-cleared">clearable</a> but not <a href="#allow-persistent-data-cleared-with-cookies">along with cookies and other site data</a>.</p>
                 <div class="note">
-                  <div class="note-title marker" aria-level="3" role="heading" id="h-note20"><span>Note</span></div>
+                  <div class="note-title marker" aria-level="3" role="heading" id="h-note19"><span>Note</span></div>
                   <p class="">For example, via some mechanism external to the user agent, such as an OS-level mechanism.</p>
                 </div>
               </li>
             </ul>
             <div class="note">
-              <div class="note-title marker" aria-level="3" role="heading" id="h-note21"><span>Note</span></div>
+              <div class="note-title marker" aria-level="3" role="heading" id="h-note20"><span>Note</span></div>
               <div class="">
                 <p>Other properties of concern that are normatively prohibited for values exposed to the application include:</p>
                 <ul>
@@ -1941,14 +1729,14 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         </ul>
 
         <div class="note">
-          <div class="note-title marker" aria-level="3" role="heading" id="h-note22"><span>Note</span></div>
+          <div class="note-title marker" aria-level="3" role="heading" id="h-note21"><span>Note</span></div>
           <p class="">
             While Distinctive Identifier are usually <a href="#associable-by-entity">associable by the entity that generated them</a> they <em class="rfc2119" title="MUST">MUST</em> be <a href="#non-associable-by-application">non-associable by applications</a>. In other words, such correlation or association is only possible by the entity, such as an <a href="#individualization">individualization</a> server, that originally generated the Distinctive Identifier values. Entities with access to the <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifier(s)</a> <em class="rfc2119" title="MUST NOT">MUST NOT</em> expose this capability to applications, as this would make resulting Distinctive Identifiers <a href="#associable-by-application">associable by the application</a>, and <em class="rfc2119" title="SHOULD">SHOULD</em> take care to avoid exposing such correlation to other entities or third parties.
           </p>
         </div>
 
         <div class="note">
-          <div class="note-title marker" aria-level="3" role="heading" id="h-note23"><span>Note</span></div>
+          <div class="note-title marker" aria-level="3" role="heading" id="h-note22"><span>Note</span></div>
           <div class="">
             <p>Examples of Distinctive Identifiers include but are not limited to:</p>
             <ul>
@@ -2029,7 +1817,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
           <a href="#uses-distinctive-identifiers">uses Distinctive Identifier(s)</a> and/or <a href="#uses-distinctive-permanent-identifiers">uses Distinctive Permanent Identifier(s)</a>.
         </p>
         <div class="note">
-          <div class="note-title marker" aria-level="3" role="heading" id="h-note24"><span>Note</span></div>
+          <div class="note-title marker" aria-level="3" role="heading" id="h-note23"><span>Note</span></div>
           <p class="">
             <code><a href="#dom-mediakeysystemconfiguration-distinctiveidentifier">distinctiveIdentifier</a></code> controls whether <a href="#distinctive-identifier">Distinctive Identifiers</a> and <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifiers</a> may be used. Specifically, such identifiers may only be used when the value of the <code><a href="#dom-mediakeysystemconfiguration-distinctiveidentifier">distinctiveIdentifier</a></code> member of the <a href="#idl-def-mediakeysystemaccess" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemAccess</code></a> used to create the <a href="#idl-def-mediakeys" class="internalDFN" data-link-type="dfn"><code>MediaKeys</code></a> object is <code><a href="#idl-def-MediaKeysRequirement.required">"required"</a></code>.
           </p>
@@ -2064,7 +1852,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
           A User Agent on a given machine may support execution in a variety of different contexts or modes or temporary states that are expected to behave independently with respect to application-visible state and data. In particular, all stored data is expected to be independent. In this specification we refer to such independent contexts or modes as "Browsing Profiles".
         </p>
         <div class="note">
-          <div class="note-title marker" aria-level="3" role="heading" id="h-note25"><span>Note</span></div>
+          <div class="note-title marker" aria-level="3" role="heading" id="h-note24"><span>Note</span></div>
           <p class="">
             Examples of such independent contexts include if the user agent is running in different operating system user accounts or if the user agent provides the capability to define multiple independent profiles for a single account.
           </p>
@@ -2087,18 +1875,20 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       </h3>
 
       <div>
-        <pre class="def idl"><span class="idlInterface" id="idl-def-navigator-partial-1" data-idl="" data-title="Navigator">partial interface <span class="idlInterfaceID">Navigator</span> {
-<span class="idlMethod" id="idl-def-navigator-requestmediakeysystemaccess(keysystem,supportedconfigurations)" data-idl="" data-title="requestMediaKeySystemAccess" data-dfn-for="navigator">    [<span class="extAttr"><span class="extAttrName"><a href="https://www.w3.org/TR/WebIDL-1/#SecureContext">SecureContext</a></span></span>]
-    <span class="idlMethType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-promise">Promise</a>&lt;<a href="#idl-def-mediakeysystemaccess" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemAccess</code></a>&gt;</span> <span class="idlMethName"><a data-lt="requestMediaKeySystemAccess" href="#dom-navigator-requestmediakeysystemaccess" class="internalDFN" data-link-type="dfn" data-for="Navigator"><code>requestMediaKeySystemAccess</code></a></span>(<span class="idlParam"><span class="idlParamType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-DOMString">DOMString</a></span> <span class="idlParamName">keySystem</span></span>,
-                                                                                  <span class="idlParam"><span class="idlParamType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-sequence">sequence</a>&lt;<a href="#idl-def-mediakeysystemconfiguration" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemConfiguration</code></a>&gt;</span> <span class="idlParamName">supportedConfigurations</span></span>);</span>
+        <div>
+          <pre class="def idl"><span class="idlInterface" id="idl-def-navigator-partial-1" data-idl="" data-title="Navigator">partial interface <span class="idlInterfaceID">Navigator</span> {
+<span class="idlMethod" id="idl-def-navigator-requestmediakeysystemaccess(keysystem,supportedconfigurations)" data-idl="" data-title="requestMediaKeySystemAccess" data-dfn-for="navigator">    [<span class="extAttr"><span class="extAttrName"><a href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a></span></span>]
+    <span class="idlMethType"><a href="https://heycam.github.io/webidl/#idl-promise">Promise</a>&lt;<a href="#idl-def-mediakeysystemaccess" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemAccess</code></a>&gt;</span> <span class="idlMethName"><a data-lt="requestMediaKeySystemAccess" href="#dom-navigator-requestmediakeysystemaccess" class="internalDFN" data-link-type="dfn" data-for="Navigator"><code>requestMediaKeySystemAccess</code></a></span>(<span class="idlParam"><span class="idlParamType"><a href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></span> <span class="idlParamName">keySystem</span></span>,
+                                                                                  <span class="idlParam"><span class="idlParamType"><a href="https://heycam.github.io/webidl/#idl-sequence">sequence</a>&lt;<a href="#idl-def-mediakeysystemconfiguration" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemConfiguration</code></a>&gt;</span> <span class="idlParamName">supportedConfigurations</span></span>);</span>
 };</span></pre>
+        </div>
 
         <section typeof="bibo:Chapter" resource="#methods" property="bibo:hasPart">
           <h4 id="methods" resource="#methods"><span property="xhv:role" resource="xhv:heading">Methods</span></h4>
           <dl class="methods" data-dfn-for="Navigator" data-link-for="Navigator"><dt><dfn data-dfn-for="navigator" data-dfn-type="dfn" id="dom-navigator-requestmediakeysystemaccess" data-idl="" data-title="requestMediaKeySystemAccess" data-lt="requestmediakeysystemaccess()|requestMediaKeySystemAccess"><code id="requestMediaKeySystemAccess">requestMediaKeySystemAccess</code></dfn></dt>
             <dd>
               <div class="note">
-                <div class="note-title marker" aria-level="5" role="heading" id="h-note26"><span>Note</span></div>
+                <div class="note-title marker" aria-level="5" role="heading" id="h-note25"><span>Note</span></div>
                 <p class="">Calling this method may have <em>user-visible effects</em>, including requests for user consent. This method should only be called when the author intends to create and use a <a href="#idl-def-mediakeys" class="internalDFN" data-link-type="dfn"><code>MediaKeys</code></a> object with the provided configuration.
                 </p>
               </div>
@@ -2108,7 +1898,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
               <p>If the <code>keySystem</code> is not supported or not allowed (in at least one of the <code>supportedConfigurations</code>, if specified), the promise is rejected. Otherwise, it is resolved with a new <a href="#idl-def-mediakeysystemaccess" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemAccess</code></a> object.
               </p>
               <div class="note">
-                <div class="note-title marker" aria-level="5" role="heading" id="h-note27"><span>Note</span></div>
+                <div class="note-title marker" aria-level="5" role="heading" id="h-note26"><span>Note</span></div>
                 <div class="">
                   <p>This method is only exposed to <a href="https://www.w3.org/TR/secure-contexts/#secure-context">secure contexts</a> [<cite><a class="bibref" href="#bib-SECURE-CONTEXTS">SECURE-CONTEXTS</a></cite>] as indicated by the <code>[SecureContext]</code> IDL attribute.</p>
                   <p>
@@ -2213,7 +2003,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                     <li>
                       <p>Reject <var>promise</var> with a <code><a href="#dfn-NotSupportedError">NotSupportedError</a></code>.</p>
                       <div class="note">
-                        <div class="note-title marker" aria-level="5" role="heading" id="h-note28"><span>Note</span></div>
+                        <div class="note-title marker" aria-level="5" role="heading" id="h-note27"><span>Note</span></div>
                         <p class=""><code>keySystem</code> was not supported/allowed or none of the configurations in <code>supportedConfigurations</code> were supported/allowed.</p>
                       </div>
                     </li>
@@ -2237,12 +2027,12 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
           </h5>
           <p>Given a <a href="#key-system">Key Systems</a> implementation <var>implementation</var>, <a href="#idl-def-mediakeysystemconfiguration" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemConfiguration</code></a> <var>candidate configuration</var>, and <var>origin</var>, this algorithm returns a supported configuration or <code>NotSupported</code> as appropriate.</p>
           <div class="note">
-            <div class="note-title marker" aria-level="6" role="heading" id="h-note29"><span>Note</span></div>
+            <div class="note-title marker" aria-level="6" role="heading" id="h-note28"><span>Note</span></div>
             <p class="">Unrecognized dictionary members in <var>candidate configuration</var> are ignored per [<cite><a class="bibref" href="#bib-WebIDL">WebIDL</a></cite>] and will never reach this algorithm. Thus, they cannot be considered as part of the configuration.
             </p>
           </div>
           <div class="note">
-            <div class="note-title marker" aria-level="6" role="heading" id="h-note30"><span>Note</span></div>
+            <div class="note-title marker" aria-level="6" role="heading" id="h-note29"><span>Note</span></div>
             <div class="">
               <p>
                 For certain configurations, it may be required to obtain user consent or inform the user. User Agents have some flexibility to determine whether consent is required for a specific configuration and whether such consent may also apply to other configurations. For example, consent to one configuration may also imply consent for less powerful, more restricted configurations. Equally, a denial of consent for one configuration may imply denial of consent for more powerful, less restricted configurations.
@@ -2255,7 +2045,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                 User Agents should reuse earlier consent responses, when appropriate, at least for the duration of the <code><a href="#dom-navigator-requestmediakeysystemaccess">requestMediaKeySystemAccess()</a></code> algorithm in order to avoid repeated requests to the user for similar configurations.
               </p>
               <p>
-                The variable <var>restrictions</var> in the steps below represents the configurations for which consent has been denied during the execution of this algorithm or based on persisted consent information for the origin. It is used to determine whether user consent for a candidate configuration or partial configuration has been denied. Consent is denied for a partial configuration if every derived configuration has already been denied. Internal representation of <var>restrictions</var> is implementation-specific.
+                The variable <var>restrictions</var> in the steps below represents the configurations for which consent has been denied during the execution of this algorithm or based on persisted consent information for the origin. It is used to determine whether user consent for a candidate configuration or accumulated configuration has been denied. Consent is denied for a accumulated configuration if every derived configuration has already been denied. Internal representation of <var>restrictions</var> is implementation-specific.
               </p>
             </div>
           </div>
@@ -2316,7 +2106,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                       <p>If the <var>implementation</var> supports generating requests based on <var>initDataType</var>, add <var>initDataType</var> to <var>supported types</var>. String comparison is case-sensitive. The empty string is never supported.
                       </p>
                       <div class="note">
-                        <div class="note-title marker" aria-level="6" role="heading" id="h-note31"><span>Note</span></div>
+                        <div class="note-title marker" aria-level="6" role="heading" id="h-note30"><span>Note</span></div>
                         <p class="">The <var>initDataType</var> <em class="rfc2119" title="MUST">MUST</em> be supported independent of content types in order to avoid unexpectedly rejecting the configuration in later steps. Support for <var>initDataType</var> includes both license generation and, when appropriate, extraction from media data. See <a href="#initialization-data-type-support-requirements">Initialization Data Type Support requirements</a>.
                         </p>
                       </div>
@@ -2370,7 +2160,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                 </dd>
               </dl>
               <div class="note">
-                <div class="note-title marker" aria-level="6" role="heading" id="h-note32"><span>Note</span></div>
+                <div class="note-title marker" aria-level="6" role="heading" id="h-note31"><span>Note</span></div>
                 <div class="">
                   <p>
                     The combination of <var>accumulated configuration</var> and <var>restrictions</var> means all the possible configurations that include everything in <var>accumulated configuration</var> and that are not denied according to <var>restrictions</var>.
@@ -2546,7 +2336,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
             <li>
               <p>If <var>implementation</var> in the configuration specified by the combination of the values in <var>accumulated configuration</var> is not supported or not allowed in the <var>origin</var>, return <code>NotSupported</code>.</p>
               <div class="note">
-                <div class="note-title marker" aria-level="6" role="heading" id="h-note33"><span>Note</span></div>
+                <div class="note-title marker" aria-level="6" role="heading" id="h-note32"><span>Note</span></div>
                 <p class="">In this step, "supported" includes the implementation being available for use when this algorithm returns, not just user agent support for such an implementation.</p>
               </div>
             </li>
@@ -2567,7 +2357,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                 </li>
               </ol>
               <div class="note">
-                <div class="note-title marker" aria-level="6" role="heading" id="h-note34"><span>Note</span></div>
+                <div class="note-title marker" aria-level="6" role="heading" id="h-note33"><span>Note</span></div>
                 <div class="">
                   <p>
                     The "unique per origin and profile" and "clearable" conditions cannot be false in a compliant implementation because implementations <em class="rfc2119" title="MUST">MUST</em> <a href="#per-origin-per-profile-identifiers">use per-origin per-profile identifiers</a> and <a href="#allow-identifiers-cleared">allow the user to clear identifier</a>.
@@ -2610,10 +2400,10 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         <section id="get-supported-capabilities-for-audio-video-type" typeof="bibo:Chapter" resource="#get-supported-capabilities-for-audio-video-type" property="bibo:hasPart">
           <h5 id="h-get-supported-capabilities-for-audio-video-type" resource="#h-get-supported-capabilities-for-audio-video-type"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.1.1.3 </span>Get Supported Capabilities for Audio/Video Type</span>
           </h5>
-          <p>Given an <var>audio/video type</var>, <a href="#idl-def-mediakeysystemmediacapability" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemMediaCapability</code></a> sequence <var>requested media capabilities</var>, <a href="#idl-def-mediakeysystemconfiguration" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemConfiguration</code></a> <var>partial configuration</var>, and <var>restrictions</var>, this algorithm returns a sequence of supported <a href="#idl-def-mediakeysystemmediacapability" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemMediaCapability</code></a> values for this audio/video type or <code>null</code> as appropriate.</p>
+          <p>Given an <var>audio/video type</var>, <a href="#idl-def-mediakeysystemmediacapability" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemMediaCapability</code></a> sequence <var>requested media capabilities</var>, <a href="#idl-def-mediakeysystemconfiguration" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemConfiguration</code></a> <var>accumulated configuration</var>, and <var>restrictions</var>, this algorithm returns a sequence of supported <a href="#idl-def-mediakeysystemmediacapability" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemMediaCapability</code></a> values for this audio/video type or <code>null</code> as appropriate.</p>
           <ol>
             <li>
-              <p>Let <var>local accumulated configuration</var> be a local copy of <var>partial configuration</var>.</p>
+              <p>Let <var>local accumulated configuration</var> be a local copy of <var>accumulated configuration</var>.</p>
             </li>
             <li>
               <p>Let <var>supported media capabilities</var> be an empty sequence of <a href="#idl-def-mediakeysystemmediacapability" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemMediaCapability</code></a> dictionaries.</p>
@@ -2640,7 +2430,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                 <li>
                   <p>If the user agent does not support <var>container</var>, continue to the next iteration. The case-sensitivity of string comparisons is determined by the appropriate RFC.</p>
                   <div class="note">
-                    <div class="note-title marker" aria-level="6" role="heading" id="h-note35"><span>Note</span></div>
+                    <div class="note-title marker" aria-level="6" role="heading" id="h-note34"><span>Note</span></div>
                     <p class="">Per RFC 6838 [<cite><a class="bibref" href="#bib-RFC6838">RFC6838</a></cite>], "Both top-level type and subtype names are case-insensitive."</p>
                   </div>
                 </li>
@@ -2653,7 +2443,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                 <li>
                   <p>Let <var>media types</var> be the set of codecs and codec constraints specified by <var>parameters</var>. The case-sensitivity of string comparisons is determined by the appropriate RFC or other specification.</p>
                   <div class="note">
-                    <div class="note-title marker" aria-level="6" role="heading" id="h-note36"><span>Note</span></div>
+                    <div class="note-title marker" aria-level="6" role="heading" id="h-note35"><span>Note</span></div>
                     <p class="">Case-sensitive string comparison is <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em> because RFC 6381 [<cite><a class="bibref" href="#bib-RFC6381">RFC6381</a></cite>] says, "Values are case sensitive" for some formats.</p>
                   </div>
                 </li>
@@ -2679,7 +2469,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                 <li>
                   <p>If <var>content type</var> is not strictly a <var>audio/video type</var>, continue to the next iteration.</p>
                   <div class="note">
-                    <div class="note-title marker" aria-level="6" role="heading" id="h-note37"><span>Note</span></div>
+                    <div class="note-title marker" aria-level="6" role="heading" id="h-note36"><span>Note</span></div>
                     <p class="">For example, if <var>audio/video type</var> is Video and the top-level type is not "video" or <var>media types</var> contains non-video codecs.</p>
                   </div>
                 </li>
@@ -2689,7 +2479,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                 <li>
                   <p>If the user agent and <var>implementation</var> definitely support playback of encrypted <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#media-data">media data</a> for the combination of <var>container</var>, <var>media types</var>, <var>robustness</var> and <var>local accumulated configuration</var> in combination with <var>restrictions</var>:</p>
                   <div class="note">
-                    <div class="note-title marker" aria-level="6" role="heading" id="h-note38"><span>Note</span></div>
+                    <div class="note-title marker" aria-level="6" role="heading" id="h-note37"><span>Note</span></div>
                     <p class=""><var>requested media capability</var> (content type and robustness) must be supported when used together with all previously added requested media capabilities.</p>
                   </div>
                   <ol>
@@ -2698,7 +2488,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                         Add <var>requested media capability</var> to <var>supported media capabilities</var>.
                       </p>
                       <div class="note">
-                        <div class="note-title marker" aria-level="6" role="heading" id="h-note39"><span>Note</span></div>
+                        <div class="note-title marker" aria-level="6" role="heading" id="h-note38"><span>Note</span></div>
                         <p class="">
                           This step ensures that the values of the members of entries in <var>supported media capabilities</var> are exactly the strings supplied in
                           <var>requested media capability</var> without modification by the User Agent.
@@ -2721,7 +2511,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                         </dd>
                       </dl>
                       <div class="note">
-                        <div class="note-title marker" aria-level="6" role="heading" id="h-note40"><span>Note</span></div>
+                        <div class="note-title marker" aria-level="6" role="heading" id="h-note39"><span>Note</span></div>
                         <p class="">
                           This step ensures that configurations are always checked with configurations from previous iterations, including from previous calls to this algorithm. Otherwise, only configurations from previous calls to this algorithm would be checked in subsequent calls.
                         </p>
@@ -2734,8 +2524,8 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
             <li>
               <p>If <var>supported media capabilities</var> is empty, return <code>null</code>.</p>
               <div class="note">
-                <div class="note-title marker" aria-level="6" role="heading" id="h-note41"><span>Note</span></div>
-                <p class="">None of the <a href="#idl-def-mediakeysystemmediacapability" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemMediaCapability</code></a> elements in <var>requested media capabilities</var> is supported in combination with <var>partial configuration</var>.</p>
+                <div class="note-title marker" aria-level="6" role="heading" id="h-note40"><span>Note</span></div>
+                <p class="">None of the <a href="#idl-def-mediakeysystemmediacapability" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemMediaCapability</code></a> elements in <var>requested media capabilities</var> is supported in combination with <var>accumulated configuration</var>.</p>
               </div>
             </li>
             <li>
@@ -2752,7 +2542,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
             <var>accumulated configuration</var> and <var>origin</var> as one of <code>ConsentDenied</code>, <code>InformUser</code> or <code>Allowed</code>, together with an updated value for <var>restrictions</var> in the <code>ConsentDenied</code> case.
           </p>
           <div class="note">
-            <div class="note-title marker" aria-level="6" role="heading" id="h-note42"><span>Note</span></div>
+            <div class="note-title marker" aria-level="6" role="heading" id="h-note41"><span>Note</span></div>
             <div class="">
               <p>
                 Consent status for <var>accumulated configuration</var> depends at least on the value of the <code><a href="#dom-mediakeysystemconfiguration-distinctiveidentifier">distinctiveIdentifier</a></code> member of
@@ -2800,7 +2590,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                     The user agent requires explicit user consent for the <var>accumulated configuration</var> for other reasons.
                   </p>
                   <div class="note">
-                    <div class="note-title marker" aria-level="6" role="heading" id="h-note43"><span>Note</span></div>
+                    <div class="note-title marker" aria-level="6" role="heading" id="h-note42"><span>Note</span></div>
                     <p class="">
                       Another reason for requiring explicit user consent may be due to the security properties of the CDM implementation.
                     </p>
@@ -2818,7 +2608,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                     <var>accumulated configuration</var>'s <code><a href="#dom-mediakeysystemconfiguration-distinctiveidentifier">distinctiveIdentifier</a></code> member is <code><a href="#idl-def-MediaKeysRequirement.required">"required"</a></code>.
                   </p>
                   <div class="note">
-                    <div class="note-title marker" aria-level="6" role="heading" id="h-note44"><span>Note</span></div>
+                    <div class="note-title marker" aria-level="6" role="heading" id="h-note43"><span>Note</span></div>
                     <div class="">
 
                       <p>User consent to use <var>accumulated configuration</var> is specific to the <var>origin</var> and may be limited to configurations sharing certain properties with <var>accumulated configuration</var>.</p>
@@ -2864,12 +2654,13 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       </h3>
 
       <div>
-        <pre class="def idl"><span class="idlEnum" id="idl-def-mediakeysrequirement" data-idl="" data-title="MediaKeysRequirement">[<span class="extAttr"><span class="extAttrName"><a href="https://www.w3.org/TR/WebIDL-1/#SecureContext">SecureContext</a></span></span>]
-enum <span class="idlEnumID">MediaKeysRequirement</span> {
+        <div>
+          <pre class="def idl"><span class="idlEnum" id="idl-def-mediakeysrequirement" data-idl="" data-title="MediaKeysRequirement">enum <span class="idlEnumID">MediaKeysRequirement</span> {
     <a href="#dom-mediakeysrequirement-required" class="idlEnumItem">"required"</a>,
     <a href="#dom-mediakeysrequirement-optional" class="idlEnumItem">"optional"</a>,
     <a href="#dom-mediakeysrequirement-not-allowed" class="idlEnumItem">"not-allowed"</a>
 };</span></pre>
+        </div>
         <table class="simple" data-dfn-for="MediaKeysRequirement" data-link-for="MediaKeysRequirement">
           <tbody>
             <tr>
@@ -2913,16 +2704,17 @@ enum <span class="idlEnumID">MediaKeysRequirement</span> {
       </div>
 
       <div>
-        <pre class="def idl"><span class="idlDictionary" id="idl-def-mediakeysystemconfiguration" data-idl="" data-title="MediaKeySystemConfiguration">[<span class="extAttr"><span class="extAttrName"><a href="https://www.w3.org/TR/WebIDL-1/#SecureContext">SecureContext</a></span></span>]
-dictionary <span class="idlDictionaryID">MediaKeySystemConfiguration</span> {
-<span class="idlMember" id="idl-def-mediakeysystemconfiguration-label" data-idl="" data-title="label" data-dfn-for="mediakeysystemconfiguration">    <span class="idlMemberType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-DOMString">DOMString</a></span>                               <span class="idlMemberName"><a data-lt="label" href="#dom-mediakeysystemconfiguration-label" class="internalDFN" data-link-type="dfn" data-for="MediaKeySystemConfiguration"><code>label</code></a></span> = <span class="idlMemberValue">""</span>;</span>
-<span class="idlMember" id="idl-def-mediakeysystemconfiguration-initdatatypes" data-idl="" data-title="initDataTypes" data-dfn-for="mediakeysystemconfiguration">    <span class="idlMemberType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-sequence">sequence</a>&lt;<a href="https://www.w3.org/TR/WebIDL-1/#idl-DOMString">DOMString</a>&gt;</span>                     <span class="idlMemberName"><a data-lt="initDataTypes" href="#dom-mediakeysystemconfiguration-initdatatypes" class="internalDFN" data-link-type="dfn" data-for="MediaKeySystemConfiguration"><code>initDataTypes</code></a></span> = <span class="idlMemberValue">[]</span>;</span>
-<span class="idlMember" id="idl-def-mediakeysystemconfiguration-audiocapabilities" data-idl="" data-title="audioCapabilities" data-dfn-for="mediakeysystemconfiguration">    <span class="idlMemberType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-sequence">sequence</a>&lt;<a href="#idl-def-mediakeysystemmediacapability" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemMediaCapability</code></a>&gt;</span> <span class="idlMemberName"><a data-lt="audioCapabilities" href="#dom-mediakeysystemconfiguration-audiocapabilities" class="internalDFN" data-link-type="dfn" data-for="MediaKeySystemConfiguration"><code>audioCapabilities</code></a></span> = <span class="idlMemberValue">[]</span>;</span>
-<span class="idlMember" id="idl-def-mediakeysystemconfiguration-videocapabilities" data-idl="" data-title="videoCapabilities" data-dfn-for="mediakeysystemconfiguration">    <span class="idlMemberType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-sequence">sequence</a>&lt;<a href="#idl-def-mediakeysystemmediacapability" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemMediaCapability</code></a>&gt;</span> <span class="idlMemberName"><a data-lt="videoCapabilities" href="#dom-mediakeysystemconfiguration-videocapabilities" class="internalDFN" data-link-type="dfn" data-for="MediaKeySystemConfiguration"><code>videoCapabilities</code></a></span> = <span class="idlMemberValue">[]</span>;</span>
+        <div>
+          <pre class="def idl"><span class="idlDictionary" id="idl-def-mediakeysystemconfiguration" data-idl="" data-title="MediaKeySystemConfiguration">dictionary <span class="idlDictionaryID">MediaKeySystemConfiguration</span> {
+<span class="idlMember" id="idl-def-mediakeysystemconfiguration-label" data-idl="" data-title="label" data-dfn-for="mediakeysystemconfiguration">    <span class="idlMemberType"><a href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></span>                               <span class="idlMemberName"><a data-lt="label" href="#dom-mediakeysystemconfiguration-label" class="internalDFN" data-link-type="dfn" data-for="MediaKeySystemConfiguration"><code>label</code></a></span> = <span class="idlMemberValue">""</span>;</span>
+<span class="idlMember" id="idl-def-mediakeysystemconfiguration-initdatatypes" data-idl="" data-title="initDataTypes" data-dfn-for="mediakeysystemconfiguration">    <span class="idlMemberType"><a href="https://heycam.github.io/webidl/#idl-sequence">sequence</a>&lt;<a href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>&gt;</span>                     <span class="idlMemberName"><a data-lt="initDataTypes" href="#dom-mediakeysystemconfiguration-initdatatypes" class="internalDFN" data-link-type="dfn" data-for="MediaKeySystemConfiguration"><code>initDataTypes</code></a></span> = <span class="idlMemberValue">[]</span>;</span>
+<span class="idlMember" id="idl-def-mediakeysystemconfiguration-audiocapabilities" data-idl="" data-title="audioCapabilities" data-dfn-for="mediakeysystemconfiguration">    <span class="idlMemberType"><a href="https://heycam.github.io/webidl/#idl-sequence">sequence</a>&lt;<a href="#idl-def-mediakeysystemmediacapability" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemMediaCapability</code></a>&gt;</span> <span class="idlMemberName"><a data-lt="audioCapabilities" href="#dom-mediakeysystemconfiguration-audiocapabilities" class="internalDFN" data-link-type="dfn" data-for="MediaKeySystemConfiguration"><code>audioCapabilities</code></a></span> = <span class="idlMemberValue">[]</span>;</span>
+<span class="idlMember" id="idl-def-mediakeysystemconfiguration-videocapabilities" data-idl="" data-title="videoCapabilities" data-dfn-for="mediakeysystemconfiguration">    <span class="idlMemberType"><a href="https://heycam.github.io/webidl/#idl-sequence">sequence</a>&lt;<a href="#idl-def-mediakeysystemmediacapability" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemMediaCapability</code></a>&gt;</span> <span class="idlMemberName"><a data-lt="videoCapabilities" href="#dom-mediakeysystemconfiguration-videocapabilities" class="internalDFN" data-link-type="dfn" data-for="MediaKeySystemConfiguration"><code>videoCapabilities</code></a></span> = <span class="idlMemberValue">[]</span>;</span>
 <span class="idlMember" id="idl-def-mediakeysystemconfiguration-distinctiveidentifier" data-idl="" data-title="distinctiveIdentifier" data-dfn-for="mediakeysystemconfiguration">    <span class="idlMemberType"><a href="#idl-def-mediakeysrequirement" class="internalDFN" data-link-type="dfn"><code>MediaKeysRequirement</code></a></span>                    <span class="idlMemberName"><a data-lt="distinctiveIdentifier" href="#dom-mediakeysystemconfiguration-distinctiveidentifier" class="internalDFN" data-link-type="dfn" data-for="MediaKeySystemConfiguration"><code>distinctiveIdentifier</code></a></span> = <span class="idlMemberValue">"optional"</span>;</span>
 <span class="idlMember" id="idl-def-mediakeysystemconfiguration-persistentstate" data-idl="" data-title="persistentState" data-dfn-for="mediakeysystemconfiguration">    <span class="idlMemberType"><a href="#idl-def-mediakeysrequirement" class="internalDFN" data-link-type="dfn"><code>MediaKeysRequirement</code></a></span>                    <span class="idlMemberName"><a data-lt="persistentState" href="#dom-mediakeysystemconfiguration-persistentstate" class="internalDFN" data-link-type="dfn" data-for="MediaKeySystemConfiguration"><code>persistentState</code></a></span> = <span class="idlMemberValue">"optional"</span>;</span>
-<span class="idlMember" id="idl-def-mediakeysystemconfiguration-sessiontypes" data-idl="" data-title="sessionTypes" data-dfn-for="mediakeysystemconfiguration">    <span class="idlMemberType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-sequence">sequence</a>&lt;<a href="https://www.w3.org/TR/WebIDL-1/#idl-DOMString">DOMString</a>&gt;</span>                     <span class="idlMemberName"><a data-lt="sessionTypes" href="#dom-mediakeysystemconfiguration-sessiontypes" class="internalDFN" data-link-type="dfn" data-for="MediaKeySystemConfiguration"><code>sessionTypes</code></a></span>;</span>
+<span class="idlMember" id="idl-def-mediakeysystemconfiguration-sessiontypes" data-idl="" data-title="sessionTypes" data-dfn-for="mediakeysystemconfiguration">    <span class="idlMemberType"><a href="https://heycam.github.io/webidl/#idl-sequence">sequence</a>&lt;<a href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>&gt;</span>                     <span class="idlMemberName"><a data-lt="sessionTypes" href="#dom-mediakeysystemconfiguration-sessiontypes" class="internalDFN" data-link-type="dfn" data-for="MediaKeySystemConfiguration"><code>sessionTypes</code></a></span>;</span>
 };</span></pre>
+        </div>
 
         <section typeof="bibo:Chapter" resource="#dictionary-mediakeysystemconfiguration-members" property="bibo:hasPart">
           <h4 id="dictionary-mediakeysystemconfiguration-members" resource="#dictionary-mediakeysystemconfiguration-members"><span property="xhv:role" resource="xhv:heading">Dictionary <a class="idlType internalDFN" href="#idl-def-mediakeysystemconfiguration" data-link-type="dfn"><code>MediaKeySystemConfiguration</code></a> Members</span></h4>
@@ -2948,16 +2740,16 @@ dictionary <span class="idlDictionaryID">MediaKeySystemConfiguration</span> {
               Whether the ability to persist state is required. This includes session data and any other type of state.
               <p>The CDM <em class="rfc2119" title="MUST NOT">MUST NOT</em> persist any state related to the application or <a href="https://www.w3.org/TR/html51/browsers.html#concept-cross-origin">origin</a> of this object's <a href="https://www.w3.org/TR/dom/#concept-document">Document</a> when this member is <code><a href="#idl-def-MediaKeysRequirement.not-allowed">"not-allowed"</a></code>.</p>
               <div class="note">
-                <div class="note-title marker" aria-level="5" role="heading" id="h-note45"><span>Note</span></div>
+                <div class="note-title marker" aria-level="5" role="heading" id="h-note44"><span>Note</span></div>
                 <p class="">For the purposes of this member, persistent state does not include persistent unique identifiers (<a href="#distinctive-identifier">Distinctive Identifiers</a>) controlled by the <a href="#key-system">Key System</a> implementation. <code><a href="#dom-mediakeysystemconfiguration-distinctiveidentifier">distinctiveIdentifier</a></code> independently reflects this requirement.</p>
               </div>
               <p>Only <code><a href="#idl-def-MediaKeySessionType.temporary">"temporary"</a></code> sessions may be created when persistent state is not supported.</p>
               <div class="note">
-                <div class="note-title marker" aria-level="5" role="heading" id="h-note46"><span>Note</span></div>
+                <div class="note-title marker" aria-level="5" role="heading" id="h-note45"><span>Note</span></div>
                 <p class="">For <code><a href="#idl-def-MediaKeySessionType.temporary">"temporary"</a></code> sessions, the need and ability to store state is <a href="#key-system">Key System</a> implementation-specific and may vary by feature used.</p>
               </div>
               <div class="note">
-                <div class="note-title marker" aria-level="5" role="heading" id="h-note47"><span>Note</span></div>
+                <div class="note-title marker" aria-level="5" role="heading" id="h-note46"><span>Note</span></div>
                 <p class="">Applications intending to create non-<code><a href="#idl-def-MediaKeySessionType.temporary">"temporary"</a></code> sessions, should set this member to <code><a href="#idl-def-MediaKeysRequirement.required">"required"</a></code> when calling <code><a href="#dom-navigator-requestmediakeysystemaccess">requestMediaKeySystemAccess()</a></code>.</p>
               </div>
             </dd><dt><dfn data-dfn-for="mediakeysystemconfiguration" data-dfn-type="dfn" id="dom-mediakeysystemconfiguration-sessiontypes" data-idl="" data-title="sessionTypes"><code>sessionTypes</code></dfn> of type <span class="idlMemberType">sequence&lt;DOMString&gt;</span></dt>
@@ -2972,7 +2764,7 @@ dictionary <span class="idlDictionaryID">MediaKeySystemConfiguration</span> {
       <p>Implementations <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> add members to the this dictionary. Should member(s) be added, they <em class="rfc2119" title="MUST">MUST</em> be of type <a href="#idl-def-mediakeysrequirement" class="internalDFN" data-link-type="dfn"><code>MediaKeysRequirement</code></a>, and it is <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em> that they have default values of <code><a href="#idl-def-MediaKeysRequirement.optional">"optional"</a></code> to support the widest range of application and client combinations.
       </p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note48"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note47"><span>Note</span></div>
         <p class="">Dictionary members not recognized by a user agent implementation are ignored per [<cite><a class="bibref" href="#bib-WebIDL">WebIDL</a></cite>] and will not be considered in the <code><a href="#dom-navigator-requestmediakeysystemaccess">requestMediaKeySystemAccess()</a></code> algorithm. Should an application use non-standard dictionary member(s), it <em class="rfc2119" title="MUST NOT">MUST NOT</em> rely on user agent implementations rejecting a configuration that includes such dictionary members.
         </p>
       </div>
@@ -2984,11 +2776,12 @@ dictionary <span class="idlDictionaryID">MediaKeySystemConfiguration</span> {
       <h3 id="h-mediakeysystemmediacapability-dictionary" resource="#h-mediakeysystemmediacapability-dictionary"><span property="xhv:role" resource="xhv:heading"><span class="secno">3.3 </span><a href="#idl-def-mediakeysystemmediacapability" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemMediaCapability</code></a> dictionary</span>
       </h3>
       <div>
-        <pre class="def idl"><span class="idlDictionary" id="idl-def-mediakeysystemmediacapability" data-idl="" data-title="MediaKeySystemMediaCapability">[<span class="extAttr"><span class="extAttrName"><a href="https://www.w3.org/TR/WebIDL-1/#SecureContext">SecureContext</a></span></span>]
-dictionary <span class="idlDictionaryID">MediaKeySystemMediaCapability</span> {
-<span class="idlMember" id="idl-def-mediakeysystemmediacapability-contenttype" data-idl="" data-title="contentType" data-dfn-for="mediakeysystemmediacapability">    <span class="idlMemberType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-DOMString">DOMString</a></span> <span class="idlMemberName"><a data-lt="contentType" href="#dom-mediakeysystemmediacapability-contenttype" class="internalDFN" data-link-type="dfn" data-for="MediaKeySystemMediaCapability"><code>contentType</code></a></span> = <span class="idlMemberValue">""</span>;</span>
-<span class="idlMember" id="idl-def-mediakeysystemmediacapability-robustness" data-idl="" data-title="robustness" data-dfn-for="mediakeysystemmediacapability">    <span class="idlMemberType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-DOMString">DOMString</a></span> <span class="idlMemberName"><a data-lt="robustness" href="#dom-mediakeysystemmediacapability-robustness" class="internalDFN" data-link-type="dfn" data-for="MediaKeySystemMediaCapability"><code>robustness</code></a></span> = <span class="idlMemberValue">""</span>;</span>
+        <div>
+          <pre class="def idl"><span class="idlDictionary" id="idl-def-mediakeysystemmediacapability" data-idl="" data-title="MediaKeySystemMediaCapability">dictionary <span class="idlDictionaryID">MediaKeySystemMediaCapability</span> {
+<span class="idlMember" id="idl-def-mediakeysystemmediacapability-contenttype" data-idl="" data-title="contentType" data-dfn-for="mediakeysystemmediacapability">    <span class="idlMemberType"><a href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></span> <span class="idlMemberName"><a data-lt="contentType" href="#dom-mediakeysystemmediacapability-contenttype" class="internalDFN" data-link-type="dfn" data-for="MediaKeySystemMediaCapability"><code>contentType</code></a></span> = <span class="idlMemberValue">""</span>;</span>
+<span class="idlMember" id="idl-def-mediakeysystemmediacapability-robustness" data-idl="" data-title="robustness" data-dfn-for="mediakeysystemmediacapability">    <span class="idlMemberType"><a href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></span> <span class="idlMemberName"><a data-lt="robustness" href="#dom-mediakeysystemmediacapability-robustness" class="internalDFN" data-link-type="dfn" data-for="MediaKeySystemMediaCapability"><code>robustness</code></a></span> = <span class="idlMemberValue">""</span>;</span>
 };</span></pre>
+        </div>
 
         <section typeof="bibo:Chapter" resource="#dictionary-mediakeysystemmediacapability-members" property="bibo:hasPart">
           <h4 id="dictionary-mediakeysystemmediacapability-members" resource="#dictionary-mediakeysystemmediacapability-members"><span property="xhv:role" resource="xhv:heading">Dictionary <a class="idlType internalDFN" href="#idl-def-mediakeysystemmediacapability" data-link-type="dfn"><code>MediaKeySystemMediaCapability</code></a> Members</span></h4>
@@ -3003,7 +2796,7 @@ dictionary <span class="idlDictionaryID">MediaKeySystemMediaCapability</span> {
                 The robustness level associated with the content type. The empty string indicates that any ability to decrypt and decode the content type is acceptable.
               </p>
               <div class="note">
-                <div class="note-title marker" aria-level="5" role="heading" id="h-note49"><span>Note</span></div>
+                <div class="note-title marker" aria-level="5" role="heading" id="h-note48"><span>Note</span></div>
                 <div class="">
                   <p>
                     Implementations <em class="rfc2119" title="MUST">MUST</em> configure the CDM to support at least the robustness levels specified in the configuration of the MediaKeySystemAccess object used to create the MediaKeys object. Exact configuration of the CDM is implementation-specific, and implementations <em class="rfc2119" title="MAY">MAY</em> configure the CDM to use the highest robustness level in the configuration even if a higher robustness level is available. If only the empty string is specified, implementations <em class="rfc2119" title="MAY">MAY</em> be configured to use the lowest robustness level the implementation supports.
@@ -3020,7 +2813,7 @@ dictionary <span class="idlDictionaryID">MediaKeySystemMediaCapability</span> {
 
       <p>In order for the capability represented by this object to be considered supported, <code><a href="#dom-mediakeysystemmediacapability-contenttype">contentType</a></code> <em class="rfc2119" title="MUST NOT">MUST NOT</em> be the empty string and its entire value, including all codecs, <em class="rfc2119" title="MUST">MUST</em> be supported with <code><a href="#dom-mediakeysystemmediacapability-robustness">robustness</a></code>.</p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note50"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note49"><span>Note</span></div>
         <p class="">If any of a set of codecs is acceptable, use a separate instances of this dictionary for each codec.</p>
       </div>
     </section>
@@ -3034,12 +2827,14 @@ dictionary <span class="idlDictionaryID">MediaKeySystemMediaCapability</span> {
     <p>The MediaKeySystemAccess object provides access to a <a href="#key-system">Key System</a>.</p>
 
     <div>
-      <pre class="def idl"><span class="idlInterface" id="idl-def-mediakeysystemaccess" data-idl="" data-title="MediaKeySystemAccess">[<span class="extAttr"><span class="extAttrName"><a href="https://www.w3.org/TR/WebIDL-1/#SecureContext">SecureContext</a></span></span>]
+      <div>
+        <pre class="def idl"><span class="idlInterface" id="idl-def-mediakeysystemaccess" data-idl="" data-title="MediaKeySystemAccess">[<span class="extAttr"><span class="extAttrName"><a href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a></span></span>]
 interface <span class="idlInterfaceID">MediaKeySystemAccess</span> {
-<span class="idlAttribute" id="idl-def-mediakeysystemaccess-keysystem" data-idl="" data-title="keySystem" data-dfn-for="mediakeysystemaccess">    readonly attribute <span class="idlAttrType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-DOMString">DOMString</a></span> <span class="idlAttrName"><a data-lt="keySystem" href="#dom-mediakeysystemaccess-keysystem" class="internalDFN" data-link-type="dfn" data-for="MediaKeySystemAccess"><code>keySystem</code></a></span>;</span>
+<span class="idlAttribute" id="idl-def-mediakeysystemaccess-keysystem" data-idl="" data-title="keySystem" data-dfn-for="mediakeysystemaccess">    readonly attribute <span class="idlAttrType"><a href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></span> <span class="idlAttrName"><a data-lt="keySystem" href="#dom-mediakeysystemaccess-keysystem" class="internalDFN" data-link-type="dfn" data-for="MediaKeySystemAccess"><code>keySystem</code></a></span>;</span>
 <span class="idlMethod" id="idl-def-mediakeysystemaccess-getconfiguration()" data-idl="" data-title="getConfiguration" data-dfn-for="mediakeysystemaccess">    <span class="idlMethType"><a href="#idl-def-mediakeysystemconfiguration" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemConfiguration</code></a></span> <span class="idlMethName"><a data-lt="getConfiguration" href="#dom-mediakeysystemaccess-getconfiguration" class="internalDFN" data-link-type="dfn" data-for="MediaKeySystemAccess"><code>getConfiguration</code></a></span>();</span>
-<span class="idlMethod" id="idl-def-mediakeysystemaccess-createmediakeys()" data-idl="" data-title="createMediaKeys" data-dfn-for="mediakeysystemaccess">    <span class="idlMethType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-promise">Promise</a>&lt;<a href="#idl-def-mediakeys" class="internalDFN" data-link-type="dfn"><code>MediaKeys</code></a>&gt;</span>          <span class="idlMethName"><a data-lt="createMediaKeys" href="#dom-mediakeysystemaccess-createmediakeys" class="internalDFN" data-link-type="dfn" data-for="MediaKeySystemAccess"><code>createMediaKeys</code></a></span>();</span>
+<span class="idlMethod" id="idl-def-mediakeysystemaccess-createmediakeys()" data-idl="" data-title="createMediaKeys" data-dfn-for="mediakeysystemaccess">    <span class="idlMethType"><a href="https://heycam.github.io/webidl/#idl-promise">Promise</a>&lt;<a href="#idl-def-mediakeys" class="internalDFN" data-link-type="dfn"><code>MediaKeys</code></a>&gt;</span>          <span class="idlMethName"><a data-lt="createMediaKeys" href="#dom-mediakeysystemaccess-createmediakeys" class="internalDFN" data-link-type="dfn" data-for="MediaKeySystemAccess"><code>createMediaKeys</code></a></span>();</span>
 };</span></pre>
+      </div>
 
       <section typeof="bibo:Chapter" resource="#attributes" property="bibo:hasPart">
         <h3 id="attributes" resource="#attributes"><span property="xhv:role" resource="xhv:heading">Attributes</span></h3>
@@ -3069,7 +2864,7 @@ interface <span class="idlInterfaceID">MediaKeySystemAccess</span> {
                   Return this object's <var>configuration</var> value.
                 </p>
                 <div class="note">
-                  <div class="note-title marker" aria-level="4" role="heading" id="h-note51"><span>Note</span></div>
+                  <div class="note-title marker" aria-level="4" role="heading" id="h-note50"><span>Note</span></div>
                   <p class="">
                     This results in a new object being created and initialized from <var>configuration</var> each time this method is called.
                   </p>
@@ -3168,18 +2963,19 @@ interface <span class="idlInterfaceID">MediaKeySystemAccess</span> {
     </p>
     <p>A <a href="#idl-def-mediakeys" class="internalDFN" data-link-type="dfn"><code>MediaKeys</code></a> object may be destroyed by the user agent when it is no longer accessible</p>
     <div class="note">
-      <div class="note-title marker" aria-level="3" role="heading" id="h-note52"><span>Note</span></div>
+      <div class="note-title marker" aria-level="3" role="heading" id="h-note51"><span>Note</span></div>
       <p class="">For example, when there are no script references and no attached media element.</p>
     </div>
     <p>For methods that return a promise, all errors are reported asynchronously by rejecting the returned Promise. This includes [<cite><a class="bibref" href="#bib-WebIDL">WebIDL</a></cite>] type mapping errors.</p>
     <p>The steps of an algorithm are always aborted when rejecting a promise.</p>
 
     <div>
-      <pre class="def idl"><span class="idlEnum" id="idl-def-mediakeysessiontype" data-idl="" data-title="MediaKeySessionType">[<span class="extAttr"><span class="extAttrName"><a href="https://www.w3.org/TR/WebIDL-1/#SecureContext">SecureContext</a></span></span>]
-enum <span class="idlEnumID">MediaKeySessionType</span> {
+      <div>
+        <pre class="def idl"><span class="idlEnum" id="idl-def-mediakeysessiontype" data-idl="" data-title="MediaKeySessionType">enum <span class="idlEnumID">MediaKeySessionType</span> {
     <a href="#dom-mediakeysessiontype-temporary" class="idlEnumItem">"temporary"</a>,
     <a href="#dom-mediakeysessiontype-persistent-license" class="idlEnumItem">"persistent-license"</a>
 };</span></pre>
+      </div>
       <table class="simple" data-dfn-for="MediaKeySessionType" data-link-for="MediaKeySessionType">
         <tbody>
           <tr>
@@ -3215,11 +3011,13 @@ enum <span class="idlEnumID">MediaKeySessionType</span> {
     </div>
 
     <div>
-      <pre class="def idl"><span class="idlInterface" id="idl-def-mediakeys" data-idl="" data-title="MediaKeys">[<span class="extAttr"><span class="extAttrName"><a href="https://www.w3.org/TR/WebIDL-1/#SecureContext">SecureContext</a></span></span>]
+      <div>
+        <pre class="def idl"><span class="idlInterface" id="idl-def-mediakeys" data-idl="" data-title="MediaKeys">[<span class="extAttr"><span class="extAttrName"><a href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a></span></span>]
 interface <span class="idlInterfaceID">MediaKeys</span> {
 <span class="idlMethod" id="idl-def-mediakeys-createsession(sessiontype)" data-idl="" data-title="createSession" data-dfn-for="mediakeys">    <span class="idlMethType"><a href="#idl-def-mediakeysession" class="internalDFN" data-link-type="dfn"><code>MediaKeySession</code></a></span>  <span class="idlMethName"><a data-lt="createSession" href="#dom-mediakeys-createsession" class="internalDFN" data-link-type="dfn" data-for="MediaKeys"><code>createSession</code></a></span>(<span class="idlParam">optional <span class="idlParamType"><a href="#idl-def-mediakeysessiontype" class="internalDFN" data-link-type="dfn"><code>MediaKeySessionType</code></a></span> <span class="idlParamName">sessionType</span> = <span class="idlDefaultValue">"temporary"</span></span>);</span>
-<span class="idlMethod" id="idl-def-mediakeys-setservercertificate(servercertificate)" data-idl="" data-title="setServerCertificate" data-dfn-for="mediakeys">    <span class="idlMethType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-promise">Promise</a>&lt;<a href="https://www.w3.org/TR/WebIDL-1/#idl-boolean">boolean</a>&gt;</span> <span class="idlMethName"><a data-lt="setServerCertificate" href="#dom-mediakeys-setservercertificate" class="internalDFN" data-link-type="dfn" data-for="MediaKeys"><code>setServerCertificate</code></a></span>(<span class="idlParam"><span class="idlParamType">BufferSource</span> <span class="idlParamName">serverCertificate</span></span>);</span>
+<span class="idlMethod" id="idl-def-mediakeys-setservercertificate(servercertificate)" data-idl="" data-title="setServerCertificate" data-dfn-for="mediakeys">    <span class="idlMethType"><a href="https://heycam.github.io/webidl/#idl-promise">Promise</a>&lt;<a href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>&gt;</span> <span class="idlMethName"><a data-lt="setServerCertificate" href="#dom-mediakeys-setservercertificate" class="internalDFN" data-link-type="dfn" data-for="MediaKeys"><code>setServerCertificate</code></a></span>(<span class="idlParam"><span class="idlParamType">BufferSource</span> <span class="idlParamName">serverCertificate</span></span>);</span>
 };</span></pre>
+      </div>
 
       <section typeof="bibo:Chapter" resource="#methods-2" property="bibo:hasPart">
         <h3 id="methods-2" resource="#methods-2"><span property="xhv:role" resource="xhv:heading">Methods</span></h3>
@@ -3256,14 +3054,14 @@ interface <span class="idlInterfaceID">MediaKeys</span> {
               <li>
                 <p>If this object's <var>supported session types</var> value does not contain <var>sessionType</var>, <a href="https://heycam.github.io/webidl/#dfn-throw">throw</a> [<cite><a class="bibref" href="#bib-WebIDL">WebIDL</a></cite>] a <code><a href="#dfn-NotSupportedError">NotSupportedError</a></code>.</p>
                 <div class="note">
-                  <div class="note-title marker" aria-level="4" role="heading" id="h-note53"><span>Note</span></div>
+                  <div class="note-title marker" aria-level="4" role="heading" id="h-note52"><span>Note</span></div>
                   <p class=""><var>sessionType</var> values for which the <a href="#is-persistent-session-type">Is persistent session type?</a> algorithm returns <code>true</code> will fail if this object's <var>persistent state allowed</var> value is <code>false</code>.</p>
                 </div>
               </li>
               <li>
                 <p>If the implementation does not support <a href="#idl-def-mediakeysession" class="internalDFN" data-link-type="dfn"><code>MediaKeySession</code></a> operations in the current state, <a href="https://heycam.github.io/webidl/#dfn-throw">throw</a> [<cite><a class="bibref" href="#bib-WebIDL">WebIDL</a></cite>] an <code><a href="#dfn-InvalidStateError">InvalidStateError</a></code>.</p>
                 <div class="note">
-                  <div class="note-title marker" aria-level="4" role="heading" id="h-note54"><span>Note</span></div>
+                  <div class="note-title marker" aria-level="4" role="heading" id="h-note53"><span>Note</span></div>
                   <p class="">Some implementations are unable to execute <a href="#idl-def-mediakeysession" class="internalDFN" data-link-type="dfn"><code>MediaKeySession</code></a> algorithms until this <a href="#idl-def-mediakeys" class="internalDFN" data-link-type="dfn"><code>MediaKeys</code></a> object is associated with a media element using <code><a href="#dom-htmlmediaelement-setmediakeys">setMediaKeys()</a></code>. This step enables applications to detect this uncommon behavior before attempting to perform such operations.
                   </p>
                 </div>
@@ -3317,7 +3115,7 @@ interface <span class="idlInterfaceID">MediaKeys</span> {
             <p id="server-certificate">Provides a server certificate to be used to encrypt messages to the license server.</p>
             <p>Key Systems that use such certificates <em class="rfc2119" title="MUST">MUST</em> also support requesting the certificate from the server via the <a href="#queue-message">Queue a "message" Event</a> algorithm.</p>
             <div class="note">
-              <div class="note-title marker" aria-level="4" role="heading" id="h-note55"><span>Note</span></div>
+              <div class="note-title marker" aria-level="4" role="heading" id="h-note54"><span>Note</span></div>
               <p class="">This method allows an application to proactively provide a server certificate to implementations that support it to avoid the additional round trip should the CDM request it. It is intended as an optimization, and applications are not required to use it.
               </p>
             </div>
@@ -3365,7 +3163,15 @@ interface <span class="idlInterfaceID">MediaKeys</span> {
                 <p>Run the following steps in parallel:</p>
                 <ol>
                   <li>
-                    <p>Use this object's <var>cdm instance</var> to process <var>certificate</var>.</p>
+                    <p>Let <var>sanitized certificate</var> be a validated and/or sanitized version of <var>certificate</var>.</p>
+                    <div class="note">
+                      <div class="note-title marker" aria-level="4" role="heading" id="h-note55"><span>Note</span></div>
+                      <p class="">The user agent should thoroughly validate the certificate before passing it to the CDM. This may include verifying values are within reasonable limits, stripping irrelevant data or fields, pre-parsing it, sanitizing it, and/or generating a fully sanitized version. The user agent should check that the length and values of fields are reasonable. Unknown fields should be rejected or removed.
+                      </p>
+                    </div>
+                  </li>
+                  <li>
+                    <p>Use this object's <var>cdm instance</var> to process <var>sanitized certificate</var>.</p>
                   </li>
                   <li>
                     <p>If the preceding step failed, resolve <var>promise</var> with a new <code><a href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> whose name is the appropriate <a href="#error-names">error name</a>.</p>
@@ -3488,21 +3294,23 @@ interface <span class="idlInterfaceID">MediaKeys</span> {
     <p>The following steps of an algorithm are always aborted when rejecting a promise.</p>
 
     <div>
-      <pre class="def idl"><span class="idlInterface" id="idl-def-mediakeysession" data-idl="" data-title="MediaKeySession">[<span class="extAttr"><span class="extAttrName"><a href="https://www.w3.org/TR/WebIDL-1/#SecureContext">SecureContext</a></span></span>]
+      <div>
+        <pre class="def idl"><span class="idlInterface" id="idl-def-mediakeysession" data-idl="" data-title="MediaKeySession">[<span class="extAttr"><span class="extAttrName"><a href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a></span></span>]
 interface <span class="idlInterfaceID">MediaKeySession</span> : <span class="idlSuperclass">EventTarget</span> {
-<span class="idlAttribute" id="idl-def-mediakeysession-sessionid" data-idl="" data-title="sessionId" data-dfn-for="mediakeysession">    readonly attribute <span class="idlAttrType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-DOMString">DOMString</a></span>           <span class="idlAttrName"><a data-lt="sessionId" href="#dom-mediakeysession-sessionid" class="internalDFN" data-link-type="dfn" data-for="MediaKeySession"><code>sessionId</code></a></span>;</span>
-<span class="idlAttribute" id="idl-def-mediakeysession-expiration" data-idl="" data-title="expiration" data-dfn-for="mediakeysession">    readonly attribute <span class="idlAttrType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-unrestricted-double">unrestricted double</a></span> <span class="idlAttrName"><a data-lt="expiration" href="#dom-mediakeysession-expiration" class="internalDFN" data-link-type="dfn" data-for="MediaKeySession"><code>expiration</code></a></span>;</span>
-<span class="idlAttribute" id="idl-def-mediakeysession-closed" data-idl="" data-title="closed" data-dfn-for="mediakeysession">    readonly attribute <span class="idlAttrType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-promise">Promise</a>&lt;void&gt;</span>       <span class="idlAttrName"><a data-lt="closed" href="#dom-mediakeysession-closed" class="internalDFN" data-link-type="dfn" data-for="MediaKeySession"><code>closed</code></a></span>;</span>
+<span class="idlAttribute" id="idl-def-mediakeysession-sessionid" data-idl="" data-title="sessionId" data-dfn-for="mediakeysession">    readonly attribute <span class="idlAttrType"><a href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></span>           <span class="idlAttrName"><a data-lt="sessionId" href="#dom-mediakeysession-sessionid" class="internalDFN" data-link-type="dfn" data-for="MediaKeySession"><code>sessionId</code></a></span>;</span>
+<span class="idlAttribute" id="idl-def-mediakeysession-expiration" data-idl="" data-title="expiration" data-dfn-for="mediakeysession">    readonly attribute <span class="idlAttrType"><a href="https://heycam.github.io/webidl/#idl-unrestricted-double">unrestricted double</a></span> <span class="idlAttrName"><a data-lt="expiration" href="#dom-mediakeysession-expiration" class="internalDFN" data-link-type="dfn" data-for="MediaKeySession"><code>expiration</code></a></span>;</span>
+<span class="idlAttribute" id="idl-def-mediakeysession-closed" data-idl="" data-title="closed" data-dfn-for="mediakeysession">    readonly attribute <span class="idlAttrType"><a href="https://heycam.github.io/webidl/#idl-promise">Promise</a>&lt;void&gt;</span>       <span class="idlAttrName"><a data-lt="closed" href="#dom-mediakeysession-closed" class="internalDFN" data-link-type="dfn" data-for="MediaKeySession"><code>closed</code></a></span>;</span>
 <span class="idlAttribute" id="idl-def-mediakeysession-keystatuses" data-idl="" data-title="keyStatuses" data-dfn-for="mediakeysession">    readonly attribute <span class="idlAttrType"><a href="#idl-def-mediakeystatusmap" class="internalDFN" data-link-type="dfn"><code>MediaKeyStatusMap</code></a></span>   <span class="idlAttrName"><a data-lt="keyStatuses" href="#dom-mediakeysession-keystatuses" class="internalDFN" data-link-type="dfn" data-for="MediaKeySession"><code>keyStatuses</code></a></span>;</span>
 <span class="idlAttribute" id="idl-def-mediakeysession-onkeystatuseschange" data-idl="" data-title="onkeystatuseschange" data-dfn-for="mediakeysession">             attribute <span class="idlAttrType"><a href="https://html.spec.whatwg.org/multipage/#eventhandler">EventHandler</a></span>        <span class="idlAttrName"><a data-lt="onkeystatuseschange" href="#dom-mediakeysession-onkeystatuseschange" class="internalDFN" data-link-type="dfn" data-for="MediaKeySession"><code>onkeystatuseschange</code></a></span>;</span>
 <span class="idlAttribute" id="idl-def-mediakeysession-onmessage" data-idl="" data-title="onmessage" data-dfn-for="mediakeysession">             attribute <span class="idlAttrType"><a href="https://html.spec.whatwg.org/multipage/#eventhandler">EventHandler</a></span>        <span class="idlAttrName"><a data-lt="onmessage" href="#dom-mediakeysession-onmessage" class="internalDFN" data-link-type="dfn" data-for="MediaKeySession"><code>onmessage</code></a></span>;</span>
-<span class="idlMethod" id="idl-def-mediakeysession-generaterequest(initdatatype,initdata)" data-idl="" data-title="generateRequest" data-dfn-for="mediakeysession">    <span class="idlMethType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-promise">Promise</a>&lt;void&gt;</span>    <span class="idlMethName"><a data-lt="generateRequest" href="#dom-mediakeysession-generaterequest" class="internalDFN" data-link-type="dfn" data-for="MediaKeySession"><code>generateRequest</code></a></span>(<span class="idlParam"><span class="idlParamType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-DOMString">DOMString</a></span> <span class="idlParamName">initDataType</span></span>,
+<span class="idlMethod" id="idl-def-mediakeysession-generaterequest(initdatatype,initdata)" data-idl="" data-title="generateRequest" data-dfn-for="mediakeysession">    <span class="idlMethType"><a href="https://heycam.github.io/webidl/#idl-promise">Promise</a>&lt;void&gt;</span>    <span class="idlMethName"><a data-lt="generateRequest" href="#dom-mediakeysession-generaterequest" class="internalDFN" data-link-type="dfn" data-for="MediaKeySession"><code>generateRequest</code></a></span>(<span class="idlParam"><span class="idlParamType"><a href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></span> <span class="idlParamName">initDataType</span></span>,
                                      <span class="idlParam"><span class="idlParamType">BufferSource</span> <span class="idlParamName">initData</span></span>);</span>
-<span class="idlMethod" id="idl-def-mediakeysession-load(sessionid)" data-idl="" data-title="load" data-dfn-for="mediakeysession">    <span class="idlMethType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-promise">Promise</a>&lt;<a href="https://www.w3.org/TR/WebIDL-1/#idl-boolean">boolean</a>&gt;</span> <span class="idlMethName"><a data-lt="load" href="#dom-mediakeysession-load" class="internalDFN" data-link-type="dfn" data-for="MediaKeySession"><code>load</code></a></span>(<span class="idlParam"><span class="idlParamType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-DOMString">DOMString</a></span> <span class="idlParamName">sessionId</span></span>);</span>
-<span class="idlMethod" id="idl-def-mediakeysession-update(response)" data-idl="" data-title="update" data-dfn-for="mediakeysession">    <span class="idlMethType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-promise">Promise</a>&lt;void&gt;</span>    <span class="idlMethName"><a data-lt="update" href="#dom-mediakeysession-update" class="internalDFN" data-link-type="dfn" data-for="MediaKeySession"><code>update</code></a></span>(<span class="idlParam"><span class="idlParamType">BufferSource</span> <span class="idlParamName">response</span></span>);</span>
-<span class="idlMethod" id="idl-def-mediakeysession-close()" data-idl="" data-title="close" data-dfn-for="mediakeysession">    <span class="idlMethType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-promise">Promise</a>&lt;void&gt;</span>    <span class="idlMethName"><a data-lt="close" href="#dom-mediakeysession-close" class="internalDFN" data-link-type="dfn" data-for="MediaKeySession"><code>close</code></a></span>();</span>
-<span class="idlMethod" id="idl-def-mediakeysession-remove()" data-idl="" data-title="remove" data-dfn-for="mediakeysession">    <span class="idlMethType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-promise">Promise</a>&lt;void&gt;</span>    <span class="idlMethName"><a data-lt="remove" href="#dom-mediakeysession-remove" class="internalDFN" data-link-type="dfn" data-for="MediaKeySession"><code>remove</code></a></span>();</span>
+<span class="idlMethod" id="idl-def-mediakeysession-load(sessionid)" data-idl="" data-title="load" data-dfn-for="mediakeysession">    <span class="idlMethType"><a href="https://heycam.github.io/webidl/#idl-promise">Promise</a>&lt;<a href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>&gt;</span> <span class="idlMethName"><a data-lt="load" href="#dom-mediakeysession-load" class="internalDFN" data-link-type="dfn" data-for="MediaKeySession"><code>load</code></a></span>(<span class="idlParam"><span class="idlParamType"><a href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></span> <span class="idlParamName">sessionId</span></span>);</span>
+<span class="idlMethod" id="idl-def-mediakeysession-update(response)" data-idl="" data-title="update" data-dfn-for="mediakeysession">    <span class="idlMethType"><a href="https://heycam.github.io/webidl/#idl-promise">Promise</a>&lt;void&gt;</span>    <span class="idlMethName"><a data-lt="update" href="#dom-mediakeysession-update" class="internalDFN" data-link-type="dfn" data-for="MediaKeySession"><code>update</code></a></span>(<span class="idlParam"><span class="idlParamType">BufferSource</span> <span class="idlParamName">response</span></span>);</span>
+<span class="idlMethod" id="idl-def-mediakeysession-close()" data-idl="" data-title="close" data-dfn-for="mediakeysession">    <span class="idlMethType"><a href="https://heycam.github.io/webidl/#idl-promise">Promise</a>&lt;void&gt;</span>    <span class="idlMethName"><a data-lt="close" href="#dom-mediakeysession-close" class="internalDFN" data-link-type="dfn" data-for="MediaKeySession"><code>close</code></a></span>();</span>
+<span class="idlMethod" id="idl-def-mediakeysession-remove()" data-idl="" data-title="remove" data-dfn-for="mediakeysession">    <span class="idlMethType"><a href="https://heycam.github.io/webidl/#idl-promise">Promise</a>&lt;void&gt;</span>    <span class="idlMethName"><a data-lt="remove" href="#dom-mediakeysession-remove" class="internalDFN" data-link-type="dfn" data-for="MediaKeySession"><code>remove</code></a></span>();</span>
 };</span></pre>
+      </div>
 
       <section typeof="bibo:Chapter" resource="#attributes-1" property="bibo:hasPart">
         <h3 id="attributes-1" resource="#attributes-1"><span property="xhv:role" resource="xhv:heading">Attributes</span></h3>
@@ -3716,7 +3524,7 @@ interface <span class="idlInterfaceID">MediaKeySession</span> : <span class="idl
                     </ol>
                   </li>
                   <li>
-                    <p><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to run the following steps:</p>
+                    <p><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to run the following steps:</p>
                     <ol>
                       <li>
                         <p>If any of the preceding steps failed, reject <var>promise</var> with a new <code><a href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> whose name is the appropriate <a href="#error-names">error name</a>.</p>
@@ -3871,7 +3679,7 @@ interface <span class="idlInterfaceID">MediaKeySession</span> : <span class="idl
                     </ol>
                   </li>
                   <li>
-                    <p><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to run the following steps:</p>
+                    <p><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to run the following steps:</p>
                     <ol>
                       <li>
                         <p>If any of the preceding steps failed, reject <var>promise</var> with a the appropriate <a href="#error-names">error name</a>.</p>
@@ -4067,7 +3875,7 @@ interface <span class="idlInterfaceID">MediaKeySession</span> : <span class="idl
                     </ol>
                   </li>
                   <li>
-                    <p><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to run the following steps:</p>
+                    <p><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to run the following steps:</p>
                     <ol>
                       <li>
                         <dl class="switch">
@@ -4154,7 +3962,7 @@ interface <span class="idlInterfaceID">MediaKeySession</span> : <span class="idl
                     </div>
                   </li>
                   <li>
-                    <p><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to run the following steps:</p>
+                    <p><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to run the following steps:</p>
                     <ol>
                       <li>
                         <p>Run the <a href="#session-closed">Session Closed</a> algorithm on the <var>session</var>.</p>
@@ -4259,7 +4067,7 @@ interface <span class="idlInterfaceID">MediaKeySession</span> : <span class="idl
                     </ol>
                   </li>
                   <li>
-                    <p><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to run the following steps:</p>
+                    <p><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to run the following steps:</p>
                     <ol>
                       <li>
                         <p>
@@ -4308,13 +4116,15 @@ interface <span class="idlInterfaceID">MediaKeySession</span> : <span class="idl
         <p class="">For example, if a key has output requirements that cannot currently be met, the key's status should be <code><a href="#idl-def-MediaKeyStatus.output-downscaled">"output-downscaled"</a></code> or <code><a href="#idl-def-MediaKeyStatus.output-restricted">"output-restricted"</a></code>, as appropriate, regardless of whether that key has been or is currently needed to decrypt media data.</p>
       </div>
       <div>
-        <pre class="def idl"><span class="idlInterface" id="idl-def-mediakeystatusmap" data-idl="" data-title="MediaKeyStatusMap">[<span class="extAttr"><span class="extAttrName"><a href="https://www.w3.org/TR/WebIDL-1/#SecureContext">SecureContext</a></span></span>]
+        <div>
+          <pre class="def idl"><span class="idlInterface" id="idl-def-mediakeystatusmap" data-idl="" data-title="MediaKeyStatusMap">[<span class="extAttr"><span class="extAttrName"><a href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a></span></span>]
 interface <span class="idlInterfaceID">MediaKeyStatusMap</span> {
 <span class="idlIterable" id="idl-def-mediakeystatusmap-iterable" data-idl="" data-title="iterable" data-dfn-for="mediakeystatusmap">    iterable&lt;BufferSource, <a href="#idl-def-mediakeystatus" class="internalDFN" data-link-type="dfn"><code>MediaKeyStatus</code></a>&gt;;</span>
-<span class="idlAttribute" id="idl-def-mediakeystatusmap-size" data-idl="" data-title="size" data-dfn-for="mediakeystatusmap">    readonly attribute <span class="idlAttrType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-unsigned-long">unsigned long</a></span> <span class="idlAttrName"><a data-lt="size" href="#dom-mediakeystatusmap-size" class="internalDFN" data-link-type="dfn" data-for="MediaKeyStatusMap"><code>size</code></a></span>;</span>
-<span class="idlMethod" id="idl-def-mediakeystatusmap-has(keyid)" data-idl="" data-title="has" data-dfn-for="mediakeystatusmap">    <span class="idlMethType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-boolean">boolean</a></span> <span class="idlMethName"><a data-lt="has" href="#dom-mediakeystatusmap-has" class="internalDFN" data-link-type="dfn" data-for="MediaKeyStatusMap"><code>has</code></a></span>(<span class="idlParam"><span class="idlParamType">BufferSource</span> <span class="idlParamName">keyId</span></span>);</span>
-<span class="idlMethod" id="idl-def-mediakeystatusmap-get(keyid)" data-idl="" data-title="get" data-dfn-for="mediakeystatusmap">    <span class="idlMethType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-any">any</a></span>     <span class="idlMethName"><a data-lt="get" href="#dom-mediakeystatusmap-get" class="internalDFN" data-link-type="dfn" data-for="MediaKeyStatusMap"><code>get</code></a></span>(<span class="idlParam"><span class="idlParamType">BufferSource</span> <span class="idlParamName">keyId</span></span>);</span>
+<span class="idlAttribute" id="idl-def-mediakeystatusmap-size" data-idl="" data-title="size" data-dfn-for="mediakeystatusmap">    readonly attribute <span class="idlAttrType"><a href="https://heycam.github.io/webidl/#idl-unsigned-long">unsigned long</a></span> <span class="idlAttrName"><a data-lt="size" href="#dom-mediakeystatusmap-size" class="internalDFN" data-link-type="dfn" data-for="MediaKeyStatusMap"><code>size</code></a></span>;</span>
+<span class="idlMethod" id="idl-def-mediakeystatusmap-has(keyid)" data-idl="" data-title="has" data-dfn-for="mediakeystatusmap">    <span class="idlMethType"><a href="https://heycam.github.io/webidl/#idl-boolean">boolean</a></span> <span class="idlMethName"><a data-lt="has" href="#dom-mediakeystatusmap-has" class="internalDFN" data-link-type="dfn" data-for="MediaKeyStatusMap"><code>has</code></a></span>(<span class="idlParam"><span class="idlParamType">BufferSource</span> <span class="idlParamName">keyId</span></span>);</span>
+<span class="idlMethod" id="idl-def-mediakeystatusmap-get(keyid)" data-idl="" data-title="get" data-dfn-for="mediakeystatusmap">    <span class="idlMethType"><a href="https://heycam.github.io/webidl/#idl-any">any</a></span>     <span class="idlMethName"><a data-lt="get" href="#dom-mediakeystatusmap-get" class="internalDFN" data-link-type="dfn" data-for="MediaKeyStatusMap"><code>get</code></a></span>(<span class="idlParam"><span class="idlParamType">BufferSource</span> <span class="idlParamName">keyId</span></span>);</span>
 };</span></pre>
+        </div>
 
         <section typeof="bibo:Chapter" resource="#attributes-2" property="bibo:hasPart">
           <h4 id="attributes-2" resource="#attributes-2"><span property="xhv:role" resource="xhv:heading">Attributes</span></h4>
@@ -4387,8 +4197,8 @@ interface <span class="idlInterfaceID">MediaKeyStatusMap</span> {
       </div>
 
       <div>
-        <pre class="def idl"><span class="idlEnum" id="idl-def-mediakeystatus" data-idl="" data-title="MediaKeyStatus">[<span class="extAttr"><span class="extAttrName"><a href="https://www.w3.org/TR/WebIDL-1/#SecureContext">SecureContext</a></span></span>]
-enum <span class="idlEnumID">MediaKeyStatus</span> {
+        <div>
+          <pre class="def idl"><span class="idlEnum" id="idl-def-mediakeystatus" data-idl="" data-title="MediaKeyStatus">enum <span class="idlEnumID">MediaKeyStatus</span> {
     <a href="#dom-mediakeystatus-usable" class="idlEnumItem">"usable"</a>,
     <a href="#dom-mediakeystatus-expired" class="idlEnumItem">"expired"</a>,
     <a href="#dom-mediakeystatus-released" class="idlEnumItem">"released"</a>,
@@ -4397,6 +4207,7 @@ enum <span class="idlEnumID">MediaKeyStatus</span> {
     <a href="#dom-mediakeystatus-status-pending" class="idlEnumItem">"status-pending"</a>,
     <a href="#dom-mediakeystatus-internal-error" class="idlEnumItem">"internal-error"</a>
 };</span></pre>
+        </div>
         <table class="simple" data-dfn-for="MediaKeyStatus" data-link-for="MediaKeyStatus">
           <tbody>
             <tr>
@@ -4456,13 +4267,14 @@ enum <span class="idlEnumID">MediaKeyStatus</span> {
       <p>Events are constructed as defined in <a href="https://www.w3.org/TR/dom/#constructing-events">Constructing events</a> [<cite><a class="bibref" href="#bib-DOM">DOM</a></cite>].</p>
 
       <div>
-        <pre class="def idl"><span class="idlEnum" id="idl-def-mediakeymessagetype" data-idl="" data-title="MediaKeyMessageType">[<span class="extAttr"><span class="extAttrName"><a href="https://www.w3.org/TR/WebIDL-1/#SecureContext">SecureContext</a></span></span>]
-enum <span class="idlEnumID">MediaKeyMessageType</span> {
+        <div>
+          <pre class="def idl"><span class="idlEnum" id="idl-def-mediakeymessagetype" data-idl="" data-title="MediaKeyMessageType">enum <span class="idlEnumID">MediaKeyMessageType</span> {
     <a href="#dom-mediakeymessagetype-license-request" class="idlEnumItem">"license-request"</a>,
     <a href="#dom-mediakeymessagetype-license-renewal" class="idlEnumItem">"license-renewal"</a>,
     <a href="#dom-mediakeymessagetype-license-release" class="idlEnumItem">"license-release"</a>,
     <a href="#dom-mediakeymessagetype-individualization-request" class="idlEnumItem">"individualization-request"</a>
 };</span></pre>
+        </div>
         <table class="simple" data-dfn-for="MediaKeyMessageType" data-link-for="MediaKeyMessageType">
           <tbody>
             <tr>
@@ -4491,12 +4303,14 @@ enum <span class="idlEnumID">MediaKeyMessageType</span> {
       </div>
 
       <div>
-        <pre class="def idl"><span class="idlInterface" id="idl-def-mediakeymessageevent" data-idl="" data-title="MediaKeyMessageEvent">[<span class="extAttr"><span class="extAttrName"><a href="https://www.w3.org/TR/WebIDL-1/#SecureContext">SecureContext</a></span></span>,
- <span class="idlCtor"><span class="extAttrName"><a href="https://www.w3.org/TR/WebIDL-1/#Constructor">Constructor</a></span>(<span class="idlParam"><span class="idlParamType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-DOMString">DOMString</a></span> <span class="idlParamName">type</span></span>, <span class="idlParam"><span class="idlParamType"><a href="#idl-def-mediakeymessageeventinit" class="internalDFN" data-link-type="dfn"><code>MediaKeyMessageEventInit</code></a></span> <span class="idlParamName">eventInitDict</span></span>)</span>]
+        <div>
+          <pre class="def idl"><span class="idlInterface" id="idl-def-mediakeymessageevent" data-idl="" data-title="MediaKeyMessageEvent">[<span class="extAttr"><span class="extAttrName"><a href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a></span></span>,
+ <span class="idlCtor"><span class="extAttrName"><a href="https://heycam.github.io/webidl/#Constructor">Constructor</a></span>(<span class="idlParam"><span class="idlParamType"><a href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></span> <span class="idlParamName">type</span></span>, <span class="idlParam"><span class="idlParamType"><a href="#idl-def-mediakeymessageeventinit" class="internalDFN" data-link-type="dfn"><code>MediaKeyMessageEventInit</code></a></span> <span class="idlParamName">eventInitDict</span></span>)</span>]
 interface <span class="idlInterfaceID"><a data-lt="MediaKeyMessageEvent" href="#dom-mediakeymessageevent" class="internalDFN" data-link-type="dfn" data-for=""><code>MediaKeyMessageEvent</code></a></span> : <span class="idlSuperclass">Event</span> {
 <span class="idlAttribute" id="idl-def-mediakeymessageevent-messagetype" data-idl="" data-title="messageType" data-dfn-for="mediakeymessageevent">    readonly attribute <span class="idlAttrType"><a href="#idl-def-mediakeymessagetype" class="internalDFN" data-link-type="dfn"><code>MediaKeyMessageType</code></a></span> <span class="idlAttrName"><a data-lt="messageType" href="#dom-mediakeymessageevent-messagetype" class="internalDFN" data-link-type="dfn" data-for="MediaKeyMessageEvent"><code>messageType</code></a></span>;</span>
-<span class="idlAttribute" id="idl-def-mediakeymessageevent-message" data-idl="" data-title="message" data-dfn-for="mediakeymessageevent">    readonly attribute <span class="idlAttrType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-ArrayBuffer">ArrayBuffer</a></span>         <span class="idlAttrName"><a data-lt="message" href="#dom-mediakeymessageevent-message" class="internalDFN" data-link-type="dfn" data-for="MediaKeyMessageEvent"><code>message</code></a></span>;</span>
+<span class="idlAttribute" id="idl-def-mediakeymessageevent-message" data-idl="" data-title="message" data-dfn-for="mediakeymessageevent">    readonly attribute <span class="idlAttrType"><a href="https://heycam.github.io/webidl/#idl-ArrayBuffer">ArrayBuffer</a></span>         <span class="idlAttrName"><a data-lt="message" href="#dom-mediakeymessageevent-message" class="internalDFN" data-link-type="dfn" data-for="MediaKeyMessageEvent"><code>message</code></a></span>;</span>
 };</span></pre>
+        </div>
 
         <section typeof="bibo:Chapter" resource="#constructors" property="bibo:hasPart">
           <h4 id="constructors" resource="#constructors"><span property="xhv:role" resource="xhv:heading">Constructors</span></h4>
@@ -4556,11 +4370,12 @@ interface <span class="idlInterfaceID"><a data-lt="MediaKeyMessageEvent" href="#
         <h4 id="h-mediakeymessageeventinit" resource="#h-mediakeymessageeventinit"><span property="xhv:role" resource="xhv:heading"><span class="secno">6.2.1 </span><a href="#idl-def-mediakeymessageeventinit" class="internalDFN" data-link-type="dfn"><code>MediaKeyMessageEventInit</code></a></span>
         </h4>
         <div>
-          <pre class="def idl"><span class="idlDictionary" id="idl-def-mediakeymessageeventinit" data-idl="" data-title="MediaKeyMessageEventInit">[<span class="extAttr"><span class="extAttrName"><a href="https://www.w3.org/TR/WebIDL-1/#SecureContext">SecureContext</a></span></span>]
-dictionary <span class="idlDictionaryID">MediaKeyMessageEventInit</span> : <span class="idlSuperclass">EventInit</span> {
+          <div>
+            <pre class="def idl"><span class="idlDictionary" id="idl-def-mediakeymessageeventinit" data-idl="" data-title="MediaKeyMessageEventInit">dictionary <span class="idlDictionaryID">MediaKeyMessageEventInit</span> : <span class="idlSuperclass">EventInit</span> {
 <span class="idlMember" id="idl-def-mediakeymessageeventinit-messagetype" data-idl="" data-title="messageType" data-dfn-for="mediakeymessageeventinit">    required <span class="idlMemberType"><a href="#idl-def-mediakeymessagetype" class="internalDFN" data-link-type="dfn"><code>MediaKeyMessageType</code></a></span> <span class="idlMemberName"><a data-lt="messageType" href="#dom-mediakeymessageeventinit-messagetype" class="internalDFN" data-link-type="dfn" data-for="MediaKeyMessageEventInit"><code>messageType</code></a></span>;</span>
-<span class="idlMember" id="idl-def-mediakeymessageeventinit-message" data-idl="" data-title="message" data-dfn-for="mediakeymessageeventinit">    required <span class="idlMemberType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-ArrayBuffer">ArrayBuffer</a></span>         <span class="idlMemberName"><a data-lt="message" href="#dom-mediakeymessageeventinit-message" class="internalDFN" data-link-type="dfn" data-for="MediaKeyMessageEventInit"><code>message</code></a></span>;</span>
+<span class="idlMember" id="idl-def-mediakeymessageeventinit-message" data-idl="" data-title="message" data-dfn-for="mediakeymessageeventinit">    required <span class="idlMemberType"><a href="https://heycam.github.io/webidl/#idl-ArrayBuffer">ArrayBuffer</a></span>         <span class="idlMemberName"><a data-lt="message" href="#dom-mediakeymessageeventinit-message" class="internalDFN" data-link-type="dfn" data-for="MediaKeyMessageEventInit"><code>message</code></a></span>;</span>
 };</span></pre>
+          </div>
 
           <section typeof="bibo:Chapter" resource="#dictionary-mediakeymessageeventinit-members" property="bibo:hasPart">
             <h5 id="dictionary-mediakeymessageeventinit-members" resource="#dictionary-mediakeymessageeventinit-members"><span property="xhv:role" resource="xhv:heading">Dictionary <a class="idlType internalDFN" href="#idl-def-mediakeymessageeventinit" data-link-type="dfn"><code>MediaKeyMessageEventInit</code></a> Members</span></h5>
@@ -4624,7 +4439,7 @@ dictionary <span class="idlDictionaryID">MediaKeyMessageEventInit</span> : <span
             <p>Let the <var>session</var> be the specified <a href="#idl-def-mediakeysession" class="internalDFN" data-link-type="dfn"><code>MediaKeySession</code></a> object.</p>
           </li>
           <li>
-            <p><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to create an event named <code><a href="#dom-evt-message">message</a></code> that does not bubble and is not cancellable using the <a href="#dom-mediakeymessageevent" class="internalDFN" data-link-type="dfn"><code>MediaKeyMessageEvent</code></a> interface with its <var>type</var> attribute set to <code>message</code> and its <var>isTrusted</var> attribute initialized to <code>true</code>, and dispatch it at the <var>session</var>.</p>
+            <p><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to create an event named <code><a href="#dom-evt-message">message</a></code> that does not bubble and is not cancellable using the <a href="#dom-mediakeymessageevent" class="internalDFN" data-link-type="dfn"><code>MediaKeyMessageEvent</code></a> interface with its <var>type</var> attribute set to <code>message</code> and its <var>isTrusted</var> attribute initialized to <code>true</code>, and dispatch it at the <var>session</var>.</p>
             <p>The event interface <a href="#dom-mediakeymessageevent" class="internalDFN" data-link-type="dfn"><code>MediaKeyMessageEvent</code></a> has:</p>
             <ul style="list-style-type:none">
               <li>
@@ -5005,14 +4820,16 @@ dictionary <span class="idlDictionaryID">MediaKeyMessageEventInit</span> : <span
     <p>The steps of an algorithm are always aborted when rejecting a promise.</p>
 
     <div>
-      <pre class="def idl"><span class="idlInterface" id="idl-def-htmlmediaelement-partial-1" data-idl="" data-title="HTMLMediaElement">partial interface <span class="idlInterfaceID">HTMLMediaElement</span> {
-<span class="idlAttribute" id="idl-def-htmlmediaelement-mediakeys" data-idl="" data-title="mediaKeys" data-dfn-for="htmlmediaelement">    [<span class="extAttr"><span class="extAttrName"><a href="https://www.w3.org/TR/WebIDL-1/#SecureContext">SecureContext</a></span></span>]
+      <div>
+        <pre class="def idl"><span class="idlInterface" id="idl-def-htmlmediaelement-partial-1" data-idl="" data-title="HTMLMediaElement">partial interface <span class="idlInterfaceID">HTMLMediaElement</span> {
+<span class="idlAttribute" id="idl-def-htmlmediaelement-mediakeys" data-idl="" data-title="mediaKeys" data-dfn-for="htmlmediaelement">    [<span class="extAttr"><span class="extAttrName"><a href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a></span></span>]
     readonly attribute <span class="idlAttrType"><a href="#idl-def-mediakeys" class="internalDFN" data-link-type="dfn"><code>MediaKeys</code></a>?</span>   <span class="idlAttrName">mediaKeys</span>;</span>
 <span class="idlAttribute" id="idl-def-htmlmediaelement-onencrypted" data-idl="" data-title="onencrypted" data-dfn-for="htmlmediaelement">             attribute <span class="idlAttrType"><a href="https://html.spec.whatwg.org/multipage/#eventhandler">EventHandler</a></span> <span class="idlAttrName"><a data-lt="onencrypted" href="#dom-htmlmediaelement-onencrypted" class="internalDFN" data-link-type="dfn" data-for="HTMLMediaElement"><code>onencrypted</code></a></span>;</span>
 <span class="idlAttribute" id="idl-def-htmlmediaelement-onwaitingforkey" data-idl="" data-title="onwaitingforkey" data-dfn-for="htmlmediaelement">             attribute <span class="idlAttrType"><a href="https://html.spec.whatwg.org/multipage/#eventhandler">EventHandler</a></span> <span class="idlAttrName"><a data-lt="onwaitingforkey" href="#dom-htmlmediaelement-onwaitingforkey" class="internalDFN" data-link-type="dfn" data-for="HTMLMediaElement"><code>onwaitingforkey</code></a></span>;</span>
-<span class="idlMethod" id="idl-def-htmlmediaelement-setmediakeys(mediakeys)" data-idl="" data-title="setMediaKeys" data-dfn-for="htmlmediaelement">    [<span class="extAttr"><span class="extAttrName"><a href="https://www.w3.org/TR/WebIDL-1/#SecureContext">SecureContext</a></span></span>]
-    <span class="idlMethType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-promise">Promise</a>&lt;void&gt;</span> <span class="idlMethName"><a data-lt="setMediaKeys" href="#dom-htmlmediaelement-setmediakeys" class="internalDFN" data-link-type="dfn" data-for="HTMLMediaElement"><code>setMediaKeys</code></a></span>(<span class="idlParam"><span class="idlParamType"><a href="#idl-def-mediakeys" class="internalDFN" data-link-type="dfn"><code>MediaKeys</code></a>?</span> <span class="idlParamName">mediaKeys</span></span>);</span>
+<span class="idlMethod" id="idl-def-htmlmediaelement-setmediakeys(mediakeys)" data-idl="" data-title="setMediaKeys" data-dfn-for="htmlmediaelement">    [<span class="extAttr"><span class="extAttrName"><a href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a></span></span>]
+    <span class="idlMethType"><a href="https://heycam.github.io/webidl/#idl-promise">Promise</a>&lt;void&gt;</span> <span class="idlMethName"><a data-lt="setMediaKeys" href="#dom-htmlmediaelement-setmediakeys" class="internalDFN" data-link-type="dfn" data-for="HTMLMediaElement"><code>setMediaKeys</code></a></span>(<span class="idlParam"><span class="idlParamType"><a href="#idl-def-mediakeys" class="internalDFN" data-link-type="dfn"><code>MediaKeys</code></a>?</span> <span class="idlParamName">mediaKeys</span></span>);</span>
 };</span></pre>
+      </div>
 
       <section typeof="bibo:Chapter" resource="#attributes-4" property="bibo:hasPart">
         <h3 id="attributes-4" resource="#attributes-4"><span property="xhv:role" resource="xhv:heading">Attributes</span></h3>
@@ -5074,10 +4891,10 @@ dictionary <span class="idlDictionaryID">MediaKeyMessageEventInit</span> : <span
             <ol class="method-algorithm">
               <!-- For simplicity and consistency, do not allow multiple pending calls. -->
               <li>
-                <p>If <var>mediaKeys</var> and the <code><a href="#dom-mediakeys">mediaKeys</a></code> attribute are the same object, return a resolved promise.</p>
+                <p>If this object's <var>attaching media keys</var> value is true, return a promise rejected with an <code><a href="#dfn-InvalidStateError">InvalidStateError</a></code>.</p>
               </li>
               <li>
-                <p>If this object's <var>attaching media keys</var> value is true, return a promise rejected with an <code><a href="#dfn-InvalidStateError">InvalidStateError</a></code>.</p>
+                <p>If <var>mediaKeys</var> and the <code><a href="#dom-mediakeys">mediaKeys</a></code> attribute are the same object, return a resolved promise.</p>
               </li>
               <li>
                 <p>Let this object's <var>attaching media keys</var> value be true.</p>
@@ -5179,11 +4996,13 @@ dictionary <span class="idlDictionaryID">MediaKeyMessageEventInit</span> : <span
       <p>Events are constructed as defined in <a href="https://www.w3.org/TR/dom/#constructing-events">Constructing events</a> [<cite><a class="bibref" href="#bib-DOM">DOM</a></cite>].</p>
 
       <div>
-        <pre class="def idl"><span class="idlInterface" id="idl-def-mediaencryptedevent" data-idl="" data-title="MediaEncryptedEvent">[<span class="idlCtor"><span class="extAttrName"><a href="https://www.w3.org/TR/WebIDL-1/#Constructor">Constructor</a></span>(<span class="idlParam"><span class="idlParamType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-DOMString">DOMString</a></span> <span class="idlParamName">type</span></span>, <span class="idlParam">optional <span class="idlParamType"><a href="#idl-def-mediaencryptedeventinit" class="internalDFN" data-link-type="dfn"><code>MediaEncryptedEventInit</code></a></span> <span class="idlParamName">eventInitDict</span></span>)</span>]
+        <div>
+          <pre class="def idl"><span class="idlInterface" id="idl-def-mediaencryptedevent" data-idl="" data-title="MediaEncryptedEvent">[<span class="idlCtor"><span class="extAttrName"><a href="https://heycam.github.io/webidl/#Constructor">Constructor</a></span>(<span class="idlParam"><span class="idlParamType"><a href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></span> <span class="idlParamName">type</span></span>, <span class="idlParam">optional <span class="idlParamType"><a href="#idl-def-mediaencryptedeventinit" class="internalDFN" data-link-type="dfn"><code>MediaEncryptedEventInit</code></a></span> <span class="idlParamName">eventInitDict</span></span>)</span>]
 interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#dom-mediaencryptedevent" class="internalDFN" data-link-type="dfn" data-for=""><code>MediaEncryptedEvent</code></a></span> : <span class="idlSuperclass">Event</span> {
-<span class="idlAttribute" id="idl-def-mediaencryptedevent-initdatatype" data-idl="" data-title="initDataType" data-dfn-for="mediaencryptedevent">    readonly attribute <span class="idlAttrType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-DOMString">DOMString</a></span>    <span class="idlAttrName"><a data-lt="initDataType" href="#dom-mediaencryptedevent-initdatatype" class="internalDFN" data-link-type="dfn" data-for="MediaEncryptedEvent"><code>initDataType</code></a></span>;</span>
-<span class="idlAttribute" id="idl-def-mediaencryptedevent-initdata" data-idl="" data-title="initData" data-dfn-for="mediaencryptedevent">    readonly attribute <span class="idlAttrType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-ArrayBuffer">ArrayBuffer</a>?</span> <span class="idlAttrName"><a data-lt="initData" href="#dom-mediaencryptedevent-initdata" class="internalDFN" data-link-type="dfn" data-for="MediaEncryptedEvent"><code>initData</code></a></span>;</span>
+<span class="idlAttribute" id="idl-def-mediaencryptedevent-initdatatype" data-idl="" data-title="initDataType" data-dfn-for="mediaencryptedevent">    readonly attribute <span class="idlAttrType"><a href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></span>    <span class="idlAttrName"><a data-lt="initDataType" href="#dom-mediaencryptedevent-initdatatype" class="internalDFN" data-link-type="dfn" data-for="MediaEncryptedEvent"><code>initDataType</code></a></span>;</span>
+<span class="idlAttribute" id="idl-def-mediaencryptedevent-initdata" data-idl="" data-title="initData" data-dfn-for="mediaencryptedevent">    readonly attribute <span class="idlAttrType"><a href="https://heycam.github.io/webidl/#idl-ArrayBuffer">ArrayBuffer</a>?</span> <span class="idlAttrName"><a data-lt="initData" href="#dom-mediaencryptedevent-initdata" class="internalDFN" data-link-type="dfn" data-for="MediaEncryptedEvent"><code>initData</code></a></span>;</span>
 };</span></pre>
+        </div>
 
         <section typeof="bibo:Chapter" resource="#constructors-1" property="bibo:hasPart">
           <h4 id="constructors-1" resource="#constructors-1"><span property="xhv:role" resource="xhv:heading">Constructors</span></h4>
@@ -5236,10 +5055,12 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
         <h4 id="h-mediaencryptedeventinit" resource="#h-mediaencryptedeventinit"><span property="xhv:role" resource="xhv:heading"><span class="secno">7.1.1 </span><a href="#idl-def-mediaencryptedeventinit" class="internalDFN" data-link-type="dfn"><code>MediaEncryptedEventInit</code></a></span>
         </h4>
         <div>
-          <pre class="def idl"><span class="idlDictionary" id="idl-def-mediaencryptedeventinit" data-idl="" data-title="MediaEncryptedEventInit">dictionary <span class="idlDictionaryID">MediaEncryptedEventInit</span> : <span class="idlSuperclass">EventInit</span> {
-<span class="idlMember" id="idl-def-mediaencryptedeventinit-initdatatype" data-idl="" data-title="initDataType" data-dfn-for="mediaencryptedeventinit">    <span class="idlMemberType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-DOMString">DOMString</a></span>    <span class="idlMemberName"><a data-lt="initDataType" href="#dom-mediaencryptedeventinit-initdatatype" class="internalDFN" data-link-type="dfn" data-for="MediaEncryptedEventInit"><code>initDataType</code></a></span> = <span class="idlMemberValue">""</span>;</span>
-<span class="idlMember" id="idl-def-mediaencryptedeventinit-initdata" data-idl="" data-title="initData" data-dfn-for="mediaencryptedeventinit">    <span class="idlMemberType"><a href="https://www.w3.org/TR/WebIDL-1/#idl-ArrayBuffer">ArrayBuffer</a>?</span> <span class="idlMemberName"><a data-lt="initData" href="#dom-mediaencryptedeventinit-initdata" class="internalDFN" data-link-type="dfn" data-for="MediaEncryptedEventInit"><code>initData</code></a></span> = <span class="idlMemberValue">null</span>;</span>
+          <div>
+            <pre class="def idl"><span class="idlDictionary" id="idl-def-mediaencryptedeventinit" data-idl="" data-title="MediaEncryptedEventInit">dictionary <span class="idlDictionaryID">MediaEncryptedEventInit</span> : <span class="idlSuperclass">EventInit</span> {
+<span class="idlMember" id="idl-def-mediaencryptedeventinit-initdatatype" data-idl="" data-title="initDataType" data-dfn-for="mediaencryptedeventinit">    <span class="idlMemberType"><a href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></span>    <span class="idlMemberName"><a data-lt="initDataType" href="#dom-mediaencryptedeventinit-initdatatype" class="internalDFN" data-link-type="dfn" data-for="MediaEncryptedEventInit"><code>initDataType</code></a></span> = <span class="idlMemberValue">""</span>;</span>
+<span class="idlMember" id="idl-def-mediaencryptedeventinit-initdata" data-idl="" data-title="initData" data-dfn-for="mediaencryptedeventinit">    <span class="idlMemberType"><a href="https://heycam.github.io/webidl/#idl-ArrayBuffer">ArrayBuffer</a>?</span> <span class="idlMemberName"><a data-lt="initData" href="#dom-mediaencryptedeventinit-initdata" class="internalDFN" data-link-type="dfn" data-for="MediaEncryptedEventInit"><code>initData</code></a></span> = <span class="idlMemberValue">null</span>;</span>
 };</span></pre>
+          </div>
 
           <section typeof="bibo:Chapter" resource="#dictionary-mediaencryptedeventinit-members" property="bibo:hasPart">
             <h5 id="dictionary-mediaencryptedeventinit-members" resource="#dictionary-mediaencryptedeventinit-members"><span property="xhv:role" resource="xhv:heading">Dictionary <a class="idlType internalDFN" href="#idl-def-mediaencryptedeventinit" data-link-type="dfn"><code>MediaEncryptedEventInit</code></a> Members</span></h5>
@@ -5361,7 +5182,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
             </div>
           </li>
           <li>
-            <p><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">queue a task</a> to create an event named <code><a href="#dom-evt-encrypted">encrypted</a></code> that does not bubble and is not cancellable using the <a href="#dom-mediaencryptedevent" class="internalDFN" data-link-type="dfn"><code>MediaEncryptedEvent</code></a> interface with its <var>type</var> attribute set to <code>message</code> and its <var>isTrusted</var> attribute initialized to <code>true</code>, and dispatch it at the <var>media element</var>.</p>
+            <p><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to create an event named <code><a href="#dom-evt-encrypted">encrypted</a></code> that does not bubble and is not cancellable using the <a href="#dom-mediaencryptedevent" class="internalDFN" data-link-type="dfn"><code>MediaEncryptedEvent</code></a> interface with its <var>type</var> attribute set to <code>encrypted</code> and its <var>isTrusted</var> attribute initialized to <code>true</code>, and dispatch it at the <var>media element</var>.</p>
             <p>The event interface <a href="#dom-mediaencryptedevent" class="internalDFN" data-link-type="dfn"><code>MediaEncryptedEvent</code></a> has:</p>
             <ul style="list-style-type:none">
               <li>
@@ -5619,14 +5440,14 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
               <dt>Otherwise</dt>
               <dd>
                 <p>Set the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">readyState</a></code> of <var>media element</var> to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_metadata">HAVE_METADATA</a></code>.</p>
-                <div class="note">
-                  <div class="note-title marker" aria-level="5" role="heading" id="h-note114"><span>Note</span></div>
-                  <p class="">
-                    In other words, if the video frame and audio data for the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#current-position">current playback position</a> have been decoded because they were unencrypted and/or successfully decrypted, set <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">readyState</a></code> to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_current_data">HAVE_CURRENT_DATA</a></code>. Otherwise, including if this was previously the case but the data is no longer available, set <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">readyState</a></code> to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_metadata">HAVE_METADATA</a></code>.
-                  </p>
-                </div>
               </dd>
             </dl>
+            <div class="note">
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note114"><span>Note</span></div>
+              <p class="">
+                In other words, if the video frame and audio data for the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#current-position">current playback position</a> have been decoded because they were unencrypted and/or successfully decrypted, set <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">readyState</a></code> to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_current_data">HAVE_CURRENT_DATA</a></code>. Otherwise, including if this was previously the case but the data is no longer available, set <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">readyState</a></code> to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_metadata">HAVE_METADATA</a></code>.
+              </p>
+            </div>
           </li>
           <li>
             <p><a href="https://www.w3.org/TR/html51/webappapis.html#queuing">Queue a task</a> to <a href="https://www.w3.org/TR/html51/webappapis.html#firing-a-simple-event-named-e">fire a simple event</a> named <code><a href="#dom-evt-waitingforkey">waitingforkey</a></code> at the <var>media element</var>.</p>
@@ -5690,8 +5511,8 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
       </section>
     </section>
 
-    <section id="media-element-restictions" class="informative" typeof="bibo:Chapter" resource="#media-element-restictions" property="bibo:hasPart">
-      <h3 id="h-media-element-restictions" resource="#h-media-element-restictions"><span property="xhv:role" resource="xhv:heading"><span class="secno">7.4 </span>Media Element Restrictions</span>
+    <section id="media-element-restrictions" class="informative" typeof="bibo:Chapter" resource="#media-element-restrictions" property="bibo:hasPart">
+      <h3 id="h-media-element-restrictions" resource="#h-media-element-restrictions"><span property="xhv:role" resource="xhv:heading"><span class="secno">7.4 </span>Media Element Restrictions</span>
       </h3>
       <p><em>This section is non-normative.</em></p>
       <p>Media data processed by a CDM <em class="rfc2119" title="MAY">MAY</em> be unavailable through web platform APIs in the usual way (for example using the CanvasRenderingContext2D drawImage() method and the AudioContext MediaElementAudioSourceNode). This specification does not define conditions for such non-availability of media data, however, if media data is not available to through such APIs then they <em class="rfc2119" title="MAY">MAY</em> behave as if no media data was present at all.</p>
@@ -5706,15 +5527,61 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
     </h2>
     <p>This section defines implementation requirements - for both user agents and <a href="#key-system">Key Systems</a>, including the <a href="#cdm">CDM</a> and server - that may not be explicitly addressed in the algorithms.</p>
 
+    <section id="cdm-constraint-requirements" typeof="bibo:Chapter" resource="#cdm-constraint-requirements" property="bibo:hasPart">
+      <h3 id="h-cdm-constraint-requirements" resource="#h-cdm-constraint-requirements"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.1 </span>CDM Constraints</span>
+      </h3>
+      <p>
+        User agent implementers <em class="rfc2119" title="MUST">MUST</em> ensure that CDMs do not access any information, storage or system capabilities that are not reasonably required for playback of protected media using the features of this specification. Specifically, the CDM <em class="rfc2119" title="SHALL NOT">SHALL NOT</em>:
+      </p>
+      <ul>
+        <li>
+          <p>
+            Access network resources, either local or remote, except via the user agent, or as part of the user agent, as explicitly permitted by this specification.
+          </p>
+        </li>
+        <li>
+          <p>
+            Access storage (disk or memory), except where reasonably required for playback of protected media using the features of this specification.
+          </p>
+        </li>
+        <li>
+          <p>
+            Access user data other than CDM state and persistent data.
+          </p>
+        </li>
+        <li>
+          <p>
+            Access hardware components or devices, except where reasonably required for playback of protected media using the features of this specification.
+          </p>
+        </li>
+      </ul>
+      <p>
+        User Agent implementers may use various techniques to meet the above requirements. For example, a User Agent implementer also implementing their own CDM may include the above as design requirements for that component. A User Agent implementer making use of a third party CDM may ensure that it executes in a constrained environment (e.g., "sandbox") without access to the prohibited information and components.
+      </p>
+    </section>
+
+    <section id="messaging-requirements" typeof="bibo:Chapter" resource="#messaging-requirements" property="bibo:hasPart">
+      <h3 id="h-messaging-requirements" resource="#h-messaging-requirements"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.2 </span>Messaging</span>
+      </h3>
+      <p>
+        All messages and communication to and from the CDM, such as between the CDM and a license server, <em class="rfc2119" title="MUST">MUST</em> be passed through the user agent. The CDM <em class="rfc2119" title="MUST NOT">MUST NOT</em> make direct out-of band network requests. All messages and communication other than those described in <a href="#direct-individualization">Direct Individualization</a> <em class="rfc2119" title="MUST">MUST</em> be passed through the application via the APIs defined in this specification. Specifically, all communication that contains application-, <a href="https://www.w3.org/TR/html51/browsers.html#concept-cross-origin">origin</a>-, or content-specific information or is sent to a URL specified by the application or based on its origin, <em class="rfc2119" title="MUST">MUST</em> pass through the APIs. This includes all license exchange messages.
+      </p>
+
+      <div class="note">
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note117"><span>Note</span></div>
+        <p class="">Implementations may or may not separate the implementations of CDMs or treat them as separate from the user agent. This is transparent to the API and application.</p>
+      </div>
+    </section>
+
     <section id="persistent-state-requirements" typeof="bibo:Chapter" resource="#persistent-state-requirements" property="bibo:hasPart">
-      <h3 id="h-persistent-state-requirements" resource="#h-persistent-state-requirements"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.1 </span>Persistent Data</span>
+      <h3 id="h-persistent-state-requirements" resource="#h-persistent-state-requirements"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.3 </span>Persistent Data</span>
       </h3>
       <p>
         Persistent Data includes all data stored by the CDM, or by the User Agent on behalf of the CDM, that exists after the destruction of the <a href="#idl-def-mediakeys" class="internalDFN" data-link-type="dfn"><code>MediaKeys</code></a> object. Specifically, it includes any identifiers (including <a href="#distinctive-identifier">Distinctive Identifier(s)</a>), licenses, keys, key IDs, or <a href="#record-of-license-destruction">records of license destruction</a> stored by the CDM or by the User Agent on behalf of the CDM.
       </p>
 
       <section id="use-origin-specific-key-system-storage" typeof="bibo:Chapter" resource="#use-origin-specific-key-system-storage" property="bibo:hasPart">
-        <h4 id="h-use-origin-specific-key-system-storage" resource="#h-use-origin-specific-key-system-storage"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.1.1 </span>Use origin-specific and browsing profile-specific Key System storage</span>
+        <h4 id="h-use-origin-specific-key-system-storage" resource="#h-use-origin-specific-key-system-storage"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.3.1 </span>Use origin-specific and browsing profile-specific Key System storage</span>
         </h4>
         <p>Persistent Data that might impact messages or behavior in an application- or license server-visible way <em class="rfc2119" title="MUST">MUST</em> be stored in an <a href="https://www.w3.org/TR/html51/browsers.html#concept-cross-origin">origin</a>-specific and <a href="#browsing-profile">browsing profile</a>-specific way and <em class="rfc2119" title="MUST NOT">MUST NOT</em> leak to or from private browsing sessions. Specifically but not exhaustively, session data, licenses, keys and per-origin identifiers <em class="rfc2119" title="MUST">MUST</em> be stored per-<a href="https://www.w3.org/TR/html51/browsers.html#concept-cross-origin">origin</a> and per-<a href="#browsing-profile">browsing profile</a>.
         </p>
@@ -5724,7 +5591,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
       </section>
 
       <section id="allow-persistent-data-cleared" typeof="bibo:Chapter" resource="#allow-persistent-data-cleared" property="bibo:hasPart">
-        <h4 id="h-allow-persistent-data-cleared" resource="#h-allow-persistent-data-cleared"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.1.2 </span>Allow Persistent Data to Be Cleared</span>
+        <h4 id="h-allow-persistent-data-cleared" resource="#h-allow-persistent-data-cleared"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.3.2 </span>Allow Persistent Data to Be Cleared</span>
         </h4>
         <p>
           Implementations that use Persistent Data <em class="rfc2119" title="MUST">MUST</em> allow the user to clear that data such that it is no longer retrievable both outside, such as via the APIs defined in this specification, and on the client device.
@@ -5789,7 +5656,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
       </section>
 
       <section id="encrypt-or-obfuscate-persistent-data" typeof="bibo:Chapter" resource="#encrypt-or-obfuscate-persistent-data" property="bibo:hasPart">
-        <h4 id="h-encrypt-or-obfuscate-persistent-data" resource="#h-encrypt-or-obfuscate-persistent-data"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.1.3 </span>Encrypt or obfuscate Persistent Data</span>
+        <h4 id="h-encrypt-or-obfuscate-persistent-data" resource="#h-encrypt-or-obfuscate-persistent-data"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.3.3 </span>Encrypt or obfuscate Persistent Data</span>
         </h4>
         <p>User agents <em class="rfc2119" title="SHOULD">SHOULD</em> treat Persistent Data as potentially sensitive; it is quite possible for user privacy to be compromised by the release of this information. To this end, user agents <em class="rfc2119" title="SHOULD">SHOULD</em> ensure that Persistent Data is securely stored and when deleting data, it is promptly deleted from the underlying storage.
         </p>
@@ -5797,13 +5664,13 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
     </section>
 
     <section id="exposed-value-requirements" typeof="bibo:Chapter" resource="#exposed-value-requirements" property="bibo:hasPart">
-      <h3 id="h-exposed-value-requirements" resource="#h-exposed-value-requirements"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.2 </span>Values Exposed to the Application</span>
+      <h3 id="h-exposed-value-requirements" resource="#h-exposed-value-requirements"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.4 </span>Values Exposed to the Application</span>
       </h3>
       <p>Values exposed to or inferable by, such as via its use by the CDM, the application could be used to identify the client or user, regardless of whether they are designed to be identifiers. This section defines requirements for avoiding or at least mitigating such concerns. There are additional requirements for <a href="#identifier-requirements">Identifiers</a>.
       </p>
 
       <section id="per-origin-per-profile-values" typeof="bibo:Chapter" resource="#per-origin-per-profile-values" property="bibo:hasPart">
-        <h4 id="h-per-origin-per-profile-values" resource="#h-per-origin-per-profile-values"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.2.1 </span>Use Per-Origin Per-Profile Values</span>
+        <h4 id="h-per-origin-per-profile-values" resource="#h-per-origin-per-profile-values"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.4.1 </span>Use Per-Origin Per-Profile Values</span>
         </h4>
         <!-- Issue #101 may affect this text. -->
         <p>
@@ -5815,7 +5682,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
       </section>
 
       <section id="allow-values-to-be-cleared" typeof="bibo:Chapter" resource="#allow-values-to-be-cleared" property="bibo:hasPart">
-        <h4 id="h-allow-values-to-be-cleared" resource="#h-allow-values-to-be-cleared"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.2.2 </span>Allow Values to Be Cleared</span>
+        <h4 id="h-allow-values-to-be-cleared" resource="#h-allow-values-to-be-cleared"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.4.2 </span>Allow Values to Be Cleared</span>
         </h4>
         <p>
           As a consequence of the requirements in <a href="#allow-persistent-data-cleared">Allow Persistent Data to Be Cleared</a>, all persisted values exposed to the application <em class="rfc2119" title="MUST">MUST</em> be clearable such that the values are no longer retrievable, observable, or inferable both outside, such as via the APIs defined in this specification, and on the client device.
@@ -5827,12 +5694,12 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
     </section>
 
     <section id="identifier-requirements" typeof="bibo:Chapter" resource="#identifier-requirements" property="bibo:hasPart">
-      <h3 id="h-identifier-requirements" resource="#h-identifier-requirements"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.3 </span>Identifiers</span>
+      <h3 id="h-identifier-requirements" resource="#h-identifier-requirements"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.5 </span>Identifiers</span>
       </h3>
       <p>The use of identifiers, especially <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">Distinctive Identifier(s) or Distinctive Permanent Identifier(s)</a>, by implementations presents a privacy concern. This section defines requirements for avoiding or at least mitigating such concerns. The requirements for <a href="#exposed-value-requirements">Values Exposed to the Application</a> also apply to identifiers exposed to the application.
       </p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note117"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note118"><span>Note</span></div>
         <div class="">
           <p>In summary:</p>
           <ul>
@@ -5865,20 +5732,20 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
       </div>
 
       <section id="limit-or-avoid-use-of-distinctive-identifiers-and-permanent-identifiers" typeof="bibo:Chapter" resource="#limit-or-avoid-use-of-distinctive-identifiers-and-permanent-identifiers" property="bibo:hasPart">
-        <h4 id="h-limit-or-avoid-use-of-distinctive-identifiers-and-permanent-identifiers" resource="#h-limit-or-avoid-use-of-distinctive-identifiers-and-permanent-identifiers"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.3.1 </span>Limit or Avoid use of Distinctive Identifiers and Permanent Identifiers</span>
+        <h4 id="h-limit-or-avoid-use-of-distinctive-identifiers-and-permanent-identifiers" resource="#h-limit-or-avoid-use-of-distinctive-identifiers-and-permanent-identifiers"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.5.1 </span>Limit or Avoid use of Distinctive Identifiers and Permanent Identifiers</span>
         </h4>
         <ul>
           <li>
             <p>Implementations <em class="rfc2119" title="SHOULD">SHOULD</em> avoid <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">use of Distinctive Identifier(s) or Distinctive Permanent Identifier(s)</a>.</p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note118"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note119"><span>Note</span></div>
               <p class="">For example, use identifiers or other values that apply to a group of clients or devices rather than individual clients.</p>
             </div>
           </li>
           <li>
             <p>Implementations <em class="rfc2119" title="SHOULD">SHOULD</em> only <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">use Distinctive Identifier(s) or Distinctive Permanent Identifier(s)</a> when necessary to enforce the policies related to the specific CDM instance and session.</p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note119"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note120"><span>Note</span></div>
               <p class="">For example, <code><a href="#idl-def-MediaKeySessionType.temporary">"temporary"</a></code> and <code><a href="#idl-def-MediaKeySessionType.persistent-license">"persistent-license"</a></code> sessions may have different requirements.</p>
             </div>
           </li>
@@ -5887,7 +5754,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
               Implementations that <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">use Distinctive Identifier(s) or Distinctive Permanent Identifier(s)</a> <em class="rfc2119" title="SHOULD">SHOULD</em> support the option to not use them. Implementations with such support <em class="rfc2119" title="SHOULD">SHOULD</em> expose the ability for the user to select this option.
             </p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note120"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note121"><span>Note</span></div>
               <div class="">
                 <p>
                   When supported, applications can select for this mode using <code><a href="#dom-mediakeysystemconfiguration-distinctiveidentifier">distinctiveIdentifier</a></code> = <code><a href="#idl-def-MediaKeysRequirement.not-allowed">"not-allowed"</a></code>. Selecting such an option may affect the results of the <code><a href="#dom-navigator-requestmediakeysystemaccess">requestMediaKeySystemAccess()</a></code> call and/or the license requests that are generated from subsequently generated sessions.
@@ -5902,13 +5769,13 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
       </section>
 
       <section id="encrypt-identifiers" typeof="bibo:Chapter" resource="#encrypt-identifiers" property="bibo:hasPart">
-        <h4 id="h-encrypt-identifiers" resource="#h-encrypt-identifiers"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.3.2 </span>Encrypt Identifiers</span>
+        <h4 id="h-encrypt-identifiers" resource="#h-encrypt-identifiers"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.5.2 </span>Encrypt Identifiers</span>
         </h4>
         <p>
           <a href="#distinctive-identifier">Distinctive Identifiers</a> and <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifiers</a> <em class="rfc2119" title="MUST">MUST</em> be encrypted at the message exchange level when exposed outside the client. All other identifiers <em class="rfc2119" title="SHOULD">SHOULD</em> be encrypted at the message exchange level when exposed outside the client. The encryption <em class="rfc2119" title="MUST">MUST</em> ensure that any two instances of the identifier ciphertext are <a href="#associable-by-entity">associable</a> only by an entity in possession of the decryption key.
         </p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note121"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note122"><span>Note</span></div>
           <div class="">
             <p>Identifiers may be exposed in the following ways:</p>
             <ul>
@@ -5929,12 +5796,12 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
         </p>
         <p>The server <em class="rfc2119" title="MUST NOT">MUST NOT</em> expose a <a href="#distinctive-identifier">Distinctive Identifier</a> to any entity other than the CDM that sent it.</p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note122"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note123"><span>Note</span></div>
           <p class="">Specifically, it should not be provided to the application or included unencrypted in messages to the CDM. This can be accomplished by encrypting the identifier or message with the identifier or such that it is only decryptable by that specific CDM.
           </p>
         </div>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note123"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note124"><span>Note</span></div>
           <div class="">
             <p>Among other things, this means that:</p>
             <ul>
@@ -5953,13 +5820,13 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
       </section>
 
       <section id="per-origin-per-profile-identifiers" typeof="bibo:Chapter" resource="#per-origin-per-profile-identifiers" property="bibo:hasPart">
-        <h4 id="h-per-origin-per-profile-identifiers" resource="#h-per-origin-per-profile-identifiers"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.3.3 </span>Use Per-Origin Per-Profile Identifiers</span>
+        <h4 id="h-per-origin-per-profile-identifiers" resource="#h-per-origin-per-profile-identifiers"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.5.3 </span>Use Per-Origin Per-Profile Identifiers</span>
         </h4>
         <p>
-          All identifiers except <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifiers</a> <em class="rfc2119" title="MUST">MUST</em> be unique per <a href="https://www.w3.org/TR/html51/browsers.html#concept-cross-origin">origin</a> and <a href="#browsing-profile">browsing profile</a>. See <a href="#per-origin-per-profile-values" class="sec-ref"><span class="secno">8.2.1</span> <span class="sec-title">Use Per-Origin Per-Profile Values</span></a>.
+          All identifiers except <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifiers</a> <em class="rfc2119" title="MUST">MUST</em> be unique per <a href="https://www.w3.org/TR/html51/browsers.html#concept-cross-origin">origin</a> and <a href="#browsing-profile">browsing profile</a>. See <a href="#per-origin-per-profile-values" class="sec-ref"><span class="secno">8.4.1</span> <span class="sec-title">Use Per-Origin Per-Profile Values</span></a>.
         </p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note124"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note125"><span>Note</span></div>
           <div class="">
             <p>This includes but is not limited to <a href="#distinctive-identifier">Distinctive Identifiers</a>.</p>
             <p><a href="#distinctive-permanent-identifier">Distinctive Permanent Identifiers</a> <em class="rfc2119" title="MUST NOT">MUST NOT</em> be exposed to the application or origin.</p>
@@ -5968,13 +5835,13 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
       </section>
 
       <section id="non-associable-identifiers" typeof="bibo:Chapter" resource="#non-associable-identifiers" property="bibo:hasPart">
-        <h4 id="h-non-associable-identifiers" resource="#h-non-associable-identifiers"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.3.4 </span>Use Non-Associable Identifiers</span>
+        <h4 id="h-non-associable-identifiers" resource="#h-non-associable-identifiers"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.5.4 </span>Use Non-Associable Identifiers</span>
         </h4>
         <p>
           All identifiers, including <a href="#distinctive-identifier">Distinctive Identifiers</a>, exposed by the implementation to applications, even in encrypted form, <em class="rfc2119" title="MUST">MUST</em> be <a href="#non-associable-by-application">non-associable by application(s)</a> across <a href="https://www.w3.org/TR/html51/browsers.html#concept-cross-origin">origins</a>, <a href="#browsing-profile">browsing profiles</a>, and <a href="#allow-identifiers-cleared">clearing of identifiers</a>.
         </p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note125"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note126"><span>Note</span></div>
           <p class="">
             For all such identifiers, it <em class="rfc2119" title="MUST NOT">MUST NOT</em> be possible for one or more applications, including related license or other servers to achieve such correlation or association.
           </p>
@@ -5982,7 +5849,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
       </section>
 
       <section id="allow-identifiers-cleared" typeof="bibo:Chapter" resource="#allow-identifiers-cleared" property="bibo:hasPart">
-        <h4 id="h-allow-identifiers-cleared" resource="#h-allow-identifiers-cleared"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.3.5 </span>Allow Identifiers to Be Cleared</span>
+        <h4 id="h-allow-identifiers-cleared" resource="#h-allow-identifiers-cleared"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.5.5 </span>Allow Identifiers to Be Cleared</span>
         </h4>
         <p>
           As a consequence of the requirements in <a href="#allow-persistent-data-cleared">Allow Persistent Data to Be Cleared</a>, all potential identifiers or <a href="#distinctive-value">distinctive values</a> except <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifiers</a> <em class="rfc2119" title="MUST">MUST</em> be clearable such that the values are no longer retrievable, observable, or inferable both outside, such as via the APIs defined in this specification, and on the client device.
@@ -5997,7 +5864,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
     </section>
 
     <section id="individualization" typeof="bibo:Chapter" resource="#individualization" property="bibo:hasPart">
-      <h3 id="h-individualization" resource="#h-individualization"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.4 </span>Individualization</span>
+      <h3 id="h-individualization" resource="#h-individualization"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.6 </span>Individualization</span>
       </h3>
       <p>
         Identifiers, especially <a href="#distinctive-identifier">Distinctive Identifiers</a>, are sometimes generated or obtained via a process called individualization or provisioning. The resulting identifier(s) <em class="rfc2119" title="MUST">MUST</em> be <a href="#non-associable-by-application">non-associable by applications</a> and <a href="#uses-distinctive-identifiers">use of them</a> <em class="rfc2119" title="MUST">MUST</em> only be exposed to a <a href="#per-origin-per-profile-identifiers">single origin from a single profile</a>. This process <em class="rfc2119" title="MAY">MAY</em> be performed multiple times, such as after identifier(s) are <a href="#allow-identifiers-cleared">cleared</a>.
@@ -6005,20 +5872,20 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
       <p>This process <em class="rfc2119" title="MUST">MUST</em> be performed either <a href="#direct-individualization">directly by the user agent</a> or <a href="#app-assisted-individualization">through the application</a>. The mechanisms, flow, and restrictions for the two types of individualization are different, as described in the following sections. Which method is used depends on the CDM implementation and application of the requirements of this specification, especially those below.
       </p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note126"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note127"><span>Note</span></div>
         <p class="">
           <code><a href="#dom-mediakeysystemconfiguration-distinctiveidentifier">distinctiveIdentifier</a></code> controls whether <a href="#distinctive-identifier">Distinctive Identifiers</a> and <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifiers</a> may be <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">used</a>, including for individualization. Specifically, such identifiers may only be <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">used</a> when the value of the <code><a href="#dom-mediakeysystemconfiguration-distinctiveidentifier">distinctiveIdentifier</a></code> member of the <a href="#idl-def-mediakeysystemaccess" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemAccess</code></a> used to create the <a href="#idl-def-mediakeys" class="internalDFN" data-link-type="dfn"><code>MediaKeys</code></a> object is <code><a href="#idl-def-MediaKeysRequirement.required">"required"</a></code>.
         </p>
       </div>
 
       <section id="direct-individualization" typeof="bibo:Chapter" resource="#direct-individualization" property="bibo:hasPart">
-        <h4 id="h-direct-individualization" resource="#h-direct-individualization"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.4.1 </span>Direct Individualization</span>
+        <h4 id="h-direct-individualization" resource="#h-direct-individualization"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.6.1 </span>Direct Individualization</span>
         </h4>
         <p>
           Direct Individualization is performed between the <a href="#cdm">CDM</a> and an origin- and application-independent server. Although the server is origin-independent, the result of the individualization enables the CDM to provide origin-specific identifiers per the other requirements of this specification. The process <em class="rfc2119" title="MUST">MUST</em> be performed by the user agent and <em class="rfc2119" title="MUST NOT">MUST NOT</em> use the APIs defined in this specification.
         </p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note127"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note128"><span>Note</span></div>
           <p class="">For example, such a process may initialize a client device and/or obtain a <a href="#per-origin-per-profile-identifiers">per-origin</a> <a href="#allow-identifiers-cleared">clearable</a> identifier for <a href="#per-origin-per-profile-identifiers">a single browsing profile</a> by communicating with a pre-determined server hosted by the user agent or CDM vendor, possibly <a href="#uses-distinctive-permanent-identifiers">using Distinctive Permanent Identifier(s)</a> or other <a href="#permanent-identifier">Permanent Identifier(s)</a> from the client device.
           </p>
         </div>
@@ -6049,7 +5916,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
       </section>
 
       <section id="app-assisted-individualization" typeof="bibo:Chapter" resource="#app-assisted-individualization" property="bibo:hasPart">
-        <h4 id="h-app-assisted-individualization" resource="#h-app-assisted-individualization"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.4.2 </span>App-Assisted Individualization</span>
+        <h4 id="h-app-assisted-individualization" resource="#h-app-assisted-individualization"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.6.2 </span>App-Assisted Individualization</span>
         </h4>
         <p>App-Assisted Individualization is performed between the <a href="#cdm">CDM</a> and the application, including an application-selected server, and results in a per-origin identifier. The process <em class="rfc2119" title="MUST">MUST</em> be performed via the APIs defined in this specification and <em class="rfc2119" title="MUST NOT">MUST NOT</em> involve other methods of communication. As with all other uses of the APIs, the process <em class="rfc2119" title="MAY">MAY</em> <a href="#uses-distinctive-identifiers">use one or more Distinctive Identifier(s)</a>, but it <em class="rfc2119" title="MUST NOT">MUST NOT</em> <a href="#uses-distinctive-permanent-identifiers">use Distinctive Permanent Identifier(s)</a> or non-origin-specific values, even in encrypted form. If the process <a href="#uses-distinctive-identifiers">use one or more Distinctive Identifier(s)</a>, the resulting identifier is by definition also a <a href="#distinctive-identifier">Distinctive Identifier</a>.
         </p>
@@ -6076,7 +5943,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
           <li>
             <p><em class="rfc2119" title="MUST">MUST</em> adhere to the <a href="#identifier-requirements">identifier requirements</a>.</p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note128"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note129"><span>Note</span></div>
               <p class="">This includes only using values that are <a href="#per-origin-per-profile-identifiers">unique per origin and profile</a> and <a href="#allow-identifiers-cleared">clearable</a> and <a href="#encrypt-identifiers">encrypting</a> them as required.</p>
             </div>
           </li>
@@ -6093,11 +5960,11 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
     </section>
 
     <section id="support-multiple-keys" typeof="bibo:Chapter" resource="#support-multiple-keys" property="bibo:hasPart">
-      <h3 id="h-support-multiple-keys" resource="#h-support-multiple-keys"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.5 </span>Support Multiple Keys</span>
+      <h3 id="h-support-multiple-keys" resource="#h-support-multiple-keys"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.7 </span>Support Multiple Keys</span>
       </h3>
       <p>Implementations <em class="rfc2119" title="MUST">MUST</em> support multiple keys in each <a href="#idl-def-mediakeysession" class="internalDFN" data-link-type="dfn"><code>MediaKeySession</code></a> object.</p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note129"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note130"><span>Note</span></div>
         <p class="">The mechanics of how multiple keys are supported is an implementation detail, but it <em class="rfc2119" title="MUST">MUST</em> be transparent to the application and the APIs defined in this specification.</p>
       </div>
 
@@ -6106,25 +5973,25 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
     </section>
 
     <section id="initialization-data-type-support-requirements" typeof="bibo:Chapter" resource="#initialization-data-type-support-requirements" property="bibo:hasPart">
-      <h3 id="h-initialization-data-type-support-requirements" resource="#h-initialization-data-type-support-requirements"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.6 </span>Initialization Data Type Support</span>
+      <h3 id="h-initialization-data-type-support-requirements" resource="#h-initialization-data-type-support-requirements"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.8 </span>Initialization Data Type Support</span>
       </h3>
 
       <section id="licenses-generated-are-independent-of-content-type" typeof="bibo:Chapter" resource="#licenses-generated-are-independent-of-content-type" property="bibo:hasPart">
-        <h4 id="h-licenses-generated-are-independent-of-content-type" resource="#h-licenses-generated-are-independent-of-content-type"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.6.1 </span>Licenses Generated are Independent of Content Type</span>
+        <h4 id="h-licenses-generated-are-independent-of-content-type" resource="#h-licenses-generated-are-independent-of-content-type"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.8.1 </span>Licenses Generated are Independent of Content Type</span>
         </h4>
         <p>Implementations <em class="rfc2119" title="SHOULD">SHOULD</em> allow licenses generated with any <a href="#initialization-data-type">Initialization Data Type</a> they support to be used with any content type.</p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note130"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note131"><span>Note</span></div>
           <p class="">Otherwise, the <code><a href="#dom-navigator-requestmediakeysystemaccess">requestMediaKeySystemAccess()</a></code> algorithm might, for example, reject a <a href="#idl-def-mediakeysystemconfiguration" class="internalDFN" data-link-type="dfn"><code>MediaKeySystemConfiguration</code></a> because one of the <code><a href="#dom-mediakeysystemconfiguration-initdatatypes">initDataTypes</a></code> is not supported with one of the <code><a href="#dom-mediakeysystemconfiguration-videocapabilities">videoCapabilities</a></code>.</p>
         </div>
       </section>
 
       <section id="support-extraction-from-media-data" typeof="bibo:Chapter" resource="#support-extraction-from-media-data" property="bibo:hasPart">
-        <h4 id="h-support-extraction-from-media-data" resource="#h-support-extraction-from-media-data"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.6.2 </span>Support Extraction From Media Data</span>
+        <h4 id="h-support-extraction-from-media-data" resource="#h-support-extraction-from-media-data"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.8.2 </span>Support Extraction From Media Data</span>
         </h4>
         <p>For any supported <a href="#initialization-data-type">Initialization Data Type</a> that may appear in a supported container, the user agents <em class="rfc2119" title="MUST">MUST</em> support <a href="#initdata-encountered">extracting</a> that type of <a href="#initialization-data">Initialization Data</a> from each such supported container.</p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note131"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note132"><span>Note</span></div>
           <p class="">In other words, indicating support for an <a href="#initialization-data-type">Initialization Data Type</a> implies both CDM support for generating license requests and, for container-specific types, user agent support for extracting it from the container. This does <strong>not</strong> mean that implementations must be able to parse <em>any</em> supported <a href="#initialization-data">Initialization Data</a> from <em>any</em> supported content type.
           </p>
         </div>
@@ -6132,12 +5999,12 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
     </section>
 
     <section id="media-requirements" typeof="bibo:Chapter" resource="#media-requirements" property="bibo:hasPart">
-      <h3 id="h-media-requirements" resource="#h-media-requirements"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.7 </span>Supported Media</span>
+      <h3 id="h-media-requirements" resource="#h-media-requirements"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.9 </span>Supported Media</span>
       </h3>
       <p>This section defines properties of content (<a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#media-resource">media resources</a>) supported by implementations of this specification.</p>
 
       <section id="unencrypted-container" typeof="bibo:Chapter" resource="#unencrypted-container" property="bibo:hasPart">
-        <h4 id="h-unencrypted-container" resource="#h-unencrypted-container"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.7.1 </span>Unencrypted Container</span>
+        <h4 id="h-unencrypted-container" resource="#h-unencrypted-container"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.9.1 </span>Unencrypted Container</span>
         </h4>
         <p>
           The media container <em class="rfc2119" title="MUST NOT">MUST NOT</em> be encrypted. This specification relies on the user agent's ability to parse the media container without having to decrypt any of the media data. This includes the <a href="#encrypted-block-encountered">Encrypted Block Encountered</a> and <a href="#initdata-encountered">Initialization Data Encountered</a> algorithms as well as supporting standard <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#htmlmediaelement-htmlmediaelement">HTMLMediaElement</a></code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] functionality, such as <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#seeking">seeking</a>.
@@ -6145,13 +6012,13 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
       </section>
 
       <section id="interoperably-encrypted" typeof="bibo:Chapter" resource="#interoperably-encrypted" property="bibo:hasPart">
-        <h4 id="h-interoperably-encrypted" resource="#h-interoperably-encrypted"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.7.2 </span>Interoperably Encrypted</span>
+        <h4 id="h-interoperably-encrypted" resource="#h-interoperably-encrypted"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.9.2 </span>Interoperably Encrypted</span>
         </h4>
         <p>
           <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#media-resource">Media resources</a>, including all tracks, <em class="rfc2119" title="MUST">MUST</em> be encrypted and packaged per a container-specific "common encryption" specification that allows the content to be decrypted in a fully specified and compatible way when a key or keys are provided.
         </p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note132"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note133"><span>Note</span></div>
           <p class="">
             The Encrypted Media Extensions Stream Format and Initialization Data Format Registry [<cite><a class="bibref" href="#bib-EME-STREAM-REGISTRY">EME-STREAM-REGISTRY</a></cite>] provides references to such stream formats.
           </p>
@@ -6159,13 +6026,13 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
       </section>
 
       <section id="unencrypted-in-band-support-content" typeof="bibo:Chapter" resource="#unencrypted-in-band-support-content" property="bibo:hasPart">
-        <h4 id="h-unencrypted-in-band-support-content" resource="#h-unencrypted-in-band-support-content"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.7.3 </span>Unencrypted In-band Support Content</span>
+        <h4 id="h-unencrypted-in-band-support-content" resource="#h-unencrypted-in-band-support-content"><span property="xhv:role" resource="xhv:heading"><span class="secno">8.9.3 </span>Unencrypted In-band Support Content</span>
         </h4>
         <p>
           In-band support content, such as captions, described audio, and transcripts, <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> be encrypted.
         </p>
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note133"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note134"><span>Note</span></div>
           <p class="">
             Decryption of such tracks - especially such that they can be provided back the user agent - is not generally supported by implementations. Thus, encrypting such tracks would prevent them from being widely available for use with accessibility features in user agent implementations.
           </p>
@@ -6184,7 +6051,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
     </h2>
     <p>All user agents <em class="rfc2119" title="MUST">MUST</em> support the common key systems described in this section.</p>
     <div class="note">
-      <div class="note-title marker" aria-level="3" role="heading" id="h-note134"><span>Note</span></div>
+      <div class="note-title marker" aria-level="3" role="heading" id="h-note135"><span>Note</span></div>
       <p class="">This ensures that there is a common baseline level of functionality that is guaranteed to be supported in all user agents, including those that are entirely open source. Thus, content providers that need only basic decryption can build simple applications that will work on all platforms without needing to work with any content protection providers.
       </p>
     </div>
@@ -6447,13 +6314,13 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
       <p>User Agent and Key System implementations <em class="rfc2119" title="MUST">MUST</em> consider <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#media-data">media data</a>, <a href="#initialization-data">Initialization Data</a>, data passed to <code><a href="#dom-mediakeysession-update">update()</a></code>, licenses, key data, and all other data provided by the application as untrusted content and potential attack vectors. They <em class="rfc2119" title="MUST">MUST</em> use appropriate safeguards to mitigate any associated threats and take care to safely parse, decrypt, etc. such data. User Agents <em class="rfc2119" title="SHOULD">SHOULD</em> validate data before passing it to the CDM.
       </p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note135"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note136"><span>Note</span></div>
         <p class="">Such validation is especially important if the CDM does not run in the same (sandboxed) context as, for example, the DOM.</p>
       </div>
 
       <p>Implementations <em class="rfc2119" title="MUST NOT">MUST NOT</em> return active content or passive content that affects program control flow to the application.</p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note136"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note137"><span>Note</span></div>
         <p class="">For example, it is not safe to expose URLs or other information that may have come from media data, such as is the case for the <a href="#initialization-data">Initialization Data</a> passed to <code><a href="#dom-mediakeysession-generaterequest">generateRequest()</a></code>. Applications must determine the URLs to use. The <code><a href="#dom-mediakeymessageevent-messagetype">messageType</a></code> attribute of the <code><a href="#dom-evt-message">message</a></code> event can be used by the application to select among a set of URLs if applicable.
         </p>
       </div>
@@ -6462,19 +6329,19 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
     <section id="cdm-security" typeof="bibo:Chapter" resource="#cdm-security" property="bibo:hasPart">
       <h3 id="h-cdm-security" resource="#h-cdm-security"><span property="xhv:role" resource="xhv:heading"><span class="secno">10.2 </span>CDM Attacks and Vulnerabilities</span>
       </h3>
-      <p>User Agents are responsible for providing users with a secure way to browse the web, including any functionality, such as CDMs, from third parties. User agent implementers <em class="rfc2119" title="MUST">MUST</em> obtain sufficient information from Key System implementers to enable them to properly assess the security implications of integrating with the Key System. User agent implementers <em class="rfc2119" title="MUST">MUST</em> ensure CDM implementations provide and/or support sufficient controls for the user agent to provide security for the user. User agent implementers <em class="rfc2119" title="MUST">MUST</em> ensure CDM implementations can and will be quickly and proactively updated in the event of security vulnerabilities.
+      <p>User Agents are responsible for providing users with a secure way to browse the web. This responsibility applies to any functionality used by User Agents, including functionalities from third parties. User agent implementers <em class="rfc2119" title="MUST">MUST</em> obtain sufficient information from Key System implementers to enable them to properly assess the security implications of integrating with the Key System. User agent implementers <em class="rfc2119" title="MUST">MUST</em> ensure CDM implementations provide and/or support sufficient controls for the user agent to provide security for the user. User agent implementers <em class="rfc2119" title="MUST">MUST</em> ensure CDM implementations can and will be quickly and proactively updated in the event of security vulnerabilities.
       </p>
       <p>Exploiting a CDM implementation that is not fully sandboxed and/or uses platform features may allow an attacker to access OS or platform features, elevate privilege (e.g., to run as system or root), and/or access drivers, kernel, firmware, hardware, etc. Such features, software, and hardware may not be written to be robust against hostile software or web-based attacks and may not be updated with security fixes, especially compared to the user agent. Lack of, infrequent, or slow updates for fixes to security vulnerabilities in CDM implementations increases the risk. Such CDM implementations and UAs that expose them <em class="rfc2119" title="MUST">MUST</em> be especially careful in all areas of security, including parsing of <a href="#input-data-security">all data</a>.
       </p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note137"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note138"><span>Note</span></div>
         <p class="">User agents should be especially diligent when using a CDM or underlying mechanism that is part of or provided by the client OS, platform and/or hardware.</p>
       </div>
 
       <p>If a user agent chooses to support a Key System implementation that cannot be sufficiently sandboxed or otherwise secured, the user agent <em class="rfc2119" title="SHOULD">SHOULD</em> <a href="#security-consent">ensure that users are fully informed and/or give explicit consent</a> before loading or invoking it.
       </p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note138"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note139"><span>Note</span></div>
         <p class="">Granting permissions to unauthenticated origins is equivalent to granting the permissions to any origin in the presence of a network attacker. See <a href="#persisted-consent-abuse">abuse of persisted consent</a>.
         </p>
       </div>
@@ -6546,7 +6413,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
             <p>Such mechanisms <em class="rfc2119" title="MUST">MUST</em> be per <a href="https://www.w3.org/TR/html51/browsers.html#concept-cross-origin">origin</a> to avoid valid uses enabling subsequent malicious access and <em class="rfc2119" title="MUST">MUST</em> be per <a href="#browsing-profile">browsing profile</a>.
             </p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note139"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note140"><span>Note</span></div>
               <p class="">The restriction of the APIs defined in this specification to secure contexts ensures that a <a href="#network-attacks">network attacker</a> cannot exploit permissions granted to an unauthenticated origin. See <a href="#persisted-consent-abuse">abuse of persisted consent</a>.
               </p>
             </div>
@@ -6587,7 +6454,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
       <p>Using the APIs defined in this specification on shared hosts compromises origin-based security and privacy mitigations implemented by user agents. For example, per-origin <a href="#distinctive-identifier">Distinctive Identifiers</a> are shared by all authors on one host name, and peristed data may be accessed and manipulated by any author on the host. The latter is especially important if, for example, modification or deletion of such data could erase a user's right to specific content.
       </p>
       <div class="note">
-        <div class="note-title marker" aria-level="4" role="heading" id="h-note140"><span>Note</span></div>
+        <div class="note-title marker" aria-level="4" role="heading" id="h-note141"><span>Note</span></div>
         <p class="">Even if a path-restriction feature was made available by user agents, the usual DOM scripting security model would make it trivial to bypass this protection and access the data from any path.</p>
       </div>
       <p>Authors on shared hosts are therefore <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em> to avoid using the APIs defined in this specification because doing so compromises origin-based security and privacy mitigations in user agents.</p>
@@ -6662,7 +6529,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
               It is not possible to extract, derive or infer information from the CDM that is not either explicitly described in this specification or available to the page through other web platform APIs without user permission. This applies to any information that is exposed outside the client device or to the application, including, for example, in CDM messages.
             </p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note141"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note142"><span>Note</span></div>
               <div class="">
                 <p>The type of information covered by this requirement includes but is not limited to:</p>
                 <ul>
@@ -6802,16 +6669,16 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
           <dd>
             <!-- Issue #101 may affect this text. -->
             <p>
-              For all <a href="#distinctive-value">distinctive values</a> exposed to the application, implementations <em class="rfc2119" title="MUST">MUST</em> use a different <a href="#non-associable-by-application">non-associable by applications</a> value for each <a href="https://www.w3.org/TR/html51/browsers.html#concept-cross-origin">origin</a> and <a href="#browsing-profile">browsing profile</a>. See <a href="#per-origin-per-profile-values" class="sec-ref"><span class="secno">8.2.1</span> <span class="sec-title">Use Per-Origin Per-Profile Values</span></a>.
+              For all <a href="#distinctive-value">distinctive values</a> exposed to the application, implementations <em class="rfc2119" title="MUST">MUST</em> use a different <a href="#non-associable-by-application">non-associable by applications</a> value for each <a href="https://www.w3.org/TR/html51/browsers.html#concept-cross-origin">origin</a> and <a href="#browsing-profile">browsing profile</a>. See <a href="#per-origin-per-profile-values" class="sec-ref"><span class="secno">8.4.1</span> <span class="sec-title">Use Per-Origin Per-Profile Values</span></a>.
             </p>
             <p>
-              This is especially important for implementations that <a href="#uses-distinctive-identifiers">use Distinctive Identifier(s)</a>. See <a href="#per-origin-per-profile-identifiers" class="sec-ref"><span class="secno">8.3.3</span> <span class="sec-title">Use Per-Origin Per-Profile Identifiers</span></a>.
+              This is especially important for implementations that <a href="#uses-distinctive-identifiers">use Distinctive Identifier(s)</a>. See <a href="#per-origin-per-profile-identifiers" class="sec-ref"><span class="secno">8.5.3</span> <span class="sec-title">Use Per-Origin Per-Profile Identifiers</span></a>.
             </p>
           </dd>
 
           <dt>Use origin-specific and browsing profile-specific Key System storage</dt>
           <dd>
-            <p>Any data used by the CDM that might impact messages or behavior in an application- or license server-visible way <em class="rfc2119" title="MUST">MUST</em> be partitioned by <a href="https://www.w3.org/TR/html51/browsers.html#concept-cross-origin">origin</a> and <a href="#browsing-profile">browsing profile</a> and <em class="rfc2119" title="MUST NOT">MUST NOT</em> leak to or from private browsing sessions. This includes both in-memory and persisted data. Specifically but not exhaustively, session data, licenses, keys, and per-origin identifiers <em class="rfc2119" title="MUST">MUST</em> be partitioned per-<a href="https://www.w3.org/TR/html51/browsers.html#concept-cross-origin">origin</a> and per-<a href="#browsing-profile">browsing profile</a>. See <a href="#use-origin-specific-key-system-storage" class="sec-ref"><span class="secno">8.1.1</span> <span class="sec-title">Use origin-specific and browsing profile-specific Key System storage</span></a> and <a href="#per-origin-per-profile-values" class="sec-ref"><span class="secno">8.2.1</span> <span class="sec-title">Use Per-Origin Per-Profile Values</span></a>.
+            <p>Any data used by the CDM that might impact messages or behavior in an application- or license server-visible way <em class="rfc2119" title="MUST">MUST</em> be partitioned by <a href="https://www.w3.org/TR/html51/browsers.html#concept-cross-origin">origin</a> and <a href="#browsing-profile">browsing profile</a> and <em class="rfc2119" title="MUST NOT">MUST NOT</em> leak to or from private browsing sessions. This includes both in-memory and persisted data. Specifically but not exhaustively, session data, licenses, keys, and per-origin identifiers <em class="rfc2119" title="MUST">MUST</em> be partitioned per-<a href="https://www.w3.org/TR/html51/browsers.html#concept-cross-origin">origin</a> and per-<a href="#browsing-profile">browsing profile</a>. See <a href="#use-origin-specific-key-system-storage" class="sec-ref"><span class="secno">8.3.1</span> <span class="sec-title">Use origin-specific and browsing profile-specific Key System storage</span></a> and <a href="#per-origin-per-profile-values" class="sec-ref"><span class="secno">8.4.1</span> <span class="sec-title">Use Per-Origin Per-Profile Values</span></a>.
             </p>
           </dd>
 
@@ -6825,7 +6692,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
           <dd>
             <p>User agents <em class="rfc2119" title="MAY">MAY</em>, possibly in a manner configured by the user, automatically delete <a href="#distinctive-identifier">Distinctive Identifiers</a> and/or other Key System data after a period of time.</p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note142"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note143"><span>Note</span></div>
               <div class="">
                 <p>For example, a user agent could be configured to store such data as session-only storage, deleting the data once the user had closed all the browsing contexts that could access it.</p>
                 <p>This can restrict the ability of a site to track a user, as the site would then only be able to track the user across multiple sessions when the user authenticates with the site itself (e.g., by making a purchase or signing in to a service).</p>
@@ -6848,7 +6715,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
             <p>Such mechanisms <em class="rfc2119" title="MUST">MUST</em> be per <a href="https://www.w3.org/TR/html51/browsers.html#concept-cross-origin">origin</a> to avoid valid uses enabling subsequent malicious access and <em class="rfc2119" title="MUST">MUST</em> be per <a href="#browsing-profile">browsing profile</a>.
             </p>
             <div class="note">
-              <div class="note-title marker" aria-level="5" role="heading" id="h-note143"><span>Note</span></div>
+              <div class="note-title marker" aria-level="5" role="heading" id="h-note144"><span>Note</span></div>
               <p class="">The restriction of the APIs defined in this specification to secure contexts ensures that a <a href="#network-attacks">network attacker</a> cannot exploit permissions granted to an unauthenticated origin. See <a href="#persisted-consent-abuse">abuse of persisted consent</a>.
               </p>
             </div>
@@ -6874,7 +6741,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
         </dl>
 
         <div class="note">
-          <div class="note-title marker" aria-level="5" role="heading" id="h-note144"><span>Note</span></div>
+          <div class="note-title marker" aria-level="5" role="heading" id="h-note145"><span>Note</span></div>
           <p class="">While these suggestions prevent trivial use of the APIs defined in this specification for user tracking, they do not block it altogether. Within a single origin, a site can continue to track the user during a session, and can then pass all this information to a third party along with any identifying information (names, credit card numbers, addresses) obtained by the site. If a third party cooperates with multiple sites to obtain such information, and if identifiers are not
             <!-- Issue #101 may affect this text. --><a href="#per-origin-per-profile-identifiers">unique per origin and profile</a>, then a profile can still be created.
           </p>
@@ -6899,7 +6766,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
       <section id="mitigations-4" typeof="bibo:Chapter" resource="#mitigations-4" property="bibo:hasPart">
         <h4 id="h-mitigations-4" resource="#h-mitigations-4"><span property="xhv:role" resource="xhv:heading"><span class="secno">11.5.2 </span>Mitigations</span>
         </h4>
-        <p>Requirements mitigating these concerns are defined in <a href="#persistent-state-requirements" class="sec-ref"><span class="secno">8.1</span> <span class="sec-title">Persistent Data</span></a>.</p>
+        <p>Requirements mitigating these concerns are defined in <a href="#persistent-state-requirements" class="sec-ref"><span class="secno">8.3</span> <span class="sec-title">Persistent Data</span></a>.</p>
       </section>
     </section>
 
@@ -6932,7 +6799,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
       <section id="mitigations-5" typeof="bibo:Chapter" resource="#mitigations-5" property="bibo:hasPart">
         <h4 id="h-mitigations-5" resource="#h-mitigations-5"><span property="xhv:role" resource="xhv:heading"><span class="secno">11.6.2 </span>Mitigations</span>
         </h4>
-        <p>Recommendations mitigating these concerns are defined in <a href="#persistent-state-requirements" class="sec-ref"><span class="secno">8.1</span> <span class="sec-title">Persistent Data</span></a>.</p>
+        <p>Recommendations mitigating these concerns are defined in <a href="#persistent-state-requirements" class="sec-ref"><span class="secno">8.3</span> <span class="sec-title">Persistent Data</span></a>.</p>
       </section>
     </section>
 
@@ -7454,7 +7321,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
         </dd><dt id="bib-RFC7517">[RFC7517]</dt>
         <dd><a href="https://tools.ietf.org/html/rfc7517" property="dc:requires"><cite>JSON Web Key (JWK)</cite></a>. M. Jones. IETF. May 2015. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7517" property="dc:requires">https://tools.ietf.org/html/rfc7517</a>
         </dd><dt id="bib-WebIDL">[WebIDL]</dt>
-        <dd><a href="https://www.w3.org/TR/WebIDL-1/" property="dc:requires"><cite>Web IDL</cite></a>. Cameron McCormack; Boris Zbarsky; Tobie Langel. W3C. 15 December 2016. W3C Working Draft. URL: <a href="https://www.w3.org/TR/WebIDL-1/" property="dc:requires">https://www.w3.org/TR/WebIDL-1/</a>
+        <dd><a href="https://heycam.github.io/webidl/" property="dc:requires"><cite>Web IDL</cite></a>. Cameron McCormack; Boris Zbarsky; Tobie Langel. W3C. 15 December 2016. W3C Editor's Draft. URL: <a href="https://heycam.github.io/webidl/" property="dc:requires">https://heycam.github.io/webidl/</a>
         </dd>
       </dl>
     </section>
@@ -7479,7 +7346,9 @@ interface <span class="idlInterfaceID"><a data-lt="MediaEncryptedEvent" href="#d
         </dd><dt id="bib-SECURE-CONTEXTS">[SECURE-CONTEXTS]</dt>
         <dd><a href="https://www.w3.org/TR/secure-contexts/" property="dc:references"><cite>Secure Contexts</cite></a>. Mike West. W3C. 15 September 2016. W3C Candidate Recommendation. URL: <a href="https://www.w3.org/TR/secure-contexts/" property="dc:references">https://www.w3.org/TR/secure-contexts/</a>
         </dd><dt id="bib-WEBIDL">[WEBIDL]</dt>
-        <dd><a href="https://www.w3.org/TR/WebIDL-1/" property="dc:references"><cite>Web IDL</cite></a>. Cameron McCormack; Boris Zbarsky; Tobie Langel. W3C. 15 December 2016. W3C Working Draft. URL: <a href="https://www.w3.org/TR/WebIDL-1/" property="dc:references">https://www.w3.org/TR/WebIDL-1/</a>
+        <dd><a href="https://heycam.github.io/webidl/" property="dc:references"><cite>Web IDL</cite></a>. Cameron McCormack; Boris Zbarsky; Tobie Langel. W3C. 15 December 2016. W3C Editor's Draft. URL: <a href="https://heycam.github.io/webidl/" property="dc:references">https://heycam.github.io/webidl/</a>
+        </dd><dt id="bib-WEBIDL-LS">[WEBIDL-LS]</dt>
+        <dd><a href="https://heycam.github.io/webidl/" property="dc:references"><cite>Web IDL</cite></a>. Cameron McCormack; Boris Zbarsky; Tobie Langel. W3C. 15 December 2016. W3C Editor's Draft. URL: <a href="https://heycam.github.io/webidl/" property="dc:references">https://heycam.github.io/webidl/</a>
         </dd>
       </dl>
     </section>


### PR DESCRIPTION
This PR adds overview text on CDM constraints and relocates CDM messaging requirements to section **8. Implementation Requirements**.  These changes were discussed in issues 307 & 308.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/jdsmith3000/encrypted-media/cdm-constraints-definition-fixes.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/encrypted-media/2aa65a9...jdsmith3000:fba8986.html)