### PR TITLE
Workaround for several respec issues

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -629,7 +629,7 @@
       <p>The steps of an algorithm are always aborted when rejecting a promise.</p>
 
       <section>
-        <h3><a>Navigator</a> Extension: <code>requestMediaKeySystemAccess()</code></h3>
+        <h3><dfn>Navigator</dfn> Extension: <code>requestMediaKeySystemAccess()</code></h3>
 
         <div><pre class="idl">partial interface Navigator {
     [SecureContext] Promise&lt;MediaKeySystemAccess&gt; requestMediaKeySystemAccess (DOMString keySystem, sequence&lt;MediaKeySystemConfiguration&gt; supportedConfigurations);
@@ -1233,7 +1233,11 @@
     "required",
     "optional",
     "not-allowed"
-};</pre><table class="simple" data-dfn-for="MediaKeysRequirement" data-link-for="MediaKeysRequirement"><tbody><tr><th colspan="2">Enumeration description</th></tr><tr><td><dfn><code id="idl-def-MediaKeysRequirement.required">required</code></dfn></td><td>
+};</pre>
+<p>
+The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows:
+</p>
+<table class="simple" data-dfn-for="MediaKeysRequirement" data-link-for="MediaKeysRequirement"><tbody><tr><th colspan="2">Enumeration description</th></tr><tr><td><dfn><code id="idl-def-MediaKeysRequirement.required">required</code></dfn></td><td>
             <dl>
               <dt>When used in a call to <a def-id="requestMediaKeySystemAccess"></a></dt>
               <dd>The returned object MUST support this feature.</dd>
@@ -1264,7 +1268,11 @@
              MediaKeysRequirement                    distinctiveIdentifier = "optional";
              MediaKeysRequirement                    persistentState = "optional";
              sequence&lt;DOMString&gt;                     sessionTypes;
-};</pre><section><h2>Dictionary <a class="idlType">MediaKeySystemConfiguration</a> Members</h2><dl class="dictionary-members" data-dfn-for="MediaKeySystemConfiguration" data-link-for="MediaKeySystemConfiguration"><dt><dfn><code>label</code></dfn> of type <span class="idlMemberType"><a>DOMString</a></span>, defaulting to <code>""</code></dt><dd>
+};</pre>
+<p>
+  The dictionary <dfn>MediaKeySystemConfiguration</dfn> contains the following members:
+</p>
+  <dl class="dictionary-members" data-dfn-for="MediaKeySystemConfiguration" data-link-for="MediaKeySystemConfiguration"><dt><dfn><code>label</code></dfn> of type <span class="idlMemberType"><a>DOMString</a></span>, defaulting to <code>""</code></dt><dd>
             An optional label that will be preserved in the <a>MediaKeySystemConfiguration</a> returned from the <a def-id="getConfiguration"></a> method of <a>MediaKeySystemAccess</a>.
           </dd><dt><dfn><code>initDataTypes</code></dfn> of type <span class="idlMemberType">sequence&lt;<a>DOMString</a>&gt;</span>, defaulting to <code>[]</code></dt><dd>
             A list of supported <a def-id="initialization-data-type"></a> names.
@@ -1307,7 +1315,7 @@
       </section>
 
       <section>
-        <h3><a>MediaKeySystemMediaCapability</a> dictionary</h3>
+        <h3><dfn>MediaKeySystemMediaCapability</dfn> dictionary</h3>
         <div><pre class="idl">dictionary MediaKeySystemMediaCapability {
              DOMString contentType = "";
              DOMString robustness = "";
@@ -1340,7 +1348,7 @@
 
 
     <section>
-      <h2><a>MediaKeySystemAccess</a> Interface</h2>
+      <h2><dfn>MediaKeySystemAccess</dfn> Interface</h2>
       <p>The MediaKeySystemAccess object provides access to a <a def-id="keysystem"></a>.</p>
 
       <div><pre class="idl">[SecureContext] interface MediaKeySystemAccess {
@@ -1413,7 +1421,7 @@
 
 
     <section>
-      <h2><a>MediaKeys</a> Interface</h2>
+      <h2><dfn>MediaKeys</dfn> Interface</h2>
       <p>The MediaKeys object represents a set of keys that an associated HTMLMediaElement can use for decryption of <a def-id="media-data"></a> during playback.
         It also represents a <a def-id="cdm"></a> instance.
       </p>
@@ -1426,6 +1434,7 @@
     "temporary",
     "persistent-license"
 };</pre>
+   <p>The <dfn>MediaKeySessionType</dfn> enumeration is defined as follows:</p>
       <table class="simple" data-dfn-for="MediaKeySessionType" data-link-for="MediaKeySessionType"><tbody>
         <tr><th colspan="2">Enumeration description</th></tr>
         <tr><td><dfn><code id="idl-def-MediaKeySessionType.temporary">temporary</code></dfn></td><td>
@@ -1593,7 +1602,7 @@
 
 
     <section>
-      <h2><a>MediaKeySession</a> Interface</h2>
+      <h2><dfn>MediaKeySession</dfn> Interface</h2>
       <p>The MediaKeySession object represents a <a href="#key-session">key session</a>.</p>
       <p>
         A <a>MediaKeySession</a> object is <dfn id="media-key-session-closed">closed</dfn> if and only if the object's <a def-id="closed"></a> attribute has been resolved.
@@ -2113,7 +2122,7 @@
         <div><em>No parameters.</em></div><div><em>Return type: </em><code>Promise&lt;void&gt;</code></div></dd></dl></section></div>
 
       <section>
-        <h2><a>MediaKeyStatusMap</a> Interface</h2>
+        <h2><dfn>MediaKeyStatusMap</dfn> Interface</h2>
         <p>The MediaKeyStatusMap object is a read-only map of <a def-id="key-id">key IDs</a> to the current status of the associated key.</p>
         <p>A key's status is independent of whether the key is currently being used and of media data.</p>
         <p class="note">For example, if a key has output requirements that cannot currently be met, the key's status should be <a def-id="status-output-downscaled"></a> or <a def-id="status-output-restricted"></a>, as appropriate, regardless of whether that key has been or is currently needed to decrypt media data.</p>
@@ -2151,7 +2160,7 @@
             </dl>
             <p>
               This interface has <code>entries</code>, <code>keys</code>, <code>values</code>, <code>forEach</code> and <code>@@iterator</code> methods
-              brought by <code>iterable</code>.
+              brought by <dfn data-dfn-for="MediaKeyStatusMap" data-link-for="MediaKeyStatusMap">iterable</dfn> (see WebIDL, <a href='https://www.w3.org/TR/WebIDL-1/#idl-iterable'>3.2.7 Iterable declarations</a>).
             </p>
             <p>
               The value pairs to iterate over are a snapshot of the set of pairs formed from the <a def-id="key-id"></a> and
@@ -2172,7 +2181,10 @@
     "output-downscaled",
     "status-pending",
     "internal-error"
-};</pre><table class="simple" data-dfn-for="MediaKeyStatus" data-link-for="MediaKeyStatus"><tbody><tr><th colspan="2">Enumeration description</th></tr><tr><td><dfn><code id="idl-def-MediaKeyStatus.usable">usable</code></dfn></td><td>
+};</pre>
+<p>The <dfn>MediaKeyStatus</dfn> enumeration is defined as follows:
+</p>
+  <table class="simple" data-dfn-for="MediaKeyStatus" data-link-for="MediaKeyStatus"><tbody><tr><th colspan="2">Enumeration description</th></tr><tr><td><dfn><code id="idl-def-MediaKeyStatus.usable">usable</code></dfn></td><td>
             The CDM is certain the key is currently <a def-id="usable-for-decryption"></a>.<br>
             Keys that <em>may not</em> currently be <a def-id="usable-for-decryption"></a> MUST NOT have this status.
           </td></tr><tr><td><dfn><code id="idl-def-MediaKeyStatus.expired">expired</code></dfn></td><td>
@@ -2214,7 +2226,9 @@
     "license-renewal",
     "license-release",
     "individualization-request"
-};</pre><table class="simple" data-dfn-for="MediaKeyMessageType" data-link-for="MediaKeyMessageType"><tbody><tr><th colspan="2">Enumeration description</th></tr><tr><td><dfn><code id="idl-def-MediaKeyMessageType.license-request">license-request</code></dfn></td><td>The message contains a request for a new license.</td></tr><tr><td><dfn><code id="idl-def-MediaKeyMessageType.license-renewal">license-renewal</code></dfn></td><td>The message contains a request to renew an existing license.</td></tr><tr><td><dfn><code id="idl-def-MediaKeyMessageType.license-release">license-release</code></dfn></td><td>The message contains a <a def-id="record-of-license-destruction"></a>.</td></tr><tr><td><dfn><code id="idl-def-MediaKeyMessageType.individualization-request">individualization-request</code></dfn></td><td>
+};</pre>
+<p>The <dfn>MediaKeyMessageType</dfn> is defined as follows:</p>
+  <table class="simple" data-dfn-for="MediaKeyMessageType" data-link-for="MediaKeyMessageType"><tbody><tr><th colspan="2">Enumeration description</th></tr><tr><td><dfn><code id="idl-def-MediaKeyMessageType.license-request">license-request</code></dfn></td><td>The message contains a request for a new license.</td></tr><tr><td><dfn><code id="idl-def-MediaKeyMessageType.license-renewal">license-renewal</code></dfn></td><td>The message contains a request to renew an existing license.</td></tr><tr><td><dfn><code id="idl-def-MediaKeyMessageType.license-release">license-release</code></dfn></td><td>The message contains a <a def-id="record-of-license-destruction"></a>.</td></tr><tr><td><dfn><code id="idl-def-MediaKeyMessageType.individualization-request">individualization-request</code></dfn></td><td>
             The message contains a request for <a href="#app-assisted-individualization">App-Assisted Individualization</a> (or re-individualization).<br>
             As with all other messages, any identifiers in the message MUST be <a href="#per-origin-per-profile-identifiers">distinctive per origin and profile</a> and MUST NOT be <a def-id="distinctive-permanent-identifier-maybe-plural"></a>.
           </td></tr></tbody></table></div>
@@ -2239,7 +2253,7 @@ interface MediaKeyMessageEvent : Event {
           </dd></dl></section></div>
 
         <section>
-          <h4><a>MediaKeyMessageEventInit</a></h4>
+          <h4><dfn>MediaKeyMessageEventInit</dfn></h4>
           <div><pre class="idl">dictionary MediaKeyMessageEventInit : EventInit {
              required MediaKeyMessageType messageType;
              required ArrayBuffer         message;
@@ -2546,7 +2560,7 @@ interface MediaKeyMessageEvent : Event {
     </section>
 
     <section>
-      <h2><a>HTMLMediaElement</a> Extensions</h2>
+      <h2><dfn>HTMLMediaElement</dfn> Extensions</h2>
       
       <!-- Put all the monkey-patching here -->
       
@@ -2622,7 +2636,7 @@ interface MediaKeyMessageEvent : Event {
                                     attribute EventHandler onencrypted;
                                     attribute EventHandler onwaitingforkey;
     [SecureContext] Promise&lt;void&gt; setMediaKeys (MediaKeys? mediaKeys);
-};</pre><section><h2>Attributes</h2><dl class="attributes" data-dfn-for="HTMLMediaElement" data-link-for="HTMLMediaElement"><dt><!-- Restore when https://github.com/w3c/respec/issues/893 is fixed. <dfn> --><!-- Remove the id in <code> when https://github.com/w3c/respec/issues/893 is fixed. --><code id=dom-mediakeys>mediaKeys</code><!-- </dfn> --> of type <span class="idlAttrType"><!-- Restore when https://github.com/w3c/respec/issues/893 is fixed. <a> -->MediaKeys<!-- </a> --></span>, readonly       , nullable</dt><dd>
+};</pre><section><h2>Attributes</h2><dl class="attributes" data-dfn-for="HTMLMediaElement" data-link-for="HTMLMediaElement"><dt><dfn><code>mediaKeys</code></dfn> of type <span class="idlAttrType"><!-- Restore when https://github.com/w3c/respec/issues/893 is fixed. <a> -->MediaKeys<!-- </a> --></span>, readonly       , nullable</dt><dd>
           <p>The <!-- Restore when https://github.com/w3c/respec/issues/893 is fixed. <a> -->MediaKeys<!-- </a> --> being used when decrypting encrypted <a def-id="media-data"></a> for this media element.</p>
         </dd><dt><dfn><code>onencrypted</code></dfn> of type <span class="idlAttrType"><a>EventHandler</a></span></dt><dd>
           <p>Event handler for the <a def-id="encrypted"></a> event. It MUST be supported by all HTMLMediaElements as both a content attribute and an IDL attribute.</p>
@@ -2707,7 +2721,7 @@ interface MediaEncryptedEvent : Event {
           </dd></dl></section></div>
 
         <section>
-          <h4><a>MediaEncryptedEventInit</a></h4>
+          <h4><dfn>MediaEncryptedEventInit</dfn></h4>
           <div><pre class="idl">dictionary MediaEncryptedEventInit : EventInit {
              DOMString    initDataType = "";
              ArrayBuffer? initData = null;

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -705,7 +705,7 @@
           <section>
             <h5>Get Supported Configuration</h5>
             <p>Given a <a def-id="keysystems"></a> implementation <var>implementation</var>, <a>MediaKeySystemConfiguration</a> <var>candidate configuration</var>, and <var>origin</var>, this algorithm returns a supported configuration or <code>NotSupported</code> as appropriate.</p>
-            <p class="note">Unrecognized dictionary members in <var>candidate configuration</var> are ignored per [[WebIDL]] and will never reach this algorithm. Thus, they cannot be considered as part of the configuration.
+            <p class="note">Unrecognized dictionary members in <var>candidate configuration</var> are ignored per [[WEBIDL]] and will never reach this algorithm. Thus, they cannot be considered as part of the configuration.
             </p>
             <div class="note">
               <p>
@@ -885,7 +885,7 @@
               </li>
               <li><p>Follow the steps for the first matching condition from the following list:</p>
                 <dl class="switch">
-                  <dt>If the <a def-id="option-sessionTypes"></a> member is <a def-id="present-dictionary-member"></a> [[!WebIDL]] in <var>candidate configuration</var></dt>
+                  <dt>If the <a def-id="option-sessionTypes"></a> member is <a def-id="present-dictionary-member"></a> [[!WEBIDL]] in <var>candidate configuration</var></dt>
                   <dd>
                     <p>Let <var>session types</var> be <var>candidate configuration</var>'s <a def-id="option-sessionTypes"></a> member.</p>
                   </dd>
@@ -1301,13 +1301,13 @@ The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows:
             <p class="note">Applications intending to create non-<a def-id="temporary-session"></a> sessions, should set this member to <a def-id="requirement-required"></a> when calling <a def-id="requestMediaKeySystemAccess"></a>.</p>
           </dd><dt><dfn><code>sessionTypes</code></dfn> of type <span class="idlMemberType">sequence&lt;<a>DOMString</a>&gt;</span></dt><dd>
             A list of <a>MediaKeySessionType</a>s that must be supported. All values must be supported.
-            <p>If this member is <a def-id="not-present-dictionary-member"></a> [[!WebIDL]] when the dictionary is passed to <a def-id="requestMediaKeySystemAccess"></a>, the dictionary will be treated as if this member is set to <code>[ <a def-id="temporary-session"></a> ]</code>.</p>
-          </dd></dl></section></div>
+            <p>If this member is <a def-id="not-present-dictionary-member"></a> [[!WEBIDL]] when the dictionary is passed to <a def-id="requestMediaKeySystemAccess"></a>, the dictionary will be treated as if this member is set to <code>[ <a def-id="temporary-session"></a> ]</code>.</p>
+          </dd></dl>
 
         <p>Implementations SHOULD NOT add members to the this dictionary.
           Should member(s) be added, they MUST be of type <a>MediaKeysRequirement</a>, and it is RECOMMENDED that they have default values of <a def-id="requirement-optional"></a> to support the widest range of application and client combinations.
         </p>
-        <p class="note">Dictionary members not recognized by a user agent implementation are ignored per [[WebIDL]] and will not be considered in the <a def-id="requestMediaKeySystemAccess"></a> algorithm.
+        <p class="note">Dictionary members not recognized by a user agent implementation are ignored per [[WEBIDL]] and will not be considered in the <a def-id="requestMediaKeySystemAccess"></a> algorithm.
           Should an application use non-standard dictionary member(s), it MUST NOT rely on user agent implementations rejecting a configuration that includes such dictionary members.
         </p>
         <p>This dictionary MUST NOT be used to pass state or data to the CDM.</p>
@@ -1427,7 +1427,7 @@ The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows:
       </p>
       <p>A <a>MediaKeys</a> object may be destroyed by the user agent when it is no longer accessible</p>
       <p class="note">For example, when there are no script references and no attached media element.</p>
-      <p>For methods that return a promise, all errors are reported asynchronously by rejecting the returned Promise. This includes [[!WebIDL]] type mapping errors.</p>
+      <p>For methods that return a promise, all errors are reported asynchronously by rejecting the returned Promise. This includes [[!WEBIDL]] type mapping errors.</p>
       <p>The steps of an algorithm are always aborted when rejecting a promise.</p>
 
       <div><pre class="idl">enum MediaKeySessionType {
@@ -1474,10 +1474,10 @@ The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows:
           
 
           <ol class="method-algorithm">
-            <li><p>If this object's <var>supported session types</var> value does not contain <var>sessionType</var>, <a def-id="throw"></a> [[!WebIDL]] a <a def-id="NotSupportedError"></a>.</p>
+            <li><p>If this object's <var>supported session types</var> value does not contain <var>sessionType</var>, <a def-id="throw"></a> [[!WEBIDL]] a <a def-id="NotSupportedError"></a>.</p>
               <p class="note"><var>sessionType</var> values for which the <a def-id="is-persistent-session-type-algorithm"></a> algorithm returns <code>true</code> will fail if this object's <var>persistent state allowed</var> value is <code>false</code>.</p>
             </li>
-            <li><p>If the implementation does not support <a>MediaKeySession</a> operations in the current state, <a def-id="throw"></a> [[!WebIDL]] an <a def-id="InvalidStateError"></a>.</p> 
+            <li><p>If the implementation does not support <a>MediaKeySession</a> operations in the current state, <a def-id="throw"></a> [[!WEBIDL]] an <a def-id="InvalidStateError"></a>.</p> 
               <p class="note">Some implementations are unable to execute <a>MediaKeySession</a> algorithms until this <a>MediaKeys</a> object is associated with a media element using <a def-id="setMediaKeys"></a>.
               This step enables applications to detect this uncommon behavior before attempting to perform such operations.
               </p>
@@ -1633,7 +1633,7 @@ The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows:
         Applications that want to ensure a session is closed before taking some other action SHOULD call <a def-id="close"></a> and wait for the returned promise to be resolved.
       </p>
 
-      <p>For methods that return a promise, all errors are reported asynchronously by rejecting the returned Promise. This includes [[!WebIDL]] type mapping errors.</p>
+      <p>For methods that return a promise, all errors are reported asynchronously by rejecting the returned Promise. This includes [[!WEBIDL]] type mapping errors.</p>
       <p>The following steps of an algorithm are always aborted when rejecting a promise.</p>
 
       <div><pre class="idl">[SecureContext] interface MediaKeySession : EventTarget {
@@ -2482,8 +2482,8 @@ interface MediaKeyMessageEvent : Event {
       </section>
       <section id="exceptions">
         <h3>Exceptions</h3>
-        <p id="error-names">The methods report errors by rejecting the returned promise with a <a def-id="simple-exception">simple exception</a> [[!WebIDL]] or a <a def-id="domexception"></a>.
-        The following <a def-id="simple-exception">simple exceptions</a> and <a def-id="domexception-names">DOMException names</a> from [[!WebIDL]] are used in the algorithms.
+        <p id="error-names">The methods report errors by rejecting the returned promise with a <a def-id="simple-exception">simple exception</a> [[!WEBIDL]] or a <a def-id="domexception"></a>.
+        The following <a def-id="simple-exception">simple exceptions</a> and <a def-id="domexception-names">DOMException names</a> from [[!WEBIDL]] are used in the algorithms.
         Causes specified specified in the algorithms are listed alongside each name, though these names MAY be used for other reasons as well.
         </p>
 
@@ -2628,7 +2628,7 @@ interface MediaKeyMessageEvent : Event {
         </li>
       </ul>
 
-      <p>For methods that return a promise, all errors are reported asynchronously by rejecting the returned Promise. This includes [[!WebIDL]] type mapping errors.</p>
+      <p>For methods that return a promise, all errors are reported asynchronously by rejecting the returned Promise. This includes [[!WEBIDL]] type mapping errors.</p>
       <p>The steps of an algorithm are always aborted when rejecting a promise.</p>
 
       <div><pre class="idl">partial interface HTMLMediaElement {

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -1304,7 +1304,7 @@ The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows:
             <p>If this member is <a def-id="not-present-dictionary-member"></a> [[!WEBIDL]] when the dictionary is passed to <a def-id="requestMediaKeySystemAccess"></a>, the dictionary will be treated as if this member is set to <code>[ <a def-id="temporary-session"></a> ]</code>.</p>
           </dd></dl>
 
-        <p>Implementations SHOULD NOT add members to the this dictionary.
+        <p>Implementations SHOULD NOT add members to this dictionary.
           Should member(s) be added, they MUST be of type <a>MediaKeysRequirement</a>, and it is RECOMMENDED that they have default values of <a def-id="requirement-optional"></a> to support the widest range of application and client combinations.
         </p>
         <p class="note">Dictionary members not recognized by a user agent implementation are ignored per [[WEBIDL]] and will not be considered in the <a def-id="requestMediaKeySystemAccess"></a> algorithm.

--- a/encrypted-media.js
+++ b/encrypted-media.js
@@ -439,6 +439,32 @@
    $("a[def-id]").each(function () {
        $(this).addClass('externalDFN');
      });
+     preElementMediaProcessor();
+  }
+
+  // The JS highlighter in respec removes all element before doing the highlight,
+  // so we need to replace the a element before the highlighter get there
+  function preElementMediaProcessor() {
+    var doc = document;
+    $("pre.example a[def-id]").each(function () {
+      var $ant = $(this);
+      var def_id = $ant.attr('def-id');
+      var info = definitionInfo[def_id];
+      if (info) {
+        var text = info.link_text;
+
+        var element_text = this.innerHTML;
+        if (element_text) {
+          text = element_text;
+        }
+        var span = doc.createElement("span");
+        span.innerHTML = text;
+        this.parentNode.replaceChild(span, this);
+
+      } else {
+        console.log("Found def-id '" + def_id + "' but it does not correspond to anything");
+      }
+    });
   }
 
   function encryptedMediaPostProcessor() {

--- a/encrypted-media.js
+++ b/encrypted-media.js
@@ -569,7 +569,7 @@
     // THIS MUST BE LAST.
     // Check for duplicate ids.
     $("[id]").each(function () {
-      var elements = $("[id='" + this.id + "']");
+      var elements = $('[id="' + this.id.replace(/"/g,'\\"') + '"]');
       if (elements.length != 1) {
         console.error("id '" + this.id + "' is used for " + elements.length + " elements. This instance: ", this);
       }


### PR DESCRIPTION
Address #416 
  adds dfn elements to prevent the warning. This does change several from idf-def- to dom- but I think that's fine
  Changed WebIDL to WEBIDL (to follow respec)

Address #428 
  the JS highlighter doesn't tolerate anchor elements so they get removed before the postProcess has the time to do its job (in particular adding the innerHTML). Added processing during the preprocessor to go around the limitation. It's no longer possible to preserve the links in the example unfortunately,
