### PR TITLE
Wait for key: run the algorithm when value is false

### DIFF
--- a/index.html
+++ b/index.html
@@ -4397,7 +4397,7 @@ interface <span class="idlInterfaceID"><a data-no-default="" data-link-for="" da
           <div class="note"><div role="heading" class="note-title marker" id="h-note-94" aria-level="3"><span>Note</span></div><p class="">The above step provides flexibility for user agent implementations to perform decryption at any time after an encrypted block is encountered before it is needed for playback.</p></div>
         </li>
         <li>
-          <p>When one of the following occurs while the <var>decryption blocked waiting for key</var> value is <code>true</code>, the user agent <em class="rfc2119" title="SHALL">SHALL</em> run the <a href="#wait-for-key">Wait for Key</a> algorithm.</p>
+          <p>When one of the following occurs while the <var>decryption blocked waiting for key</var> value is <code>false</code>, the user agent <em class="rfc2119" title="SHALL">SHALL</em> run the <a href="#wait-for-key">Wait for Key</a> algorithm.</p>
           <ul>
             <li><p>The user agent cannot advance the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#current-position">current playback position</a> in the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#direction-of-playback">direction of playback</a>.</p></li>
             <li>


### PR DESCRIPTION
The second step of the algorithm bails out if the value is true but in
the HTMLMediaElement extensions it is required to run the algorithm
when its value is true, which is useless. Therefore the common sense
requires that it is run when the value is false.