### PR TITLE
Fix #365: Do not allow operations after close() is called but before the session is actually closed

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -2355,11 +2355,13 @@ interface MediaKeyMessageEvent : Event {
           <p>The following steps are run:</p>
           <ol>
             <li><p>Let <var>session</var> be the associated <a>MediaKeySession</a> object.</p></li>
+            <li><p>Let <var>promise</var> be the <var>session</var>'s <a def-id="closed"></a> attribute.</p></li>
+            <!-- Avoid a race condition that could cause the algorithms below to be run multiple times. -->
+            <li><p>If <var>promise</var> is resolved, abort these steps.</p></li>
             <!-- Handle the case that this algorithm is reached by a path other than close(). In all cases, the value is set before the algorithms below are run. -->
-            <li><p>Set this <var>session</var>'s <var>closing or closed</var> value to true.</p></li>
+            <li><p>Set the <var>session</var>'s <var>closing or closed</var> value to true.</p></li>
             <li><p>Run the <a def-id="update-key-statuses-algorithm"></a> algorithm on the <var>session</var>, providing an empty sequence.</p></li>
             <li><p>Run the <a def-id="update-expiration-algorithm"></a> algorithm on the <var>session</var>, providing <code>NaN</code>.</p></li>
-            <li><p>Let <var>promise</var> be the <a def-id="closed"></a> attribute of the <var>session</var>.</p></li>
             <li><p>Resolve <var>promise</var>.</p></li>
           </ol>
         </section>

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -1580,8 +1580,7 @@
       <h2><a>MediaKeySession</a> Interface</h2>
       <p>The MediaKeySession object represents a <a href="#key-session">key session</a>.</p>
       <p>
-        A <a>MediaKeySession</a> object is <dfn id="media-key-session-closed">closed</dfn> if and only if the <a def-id="session-closed-algorithm"></a> algorithm has
-        been run.
+        A <a>MediaKeySession</a> object is <dfn id="media-key-session-closed">closed</dfn> if and only if the object's <a def-id="closed"></a> attribute has been resolved.
       </p>
       <p>
         The User Agent SHALL execute the <a def-id="monitor-cdm-algorithm"></a> algorithm continuously for each <a>MediaKeySession</a> object

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -1470,6 +1470,7 @@
                 <li><p>Let the <var>session type</var> value be <var>sessionType</var>.</p></li>
                 <li><p>Let the <var>uninitialized</var> value be true.</p></li>
                 <li><p>Let the <var>callable</var> value be false.</p></li>
+                <li><p>Let the <var>closed</var> value be false.</p></li>
                 <li><p>Let the <var>use distinctive identifier</var> value be this object's <var>use distinctive identifier</var> value.</p></li>
                 <li><p>Let the <var>cdm implementation</var> value be this object's <var>cdm implementation</var>.</p></li>
                 <li><p>Let the <var>cdm instance</var> value be this object's <var>cdm instance</var>.</p></li>
@@ -1659,7 +1660,7 @@
           
 
           <ol class="method-algorithm">
-            <li><p>If this object is <a def-id="media-key-session-closed"></a>, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
+            <li><p><li><p>If this object's <var>closed</var> value is true, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
             <li><p>If this object's <var>uninitialized</var> value is false, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
             <li><p>Let this object's <var>uninitialized</var> value be false.</p></li><!-- For simplicity and consistency, this object cannot be reused after any failure. -->
             <li><p>If <var>initDataType</var> is the empty string, return a promise rejected with a newly created <a def-id="TypeError"></a>.</p></li>
@@ -1756,7 +1757,7 @@
                   <ol>
                     <li><p>If any of the preceding steps failed, reject <var>promise</var> with <a def-id="new-domexception-named"></a> <a def-id="appropriate-error-name"></a>.</p></li>
                     <li><p>Set the <a def-id="sessionId"></a> attribute to <var>session id</var>.</p></li>
-                    <li><p>Let this object's <var>callable</var> value be true.</p></li>
+                    <li><p>Set this object's <var>callable</var> value to true.</p></li>
                     <li><p>Run the <a def-id="queue-message-algorithm"></a> algorithm on the <var>session</var>, providing <var>message type</var> and <var>message</var>.</p>
                     <li>
                       <p>Resolve <var>promise</var>.</p>
@@ -1778,7 +1779,7 @@
           
 
           <ol class="method-algorithm">
-            <li><p>If this object is <a def-id="media-key-session-closed"></a>, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
+            <li><p><li><p>If this object's <var>closed</var> value is true, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
             <li><p>If this object's <var>uninitialized</var> value is false, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
             <li><p>Let this object's <var>uninitialized</var> value be false.</p></li><!-- For simplicity and consistency, this object cannot be reused after any failure. -->
             <li><p>If <var>sessionId</var> is the empty string, return a promise rejected with a newly created <a def-id="TypeError"></a>.</p></li>
@@ -1825,7 +1826,7 @@
                   <ol>
                     <li><p>If any of the preceding steps failed, reject <var>promise</var> with a <a def-id="appropriate-error-name"></a>.</p></li>
                     <li><p>Set the <a def-id="sessionId"></a> attribute to <var>sanitized session ID</var>.</p></li>
-                    <li><p>Let this object's <var>callable</var> value be true.</p></li>
+                    <li><p>Set this object's <var>callable</var> value to true.</p></li>
                     <li>
                       <p>
                         If the loaded session contains information about any keys (there are <a href="#known-key">known keys</a>), run the <a def-id="update-key-statuses-algorithm"></a> algorithm on the <var>session</var>, providing each key's <a def-id="key-id"></a> along with the appropriate <a>MediaKeyStatus</a>.
@@ -1855,7 +1856,7 @@
           
 
           <ol class="method-algorithm">
-            <li><p>If this object is <a def-id="media-key-session-closed"></a>, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
+            <li><p><li><p>If this object's <var>closed</var> value is true, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
             <li><p>If this object's <var>callable</var> value is false, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
             <li><p>If <var>response</var> is an empty array, return a promise rejected with a newly created <a def-id="TypeError"></a>.</p></li>
             <li><p>Let <var>response copy</var> be a copy of the contents of the <var>response</var> parameter.</p></li>
@@ -1985,9 +1986,10 @@
           <p class="note">The returned promise is resolved when the request has been processed, and the <a def-id="closed"></a> attribute promise is resolved when the session is closed.</p>
 
           <ol class="method-algorithm">
-            <li><p>If this object is <a def-id="media-key-session-closed"></a>, return a resolved promise.</p></li>
+            <li><p><li><p>If this object's <var>closed</var> value is true, return a resolved promise.</p></li>
             <li><p>If this object's <var>callable</var> value is false, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
             <li><p>Let <var>promise</var> be a new promise.</p></li>
+            <li><p>Set this object's <var>closed</var> value to true.</p></li>
             <li><p>Run the following steps in parallel:</p>
               <ol>
                 <li><p>Let <var>cdm</var> be the CDM instance represented by this object's <var>cdm instance</var> value.</p></li>
@@ -2016,7 +2018,7 @@
           </p>
 
           <ol class="method-algorithm">
-            <li><p>If this object is <a def-id="media-key-session-closed"></a>, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
+            <li><p><li><p>If this object's <var>closed</var> value is true, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
             <li><p>If this object's <var>callable</var> value is false, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
             <li><p>Let <var>promise</var> be a new promise.</p></li>
             <li><p>Run the following steps in parallel:</p>
@@ -2354,6 +2356,8 @@ interface MediaKeyMessageEvent : Event {
           <p>The following steps are run:</p>
           <ol>
             <li><p>Let <var>session</var> be the associated <a>MediaKeySession</a> object.</p></li>
+            <!-- Handle the case that this algorithm is reached by a path other than close(). In all cases, the value is set before the algorithms below are run. -->
+            <li><p>Set this <var>session</var>'s <var>closed</var> value to true.</p></li>
             <li><p>Run the <a def-id="update-key-statuses-algorithm"></a> algorithm on the <var>session</var>, providing an empty sequence.</p></li>
             <li><p>Run the <a def-id="update-expiration-algorithm"></a> algorithm on the <var>session</var>, providing <code>NaN</code>.</p></li>
             <li><p>Let <var>promise</var> be the <a def-id="closed"></a> attribute of the <var>session</var>.</p></li>

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -1470,7 +1470,7 @@
                 <li><p>Let the <var>session type</var> value be <var>sessionType</var>.</p></li>
                 <li><p>Let the <var>uninitialized</var> value be true.</p></li>
                 <li><p>Let the <var>callable</var> value be false.</p></li>
-                <li><p>Let the <var>closed</var> value be false.</p></li>
+                <li><p>Let the <var>closing or closed</var> value be false.</p></li>
                 <li><p>Let the <var>use distinctive identifier</var> value be this object's <var>use distinctive identifier</var> value.</p></li>
                 <li><p>Let the <var>cdm implementation</var> value be this object's <var>cdm implementation</var>.</p></li>
                 <li><p>Let the <var>cdm instance</var> value be this object's <var>cdm instance</var>.</p></li>
@@ -1659,7 +1659,7 @@
           
 
           <ol class="method-algorithm">
-            <li><p><li><p>If this object's <var>closed</var> value is true, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
+            <li><p><li><p>If this object's <var>closing or closed</var> value is true, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
             <li><p>If this object's <var>uninitialized</var> value is false, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
             <li><p>Let this object's <var>uninitialized</var> value be false.</p></li><!-- For simplicity and consistency, this object cannot be reused after any failure. -->
             <li><p>If <var>initDataType</var> is the empty string, return a promise rejected with a newly created <a def-id="TypeError"></a>.</p></li>
@@ -1778,7 +1778,7 @@
           
 
           <ol class="method-algorithm">
-            <li><p><li><p>If this object's <var>closed</var> value is true, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
+            <li><p><li><p>If this object's <var>closing or closed</var> value is true, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
             <li><p>If this object's <var>uninitialized</var> value is false, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
             <li><p>Let this object's <var>uninitialized</var> value be false.</p></li><!-- For simplicity and consistency, this object cannot be reused after any failure. -->
             <li><p>If <var>sessionId</var> is the empty string, return a promise rejected with a newly created <a def-id="TypeError"></a>.</p></li>
@@ -1855,7 +1855,7 @@
           
 
           <ol class="method-algorithm">
-            <li><p><li><p>If this object's <var>closed</var> value is true, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
+            <li><p><li><p>If this object's <var>closing or closed</var> value is true, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
             <li><p>If this object's <var>callable</var> value is false, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
             <li><p>If <var>response</var> is an empty array, return a promise rejected with a newly created <a def-id="TypeError"></a>.</p></li>
             <li><p>Let <var>response copy</var> be a copy of the contents of the <var>response</var> parameter.</p></li>
@@ -1985,10 +1985,10 @@
           <p class="note">The returned promise is resolved when the request has been processed, and the <a def-id="closed"></a> attribute promise is resolved when the session is closed.</p>
 
           <ol class="method-algorithm">
-            <li><p><li><p>If this object's <var>closed</var> value is true, return a resolved promise.</p></li>
+            <li><p><li><p>If this object's <var>closing or closed</var> value is true, return a resolved promise.</p></li>
             <li><p>If this object's <var>callable</var> value is false, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
             <li><p>Let <var>promise</var> be a new promise.</p></li>
-            <li><p>Set this object's <var>closed</var> value to true.</p></li>
+            <li><p>Set this object's <var>closing or closed</var> value to true.</p></li>
             <li><p>Run the following steps in parallel:</p>
               <ol>
                 <li><p>Let <var>cdm</var> be the CDM instance represented by this object's <var>cdm instance</var> value.</p></li>
@@ -2017,7 +2017,7 @@
           </p>
 
           <ol class="method-algorithm">
-            <li><p><li><p>If this object's <var>closed</var> value is true, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
+            <li><p><li><p>If this object's <var>closing or closed</var> value is true, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
             <li><p>If this object's <var>callable</var> value is false, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
             <li><p>Let <var>promise</var> be a new promise.</p></li>
             <li><p>Run the following steps in parallel:</p>
@@ -2356,7 +2356,7 @@ interface MediaKeyMessageEvent : Event {
           <ol>
             <li><p>Let <var>session</var> be the associated <a>MediaKeySession</a> object.</p></li>
             <!-- Handle the case that this algorithm is reached by a path other than close(). In all cases, the value is set before the algorithms below are run. -->
-            <li><p>Set this <var>session</var>'s <var>closed</var> value to true.</p></li>
+            <li><p>Set this <var>session</var>'s <var>closing or closed</var> value to true.</p></li>
             <li><p>Run the <a def-id="update-key-statuses-algorithm"></a> algorithm on the <var>session</var>, providing an empty sequence.</p></li>
             <li><p>Run the <a def-id="update-expiration-algorithm"></a> algorithm on the <var>session</var>, providing <code>NaN</code>.</p></li>
             <li><p>Let <var>promise</var> be the <a def-id="closed"></a> attribute of the <var>session</var>.</p></li>


### PR DESCRIPTION
Introduces a new "closed" value and use it when determining whether to abort MediaKeySession algorithms.

Also, make media-key-session-closed depend on an explicit state.
Previously, this definition depended on whether an algorithm had been run, which is slightly ambiguous.