### PR TITLE
Change the wording for setServerCertificate() to reject promise on error

### DIFF
--- a/encrypted-media-pr.html
+++ b/encrypted-media-pr.html
@@ -3535,7 +3535,7 @@ interface <span class="idlInterfaceID">MediaKeys</span> {
                     <p>Use this object's <var>cdm instance</var> to process <var>certificate</var>.</p>
                   </li>
                   <li>
-                    <p>If the preceding step failed, reject <var>promise</var> with a new <code><a href="https://www.w3.org/TR/WebIDL-1/#dfn-DOMException">DOMException</a></code> whose name is the appropriate <a href="#error-names">error name</a>.</p>
+                    <p>If the preceding step failed, resolve <var>promise</var> with a new <code><a href="https://www.w3.org/TR/WebIDL-1/#dfn-DOMException">DOMException</a></code> whose name is the appropriate <a href="#error-names">error name</a>.</p>
                   </li>
                   <li>
                     <p>Resolve <var>promise</var> with <code>true</code>.</p>

--- a/encrypted-media-pr.html
+++ b/encrypted-media-pr.html
@@ -3535,7 +3535,7 @@ interface <span class="idlInterfaceID">MediaKeys</span> {
                     <p>Use this object's <var>cdm instance</var> to process <var>certificate</var>.</p>
                   </li>
                   <li>
-                    <p>If the preceding step failed, resolve <var>promise</var> with a new <code><a href="https://www.w3.org/TR/WebIDL-1/#dfn-DOMException">DOMException</a></code> whose name is the appropriate <a href="#error-names">error name</a>.</p>
+                    <p>If the preceding step failed, reject <var>promise</var> with a new <code><a href="https://www.w3.org/TR/WebIDL-1/#dfn-DOMException">DOMException</a></code> whose name is the appropriate <a href="#error-names">error name</a>.</p>
                   </li>
                   <li>
                     <p>Resolve <var>promise</var> with <code>true</code>.</p>

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -1530,7 +1530,7 @@ The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows:
                   </p>
                 </li>
                 <li><p>Use this object's <var>cdm instance</var> to process <var>sanitized certificate</var>.</p></li>
-                <li><p>If the preceding step failed, resolve <var>promise</var> with <a def-id="new-domexception-named"></a> <a def-id="appropriate-error-name"></a>.</p></li>
+                <li><p>If the preceding step failed, reject <var>promise</var> with <a def-id="new-domexception-named"></a> <a def-id="appropriate-error-name"></a>.</p></li>
                 <li><p>Resolve <var>promise</var> with <code>true</code>.</p></li>
               </ol>
             </li>

--- a/index.html
+++ b/index.html
@@ -1772,7 +1772,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
             </dd>
         </dl>
         <p class="copyright">
-            <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2017
+            <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2018
 
             <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
             <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,

--- a/index.html
+++ b/index.html
@@ -4040,7 +4040,7 @@ interface <span class="idlInterfaceID"><a data-lt="MediaKeys" href="#dom-mediake
                                         <p>Use this object's <var>cdm instance</var> to process <var>sanitized certificate</var>.</p>
                                     </li>
                                     <li>
-                                        <p>If the preceding step failed, resolve <var>promise</var> with a new <code><a href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> whose name is the appropriate <a href="#error-names">error name</a>.</p>
+                                        <p>If the preceding step failed, reject <var>promise</var> with a new <code><a href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> whose name is the appropriate <a href="#error-names">error name</a>.</p>
                                     </li>
                                     <li>
                                         <p>Resolve <var>promise</var> with <code>true</code>.</p>

--- a/index.html
+++ b/index.html
@@ -1723,8 +1723,8 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                     "publisher": "W3C"
                 }
             },
-            "publishISODate": "2017-09-14T00:00:00.000Z",
-            "generatedSubtitle": "Editor's Draft 14 September 2017"
+            "publishISODate": "2018-01-02T00:00:00.000Z",
+            "generatedSubtitle": "Editor's Draft 02 January 2018"
         }
     </script>
     <meta name="generator" content="ReSpec 16.2.2">
@@ -1738,7 +1738,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         </p>
         <p></p>
         <h1 class="title p-name" id="title">Encrypted Media Extensions</h1>
-        <h2 id="w3c-editor's-draft-14-september-2017"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time class="dt-published" datetime="2017-09-14">14 September 2017</time></h2>
+        <h2 id="w3c-editor-s-draft-02-january-2018"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time class="dt-published" datetime="2018-01-02">02 January 2018</time></h2>
         <dl>
             <dt>This version:</dt>
             <dd><a class="u-url" href="https://w3c.github.io/encrypted-media/">https://w3c.github.io/encrypted-media/</a></dd>


### PR DESCRIPTION
This matches the wording used for other failures noted in the spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jrummell-chromium/encrypted-media/pull/435.html" title="Last updated on Jan 3, 2018, 1:32 AM GMT (a7e887b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/435/1f8b463...jrummell-chromium:a7e887b.html" title="Last updated on Jan 3, 2018, 1:32 AM GMT (a7e887b)">Diff</a>