### PR TITLE
Add automated formatting of the respec HTML

### DIFF
--- a/.jsbeautifyrc
+++ b/.jsbeautifyrc
@@ -1,0 +1,12 @@
+{
+  "indent_size": 2,
+  "end_with_newline": true,
+  "wrap_line_length": 100,
+  "preserve_newlines": false,
+  "inline": [
+    "a"
+  ],
+  "js": {
+    "end_with_newline": false
+  }
+}

--- a/eme.css
+++ b/eme.css
@@ -15,8 +15,3 @@ dl.switch > dt:before { content: '\21AA'; padding: 0 0.5em 0 0; display: inline-
 p + * > li, dd li { margin: 1em 0; }
 
 @media screen { code :link, code :visited { color: inherit; } }
-
-/* fix bug entry form styling */
-body > form { padding: 4px; border: 1px solid red; background-color: white; }
-
-#bug-assist-form { position: fixed; width: 10em; top: 5em; right: 1em; font-family: Tahoma, sans-serif; font-size: 11px; opacity: 0.8; text-align: right; }

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -1,146 +1,125 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <title>Encrypted Media Extensions</title>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
-    
-    <script src="encrypted-media.js" class="remove"></script>
-    <script class="remove">
-      // The W3C diff service does not fix up relative URLs.
-      // To enable diffs that look better, use the files from the latest version of the spec trunk.
-      // Changes to the affected JS, CSS, and image files will NOT be reflected!
-      var diffServiceHostName = "services.w3.org";
-      var diffServicePathName = "/htmldiff";
-      var replacementOriginAndPath = "https://w3c.github.io/encrypted-media/"
-      var isDiffService = window.location.hostname == diffServiceHostName && window.location.pathname == diffServicePathName;
 
-      // The JS replacement file must be loaded here.
-      // Other resources will be replaced at the end of the file.
-      if (isDiffService) {
-        var source = replacementOriginAndPath + "encrypted-media.js"
-        var xhr = new XMLHttpRequest();
-        xhr.open("GET", source, false);
-        xhr.send();
-        var replacement = document.createElement("script");
-        replacement.type = "text/javascript";
-        replacement.className = "remove";
-        replacement.text = xhr.responseText;
-        $("head").append(replacement);
-        console.log("Rewrote URL as " + source);
-      };
-    </script>
-    <script class="remove">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <title>Encrypted Media Extensions</title>
+  <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
+  <script src="encrypted-media.js" class="remove"></script>
+  <script class="remove">
+    // The W3C diff service does not fix up relative URLs.
+    // To enable diffs that look better, use the files from the latest version of the spec trunk.
+    // Changes to the affected JS, CSS, and image files will NOT be reflected!
+    var diffServiceHostNameAndPath = "services.w3.org/htmldiff";
+    var locationHostNameAndPath = location.hostname + location.pathname;
+    var replacementOriginAndPath = "https://w3c.github.io/encrypted-media/"
+    var isDiffService = locationHostNameAndPath == diffServiceHostNameAndPath;
+    // The JS replacement file must be loaded here.
+    // Other resources will be replaced at the end of the file.
+    if (isDiffService) {
+      var source = replacementOriginAndPath + "encrypted-media.js"
+      var xhr = new XMLHttpRequest();
+      xhr.open("GET", source, false);
+      xhr.send();
+      var replacement = document.createElement("script");
+      replacement.type = "text/javascript";
+      replacement.className = "remove";
+      replacement.text = xhr.responseText;
+      $("head").append(replacement);
+      console.log("Rewrote URL as " + source);
+    };
+  </script>
+  <script class="remove">
     var respecConfig = {
       // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
       specStatus: "ED",
       implementationReportURI: "https://w3c.github.io/test-results/encrypted-media/all.html",
-
       // the specification's short name, as in https://www.w3.org/TR/short-name/
       shortName: "encrypted-media",
       license: "w3c-software-doc",
-
       useExperimentalStyles: true,
-
       // if there a publicly available Editor's Draft, this is the link
       edDraftURI: "https://w3c.github.io/encrypted-media/",
-
       // editors, add as many as you like
       // only "name" is required
-      editors: [
-        { name: "Joey Parrish", w3cid: "105371",
-          company: "Google Inc.", companyURL: "https://www.google.com/" },
-        { name: "Greg Freedman",
-          company: "Netflix Inc.", companyURL: "https://www.netflix.com/" },
-      ],
-
-      formerEditors: [
-        { name: "Mark Watson", note: "Until September 2019", w3cid: "46379",
-          company: "Netflix Inc.", companyURL: "https://www.netflix.com/" },
-        { name: "David Dorwin", note: "Until September 2017", w3cid: "52505",
-          company: "Google Inc.", companyURL: "https://www.google.com/" },
-        { name: "Jerry Smith", note: "Until September 2017", w3cid: "60176",
-          company: "Microsoft Corporation", companyURL: "https://www.microsoft.com/" },
-        { name: "Adrian Bateman", note: "Until May 2014", w3cid: "42763",
-          company: "Microsoft Corporation", companyURL: "https://www.microsoft.com/" },
-      ],
-
+      editors: [{
+        name: "Joey Parrish",
+        w3cid: "105371",
+        company: "Google Inc.",
+        companyURL: "https://www.google.com/"
+      }, {
+        name: "Greg Freedman",
+        company: "Netflix Inc.",
+        companyURL: "https://www.netflix.com/"
+      }],
+      formerEditors: [{
+        name: "Mark Watson",
+        note: "Until September 2019",
+        w3cid: "46379",
+        company: "Netflix Inc.",
+        companyURL: "https://www.netflix.com/"
+      }, {
+        name: "David Dorwin",
+        note: "Until September 2017",
+        w3cid: "52505",
+        company: "Google Inc.",
+        companyURL: "https://www.google.com/"
+      }, {
+        name: "Jerry Smith",
+        note: "Until September 2017",
+        w3cid: "60176",
+        company: "Microsoft Corporation",
+        companyURL: "https://www.microsoft.com/"
+      }, {
+        name: "Adrian Bateman",
+        note: "Until May 2014",
+        w3cid: "42763",
+        company: "Microsoft Corporation",
+        companyURL: "https://www.microsoft.com/"
+      }],
       emeDefGroupName: "encrypted-media",
-      emeContributors: [
-        "Aaron Colwell",
-        "Alex Russell",
-        "Anne van Kesteren",
-        "Bob Lund",
-        "Boris Zbarsky",
-        "Chris Pearce",
-        "David Singer",
-        "Domenic Denicola",
-        "Frank Galligan",
-        "Glenn Adams",
-        "Henri Sivonen",
-        "Jer Noble",
-        "Joe Steele",
-        "Joey Parrish",
-        "John Simmons",
-        "Mark Vickers",
-        "Pavel Pergamenshchik",
-        "Philip Jägenstedt",
-        "Pierre Lemieux",
-        "Robert O'Callahan",
-        "Ryan Sleevi",
-        "Steve Heffernan",
-        "Steven Robertson",
-        "Theresa O'Connor",
-        "Thomás Inskip",
-        "Travis Leithead",
+      emeContributors: ["Aaron Colwell", "Alex Russell", "Anne van Kesteren", "Bob Lund",
+        "Boris Zbarsky", "Chris Pearce", "David Singer", "Domenic Denicola", "Frank Galligan",
+        "Glenn Adams", "Henri Sivonen", "Jer Noble", "Joe Steele", "Joey Parrish",
+        "John Simmons", "Mark Vickers", "Pavel Pergamenshchik", "Philip Jägenstedt",
+        "Pierre Lemieux", "Robert O'Callahan", "Ryan Sleevi", "Steve Heffernan",
+        "Steven Robertson", "Theresa O'Connor", "Thomás Inskip", "Travis Leithead",
         "Xiaohan Wang",
       ],
-
       otherLinks: [{
         key: "Repository",
         data: [{
           value: "We are on GitHub.",
           href: "https://github.com/w3c/encrypted-media/",
-         }, {
+        }, {
           value: "File a bug.",
           href: "https://github.com/w3c/encrypted-media/issues",
-         }, {
+        }, {
           value: "Commit history.",
           href: "https://github.com/w3c/encrypted-media/commits/gh-pages/encrypted-media-respec.html",
-         }],
+        }],
       }],
-
       emeDefGroupName: "encrypted-media",
       emeUnusedGroupNameExcludeList: ["eme-references-from-registry"],
-
       // name of the WG
       wg: "Media Working Group",
-
       // URI of the public WG page
       wgURI: "https://www.w3.org/media-wg/",
-
       // name (without the @w3c.org) of the public mailing to which comments are due
       wgPublicList: "public-media-wg",
-
       // URI of the patent status for this WG, for Rec-track documents
       // !!!! IMPORTANT !!!!
       // This is important for Rec-track documents, do not copy a patent URI from a random
       // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
       // Team Contact.
       wgPatentURI: "https://www.w3.org/2004/01/pp-impl/115198/status",
-
       noIDLIn: true,
-
       scheme: "https",
-
-      preProcess: [ encryptedMediaPreProcessor ],
-
+      preProcess: [encryptedMediaPreProcessor],
       // Empty definitions for objects declared in the document are here to
       // prevent error messages from being displayed for references to these objects.
       definitionMap: {},
-
-      postProcess: [ encryptedMediaPostProcessor ],
-
+      postProcess: [encryptedMediaPostProcessor],
       localBiblio: {
         "CENC": {
           title: "ISO/IEC 23001-7:2016, Information technology — MPEG systems technologies — Part 7: Common encryption in ISO Base Media File Format files",
@@ -150,681 +129,988 @@
         },
       },
     };
-    </script>
-    <!-- script to register bugs -->
-    <!-- Disabled unless/until it supports GitHub issues.
-    <script src="https://w3c.github.io/webcomponents/assets/scripts/bug-assist.js"></script>
-    <meta name="bug.product" content="HTML WG"/>
-    <meta name="bug.component" content="Encrypted Media Extensions"/>
-    -->
+  </script>
+  <link rel="stylesheet" href="eme.css" />
+</head>
 
-    <link rel="stylesheet" href="eme.css"/>
-  </head>
-  <body data-cite="HTML">
-
-    <section id="abstract">
-      <p>This proposal extends <a def-id="htmlmediaelement"></a> [[HTML]] providing APIs to control playback of encrypted content.</p>
-      <p>The API supports use cases ranging from simple clear key decryption to high value video (given an appropriate user agent implementation).
-      License/key exchange is controlled by the application, facilitating the development of robust playback applications supporting a range of content decryption and protection technologies.</p>
-      <p>This specification does not define a content protection or Digital Rights Management system. Rather, it defines a common API that may be used to discover, select and interact with
-      such systems as well as with simpler content encryption systems. Implementation of Digital Rights Management is not required for compliance with this specification: only the
-      Clear Key system is required to be implemented as a common baseline.</p>
-      <p>The common API supports a simple set of content encryption capabilities, leaving application functions such as authentication and authorization to page authors. This is achieved by
-      requiring content protection system-specific messaging to be mediated by the page rather than assuming out-of-band communication between the encryption system and a license
-      or other server.</p>
-    </section>
-
-    <section id="sotd">
-    </section>
-
-    <section id="introduction" class="informative">
-      <h2>Introduction</h2>
-      <p>
-        This specification enables script to select content protection mechanisms, control license/key exchange, and
-        execute custom license management algorithms.
-        It supports a wide range of use cases without requiring client-side modifications in each user agent for each use case.
-        This enables content providers to develop a single application solution for all devices.
-      </p>
-      <p>
-        Supported content is encrypted per container-specific "common encryption" specifications, enabling use across key systems.
-        Supported content has an unencrypted container, enabling metadata to be provided to the application and maintaining compatibility with other <a def-id="htmlmediaelement"></a> features.
-      </p>
-      <p>
-        Implementers should pay attention to the mitigations for the security and privacy threats and concerns described in this specification.
-        In particular, the specification requirements for security and privacy cannot be met without knowledge of the security and privacy properties of the <a def-id="keysystem"></a> and its implementation(s).
-        <a href="#implementation-requirements"></a> contains security and privacy provisions related to the integration and use of underlying <a def-id="keysystem"></a> implementations.
-        <a href="#security"></a> focuses on external threats, such as input data or network attacks.
-        <a href="#privacy"></a> focuses on the handling of user-specific information and providing users with adequate control over their own privacy.
-      </p>
-      <p class="note">
-        While this specification is independent of the source of the media data, authors should be aware that many implementations only support decrypting media data provided via Media Source Extensions [[MEDIA-SOURCE]].
-      </p>
-      <p>
-        A generic stack implemented using the API is shown below.
-        This diagram shows an example flow; other combinations of API calls and events are possible.
-      </p>
-      <img src="stack_overview.svg" alt="A generic stack implemented using the proposed APIs" height="700"></img>
-    </section>
-
-    <section id="definitions">
-      <h2>Definitions</h2>
-
-      <dl>
-        <dt id="cdm">Content Decryption Module (CDM)</dt>
-        <dd>
-          <p>Content Decryption Module (CDM) is the client component that provides the functionality, including decryption, for one or more <a def-id="keysystems"></a>.</p>
-          <p class="note">
-            Implementations may or may not separate the implementations of CDMs or treat them as separate from the user agent.
-            This is transparent to the API and application.
-          </p>
-        </dd>
-
-        <dt id="key-system">Key System</dt>
-        <dd>
-          <p>A Key System is a generic term for a decryption mechanism and/or content protection provider.
-          Key System strings provide unique identification of a Key System.
-          They are used by the user agent to select a <a def-id="cdm"></a> and identify the source of a key-related event.
-          User agents MUST support the <a href="#common-key-systems">Common Key Systems</a>.
-          User agents MAY also provide additional CDMs with corresponding Key System strings.
-          </p>
-
-          <p>A Key System string is always a reverse domain name.
-          Key System strings are compared using case-sensitive matching. It is RECOMMENDED that CDMs use simple lower-case ASCII key system strings.</p>
-          <p class="note">For example, "com.example.somesystem".</p>
-
-          <p class="note">
-          Within a given system ("somesystem" in the example), subsystems may be defined as determined by the key system provider.
-          For example, "com.example.somesystem.1" and "com.example.somesystem.1_5".
-          Key System providers should keep in mind that these will be used for comparison and discovery, so they should be easy to compare and the structure should remain reasonably simple.
-          </p>
-        </dd>
-
-        <dt id="key-session">Key Session</dt>
-        <dd>
-          <p>A Key Session, or simply Session, provides a context for message exchange with the <a def-id="cdm"></a> as a result of which key(s) are made available to the CDM.
-          Sessions are embodied as <a>MediaKeySession</a> objects.
-          Each Key session is associated with a single instance of <a def-id="initialization-data"></a> provided in the <a def-id="generateRequest"></a> call.
-          </p>
-          <p>Each Key Session is associated with a single <a>MediaKeys</a> object, and only media element(s) associated with that <a>MediaKeys</a> object may access key(s) associated with the session.
-          Other <a>MediaKeys</a> objects, CDM instances, and media elements MUST NOT access the key session or use its key(s).
-          Key sessions and the keys they contain are no longer <a def-id="usable-for-decryption"></a> once the session has been closed, including when the <a>MediaKeySession</a> object is destroyed.
-          </p>
-          <p>
-            All license(s) and key(s) associated with a Key Session which have not been explicitly stored MUST be destroyed when the Key Session is closed.
-          </p>
-          <p><a def-id="key-id">Key IDs</a> MUST be unique within a session.</p>
-        </dd>
-
-        <dt id="session-id">Session ID</dt>
-        <dd>
-          <p>A Session ID is a unique string identifier generated by the <a def-id="cdm"></a> that can be used by the application to identify <a>MediaKeySession</a> objects.</p>
-
-          <p>A new Session ID is generated each time the user agent and CDM successfully create a new session.</p>
-
-          <p>Each Session ID SHALL be unique within the browsing context in which it was created.
-            For session types for which the <a def-id="is-persistent-session-type-algorithm"></a> algorithm returns <code>true</code>, Session IDs MUST be unique within the <a def-id="origin"></a> over time, including across browsing sessions.
-          </p>
-
-          <p class="note">The underlying content protection protocol does not necessarily need to support Session IDs.</p>
-        </dd>
-
-        <dt id="decryption-key">Key</dt>
-        <dd>
-          <p>Unless otherwise stated, key refers to a decryption key that can be used to decrypt blocks within <a def-id="media-data"></a>.
-          Each such key is uniquely identified by a <a def-id="key-id"></a>.
-          A key is associated with the <a href="#key-session">session</a> used to provide it to the <a def-id="cdm"></a>. (The same key may be present in multiple sessions.)
-          Such keys MUST only be provided to the CDM via an <a def-id="update"></a> call. (They may later be loaded by <a def-id="load"></a> as part of the stored session data.)
-          </p>
-
-          <p class="note">Authors SHOULD encrypt each set of stream(s) that requires enforcement of a meaningfully different policy with a distinct key (and key ID).
-            For example, if policies may differ between two video resolutions, stream(s) containing one resolution should not be encrypted with the key used to encrypt stream(s) containing the other resolution.
-            When encrypted, audio streams SHOULD NOT use the same key as any video stream.
-            This is the only way to ensure enforcement and compatibility across clients.
-          </p>
-        </dd>
-
-        <dt id="usable-for-decryption">Usable For Decryption</dt>
-        <dd>
-          <p>A key is considered usable for decryption if the CDM is certain the key is currently usable to decrypt one or more blocks of <a def-id="media-data"></a>.</p>
-          <p class="note">For example, a key is not usable for decryption if its license has expired.  Even if its license has not expired, a key is not usable for decryption if other conditions (e.g., output protection) for its use are not currently satisfied.</p>
-        </dd>
-
-        <dt id="decryption-key-id">Key ID</dt>
-        <dd>
-          <p>A <a href="#decryption-key">key</a> is associated with a key ID that is a sequence of octets and which uniquely identifies the key.
-          The container specifies the ID of the key that can decrypt a block or set of blocks within the <a def-id="media-data"></a>.
-          <a def-id="initialization-data"></a> MAY contain key ID(s) to identify the keys that are needed to decrypt the media data.
-          However, there is no requirement that Initialization Data contain any or all key IDs used in the <a def-id="media-data"></a> or <a def-id="media-resource"></a>.
-          <a href="#license">Licenses</a> provided to the <a def-id="cdm"></a> associate each key with a key ID so the CDM can select the appropriate key when decrypting an encrypted block of media data.
-          </p>
-        </dd>
-
-        <dt id="known-key">Known Key</dt>
-        <dd>
-          <p>A key is considered to be known to a session if the <a def-id="cdm"></a>'s implementation of the session contains any information - specifically the <a def-id="key-id"></a> - about it, regardless of whether the actual <a href="#decryption-key">key</a> is usable or its value is known.
-            Known keys are exposed via the <a def-id="keyStatuses"></a> attribute.
-          </p>
-
-          <p>Keys are considered known even after they become unusable, such as due to <a def-id="expiration-time">expiration</a> or if they are removed but a <a def-id="record-of-license-destruction"></a> or <a def-id="record-of-key-usage"></a> is available.
-            Keys only become unknown when they are explicitly removed from a session and any license release message is acknowledged.
-          </p>
-
-          <p class="note">For example, a key could become unknown if an <a def-id="update"></a> call provides a new license that does not include the key and includes instructions to replace the license(s) that previously contained the key.</p>
-        </dd>
-
-        <dt id="license">License</dt>
-        <dd>
-          <p>A license is key system-specific state information that includes one or more <a href="#decryption-key">key(s)</a> - each associated with a <a def-id="key-id"></a> - and potentially other information about key usage.</p>
-        </dd>
-
-        <dt id="initialization-data">Initialization Data</dt>
-        <dd>
-          <p class="note">
-          <a def-id="keysystems"></a> usually require a block of initialization data containing information about the stream to be decrypted before they can construct a license request message.
-          This block could be a simple key or content ID or a more complex structure containing such information.
-          It SHOULD always allow unique identification of the <a href="#decryption-key">key(s)</a> needed to decrypt the content.
-          This initialization information MAY be obtained in some application-specific way or provided with the <a def-id="media-data"></a>.
-          </p>
-
-          <p>
-          Initialization Data is a generic term for container-specific data that is used by a <a def-id="cdm"></a> to generate a license request.
-          </p>
-
-          <p>
-          The format of the initialization data depends upon the type of container, and containers MAY support more than one format
-          of initialization data. The <dfn id="initialization-data-type">Initialization Data Type</dfn> is a string that indicates the
-          format of the accompanying Initialization Data. Initialization Data Type strings are always matched case-sensitively. It is
-          RECOMMENDED that Initialization Data Type strings are lower-case ASCII strings.
-          </p>
-
-          <p>
-          The Encrypted Media Extensions Stream Format and Initialization Data Format Registry [[EME-INITDATA-REGISTRY]]
-          provides the mapping from <a def-id="initialization-data-type"></a> string to the specification for each format.
-          </p>
-
-          <p>
-          When the user agent encounters Initialization Data in the <a def-id="media-data"></a>, it provides that Initialization Data to the application in the <a def-id="encrypted-event-initdata-attribute"></a> attribute of the <a def-id="encrypted"></a> event.
-          The user agent MUST NOT store the Initialization Data or use its <em>content</em> at the time it is encountered.
-          The application provides Initialization Data to the CDM via <a def-id="generateRequest"></a>.
-          The user agent MUST NOT provide Initialization Data to the CDM by other means.
-          </p>
-
-          <p>Initialization Data MUST be a fixed value for a given set of stream(s) or <a def-id="media-data"></a>.
-            It MUST only contain information related to the keys required to play a given set of stream(s) or <a def-id="media-data"></a>.
-            It MUST NOT contain application data, client-specific data, user-specific data, or executable code.
-          </p>
-
-          <p>Initialization Data SHOULD NOT contain Key System-specific data or values.
-            Implementations MUST support the common formats defined in [[EME-INITDATA-REGISTRY]] for each <a def-id="initialization-data-type"></a> they support.
-          </p>
-          <p class="note">
-            Use of proprietary formats/contents is discouraged, and supporting or using <em>only</em> proprietary formats is strongly discouraged.
-            Proprietary formats should only be used with pre-existing content or on pre-existing client devices that do not support the common formats.
-          </p>
-        </dd>
-
-        <dt>Associable Values</dt>
-        <dd>
-          <p>
-            Two or more identifiers or other values are said to be <dfn id="associable">associable</dfn> if they are identical <em>or</em> it is possible - with a reasonable amount of time and effort - to correlate or associate them.
-            Otherwise, the values are <dfn id="non-associable">non-associable</dfn>.
-          </p>
-          <div class="note">
-            <p>For example, values created in the following ways are <a def-id="associable"></a>:</p>
-            <ul>
-              <li><p>Using a trivially-reversible hash function.</p></li>
-              <li><p>Sharing a prefix or other subset</p></li>
-              <li><p>Replacing random value N with N+10</p></li>
-              <li><p>XORing the origin with a fixed value (because it is trivially reversible)</p></li>
-            </ul>
-            <p>In contrast, two values that are completely unrelated or cryptographically distinct, such as via a cryptographically strong non-reversible hash function, are <a def-id="non-associable"></a>.</p>
-          </div>
-          <p>Two or more identifiers or other values are said to be <dfn id="associable-by-entity">associable by an entity</dfn> if it is possible - with a reasonable amount of time and effort - for the referenced entity or set of entities to correlate or associate them without participation of additional entity(ies).
-            Otherwise, the values are <dfn id="non-associable-by-entity">non-associable by an entity</dfn>.
-          </p>
-          <p>Two or more identifiers or other values are said to be <dfn id="non-associable-by-application">non-associable by the application</dfn> if they are <a href="#non-associable-by-entity">non-associable by an entity</a>
-            where the entity is set that includes the application, all other applications, and other entities such as servers that they use or with which they communicate.
-            Otherwise, the values would be considered <dfn id="associable-by-application">associable by the application</dfn>, which is forbidden.
-          </p>
-        </dd>
-
-        <dt id="distinctive-value">Distinctive Value</dt>
-        <dd>
-          <p>
-            A Distinctive Value is a value, piece of data, implication of the possession of a piece of data, or an observable behavior or timing that is <em>not</em> shared across a large population of users or client devices.
-            A Distinctive Value may be in memory or persisted.
-          </p>
-          <div class="note">
-            <p>Examples of Distinctive Values include but are not limited to:</p>
-            <ul>
-              <li><p><a def-id="distinctive-identifiers"></a></p></li>
-              <li><p><a def-id="distinctive-permanent-identifiers"></a></p></li>
-              <li><p>Other identifiers</p></li>
-              <li><p><a def-id="session-id">Session IDs</a></p></li>
-              <li><p><a href="#license">Licenses</a></p></li>
-              <li><p>Other session data</p></li>
-            </ul>
-            </div>
-            <p class="note">While a Distinctive Value is typically unique to a user or client device, a value does not need to be strictly unique to be distinctive.
-              For example, a value shared among a small number of users could still be distinctive.
-            </p>
-        </dd>
-
-        <dt>Permanent Identifiers</dt>
-        <dd>
-          <p>
-            A <dfn id="permanent-identifier">Permanent Identifier</dfn> is a value, piece of data, implication of the possession of a piece of data, or an observable behavior or timing that is indelible in some way or otherwise non-trivial for the user to remove, reset, or change.
-            This, includes but is not limited to:
-          </p>
+<body data-cite="HTML">
+  <section id="abstract">
+    <p>This proposal extends <a def-id="htmlmediaelement"></a> [[HTML]] providing APIs to control
+      playback of encrypted content.</p>
+    <p>The API supports use cases ranging from simple clear key decryption to high value video
+      (given an appropriate user agent implementation). License/key exchange is controlled by the
+      application, facilitating the development of robust playback applications supporting a range
+      of content decryption and protection technologies.</p>
+    <p>This specification does not define a content protection or Digital Rights Management system.
+      Rather, it defines a common API that may be used to discover, select and interact with such
+      systems as well as with simpler content encryption systems. Implementation of Digital Rights
+      Management is not required for compliance with this specification: only the Clear Key system
+      is required to be implemented as a common baseline.</p>
+    <p>The common API supports a simple set of content encryption capabilities, leaving application
+      functions such as authentication and authorization to page authors. This is achieved by
+      requiring content protection system-specific messaging to be mediated by the page rather than
+      assuming out-of-band communication between the encryption system and a license or other
+      server.</p>
+  </section>
+  <section id="sotd">
+  </section>
+  <section id="introduction" class="informative">
+    <h2>Introduction</h2>
+    <p> This specification enables script to select content protection mechanisms, control
+      license/key exchange, and execute custom license management algorithms. It supports a wide
+      range of use cases without requiring client-side modifications in each user agent for each use
+      case. This enables content providers to develop a single application solution for all devices.
+    </p>
+    <p> Supported content is encrypted per container-specific "common encryption" specifications,
+      enabling use across key systems. Supported content has an unencrypted container, enabling
+      metadata to be provided to the application and maintaining compatibility with other <a
+        def-id="htmlmediaelement"></a> features. </p>
+    <p> Implementers should pay attention to the mitigations for the security and privacy threats
+      and concerns described in this specification. In particular, the specification requirements
+      for security and privacy cannot be met without knowledge of the security and privacy
+      properties of the <a def-id="keysystem"></a> and its implementation(s). <a
+        href="#implementation-requirements"></a> contains security and privacy provisions related to
+      the integration and use of underlying <a def-id="keysystem"></a> implementations. <a
+        href="#security"></a> focuses on external threats, such as input data or network attacks. <a
+        href="#privacy"></a> focuses on the handling of user-specific information and providing
+      users with adequate control over their own privacy. </p>
+    <p class="note"> While this specification is independent of the source of the media data,
+      authors should be aware that many implementations only support decrypting media data provided
+      via Media Source Extensions [[MEDIA-SOURCE]]. </p>
+    <p> A generic stack implemented using the API is shown below. This diagram shows an example
+      flow; other combinations of API calls and events are possible. </p>
+    <img src="stack_overview.svg" alt="A generic stack implemented using the proposed APIs"
+      height="700">
+    </img>
+  </section>
+  <section id="definitions">
+    <h2>Definitions</h2>
+    <dl>
+      <dt id="cdm">Content Decryption Module (CDM)</dt>
+      <dd>
+        <p>Content Decryption Module (CDM) is the client component that provides the functionality,
+          including decryption, for one or more <a def-id="keysystems"></a>.</p>
+        <p class="note"> Implementations may or may not separate the implementations of CDMs or
+          treat them as separate from the user agent. This is transparent to the API and
+          application. </p>
+      </dd>
+      <dt id="key-system">Key System</dt>
+      <dd>
+        <p>A Key System is a generic term for a decryption mechanism and/or content protection
+          provider. Key System strings provide unique identification of a Key System. They are used
+          by the user agent to select a <a def-id="cdm"></a> and identify the source of a
+          key-related event. User agents MUST support the <a href="#common-key-systems">Common Key
+            Systems</a>. User agents MAY also provide additional CDMs with corresponding Key System
+          strings. </p>
+        <p>A Key System string is always a reverse domain name. Key System strings are compared
+          using case-sensitive matching. It is RECOMMENDED that CDMs use simple lower-case ASCII key
+          system strings.</p>
+        <p class="note">For example, "com.example.somesystem".</p>
+        <p class="note"> Within a given system ("somesystem" in the example), subsystems may be
+          defined as determined by the key system provider. For example, "com.example.somesystem.1"
+          and "com.example.somesystem.1_5". Key System providers should keep in mind that these will
+          be used for comparison and discovery, so they should be easy to compare and the structure
+          should remain reasonably simple. </p>
+      </dd>
+      <dt id="key-session">Key Session</dt>
+      <dd>
+        <p>A Key Session, or simply Session, provides a context for message exchange with the <a
+            def-id="cdm"></a> as a result of which key(s) are made available to the CDM. Sessions
+          are embodied as <a>MediaKeySession</a> objects. Each Key session is associated with a
+          single instance of <a def-id="initialization-data"></a> provided in the <a
+            def-id="generateRequest"></a> call. </p>
+        <p>Each Key Session is associated with a single <a>MediaKeys</a> object, and only media
+          element(s) associated with that <a>MediaKeys</a> object may access key(s) associated with
+          the session. Other <a>MediaKeys</a> objects, CDM instances, and media elements MUST NOT
+          access the key session or use its key(s). Key sessions and the keys they contain are no
+          longer <a def-id="usable-for-decryption"></a> once the session has been closed, including
+          when the <a>MediaKeySession</a> object is destroyed. </p>
+        <p> All license(s) and key(s) associated with a Key Session which have not been explicitly
+          stored MUST be destroyed when the Key Session is closed. </p>
+        <p><a def-id="key-id">Key IDs</a> MUST be unique within a session.</p>
+      </dd>
+      <dt id="session-id">Session ID</dt>
+      <dd>
+        <p>A Session ID is a unique string identifier generated by the <a def-id="cdm"></a> that can
+          be used by the application to identify <a>MediaKeySession</a> objects.</p>
+        <p>A new Session ID is generated each time the user agent and CDM successfully create a new
+          session.</p>
+        <p>Each Session ID SHALL be unique within the browsing context in which it was created. For
+          session types for which the <a def-id="is-persistent-session-type-algorithm"></a>
+          algorithm returns <code>true</code>, Session IDs MUST be unique within the <a
+            def-id="origin"></a> over time, including across browsing sessions. </p>
+        <p class="note">The underlying content protection protocol does not necessarily need to
+          support Session IDs.</p>
+      </dd>
+      <dt id="decryption-key">Key</dt>
+      <dd>
+        <p>Unless otherwise stated, key refers to a decryption key that can be used to decrypt
+          blocks within <a def-id="media-data"></a>. Each such key is uniquely identified by a <a
+            def-id="key-id"></a>. A key is associated with the <a href="#key-session">session</a>
+          used to provide it to the <a def-id="cdm"></a>. (The same key may be present in multiple
+          sessions.) Such keys MUST only be provided to the CDM via an <a def-id="update"></a> call.
+          (They may later be loaded by <a def-id="load"></a> as part of the stored session data.)
+        </p>
+        <p class="note">Authors SHOULD encrypt each set of stream(s) that requires enforcement of a
+          meaningfully different policy with a distinct key (and key ID). For example, if policies
+          may differ between two video resolutions, stream(s) containing one resolution should not
+          be encrypted with the key used to encrypt stream(s) containing the other resolution. When
+          encrypted, audio streams SHOULD NOT use the same key as any video stream. This is the only
+          way to ensure enforcement and compatibility across clients. </p>
+      </dd>
+      <dt id="usable-for-decryption">Usable For Decryption</dt>
+      <dd>
+        <p>A key is considered usable for decryption if the CDM is certain the key is currently
+          usable to decrypt one or more blocks of <a def-id="media-data"></a>.</p>
+        <p class="note">For example, a key is not usable for decryption if its license has expired.
+          Even if its license has not expired, a key is not usable for decryption if other
+          conditions (e.g., output protection) for its use are not currently satisfied.</p>
+      </dd>
+      <dt id="decryption-key-id">Key ID</dt>
+      <dd>
+        <p>A <a href="#decryption-key">key</a> is associated with a key ID that is a sequence of
+          octets and which uniquely identifies the key. The container specifies the ID of the key
+          that can decrypt a block or set of blocks within the <a def-id="media-data"></a>. <a
+            def-id="initialization-data"></a> MAY contain key ID(s) to identify the keys that are
+          needed to decrypt the media data. However, there is no requirement that Initialization
+          Data contain any or all key IDs used in the <a def-id="media-data"></a> or <a
+            def-id="media-resource"></a>. <a href="#license">Licenses</a> provided to the <a
+            def-id="cdm"></a> associate each key with a key ID so the CDM can select the appropriate
+          key when decrypting an encrypted block of media data. </p>
+      </dd>
+      <dt id="known-key">Known Key</dt>
+      <dd>
+        <p>A key is considered to be known to a session if the <a def-id="cdm"></a>'s implementation
+          of the session contains any information - specifically the <a def-id="key-id"></a> - about
+          it, regardless of whether the actual <a href="#decryption-key">key</a> is usable or its
+          value is known. Known keys are exposed via the <a def-id="keyStatuses"></a> attribute.
+        </p>
+        <p>Keys are considered known even after they become unusable, such as due to <a
+            def-id="expiration-time">expiration</a> or if they are removed but a <a
+            def-id="record-of-license-destruction"></a> or <a def-id="record-of-key-usage"></a> is
+          available. Keys only become unknown when they are explicitly removed from a session and
+          any license release message is acknowledged. </p>
+        <p class="note">For example, a key could become unknown if an <a def-id="update"></a> call
+          provides a new license that does not include the key and includes instructions to replace
+          the license(s) that previously contained the key.</p>
+      </dd>
+      <dt id="license">License</dt>
+      <dd>
+        <p>A license is key system-specific state information that includes one or more <a
+            href="#decryption-key">key(s)</a> - each associated with a <a def-id="key-id"></a> - and
+          potentially other information about key usage.</p>
+      </dd>
+      <dt id="initialization-data">Initialization Data</dt>
+      <dd>
+        <p class="note">
+          <a def-id="keysystems"></a> usually require a block of initialization data containing
+          information about the stream to be decrypted before they can construct a license request
+          message. This block could be a simple key or content ID or a more complex structure
+          containing such information. It SHOULD always allow unique identification of the <a
+            href="#decryption-key">key(s)</a> needed to decrypt the content. This initialization
+          information MAY be obtained in some application-specific way or provided with the <a
+            def-id="media-data"></a>. </p>
+        <p> Initialization Data is a generic term for container-specific data that is used by a <a
+            def-id="cdm"></a> to generate a license request. </p>
+        <p> The format of the initialization data depends upon the type of container, and containers
+          MAY support more than one format of initialization data. The <dfn
+            id="initialization-data-type">Initialization Data Type</dfn> is a string that indicates
+          the format of the accompanying Initialization Data. Initialization Data Type strings are
+          always matched case-sensitively. It is RECOMMENDED that Initialization Data Type strings
+          are lower-case ASCII strings. </p>
+        <p> The Encrypted Media Extensions Stream Format and Initialization Data Format Registry
+          [[EME-INITDATA-REGISTRY]] provides the mapping from <a
+            def-id="initialization-data-type"></a> string to the specification for each format. </p>
+        <p> When the user agent encounters Initialization Data in the <a def-id="media-data"></a>,
+          it provides that Initialization Data to the application in the <a
+            def-id="encrypted-event-initdata-attribute"></a> attribute of the <a
+            def-id="encrypted"></a> event. The user agent MUST NOT store the Initialization Data or
+          use its <em>content</em> at the time it is encountered. The application provides
+          Initialization Data to the CDM via <a def-id="generateRequest"></a>. The user agent MUST
+          NOT provide Initialization Data to the CDM by other means. </p>
+        <p>Initialization Data MUST be a fixed value for a given set of stream(s) or <a
+            def-id="media-data"></a>. It MUST only contain information related to the keys required
+          to play a given set of stream(s) or <a def-id="media-data"></a>. It MUST NOT contain
+          application data, client-specific data, user-specific data, or executable code. </p>
+        <p>Initialization Data SHOULD NOT contain Key System-specific data or values.
+          Implementations MUST support the common formats defined in [[EME-INITDATA-REGISTRY]] for
+          each <a def-id="initialization-data-type"></a> they support. </p>
+        <p class="note"> Use of proprietary formats/contents is discouraged, and supporting or using
+          <em>only</em> proprietary formats is strongly discouraged. Proprietary formats should only
+          be used with pre-existing content or on pre-existing client devices that do not support
+          the common formats. </p>
+      </dd>
+      <dt>Associable Values</dt>
+      <dd>
+        <p> Two or more identifiers or other values are said to be <dfn id="associable">associable
+          </dfn> if they are identical <em>or</em> it is possible - with a reasonable amount of time
+          and effort - to correlate or associate them. Otherwise, the values are <dfn
+            id="non-associable">non-associable</dfn>. </p>
+        <div class="note">
+          <p>For example, values created in the following ways are <a def-id="associable"></a>:</p>
           <ul>
-            <li><p>A hardware or hardware-based identifier</p></li>
-            <li><p>A value provisioned in the hardware device in the factory</p></li>
-            <li><p>A value associated with or derived from the operating system installation instance</p></li>
-            <li><p>A value associated with or derived from the user agent installation instance</p></li>
-            <li><p>A value associated with or derived from the <a def-id="cdm"></a> or other software component</p></li>
-            <li><p>A value in a configuration file or similar semi-permanent data, even if generated on the client</p></li>
-            <li><p>Client or other user account values</p></li>
+            <li>
+              <p>Using a trivially-reversible hash function.</p>
+            </li>
+            <li>
+              <p>Sharing a prefix or other subset</p>
+            </li>
+            <li>
+              <p>Replacing random value N with N+10</p>
+            </li>
+            <li>
+              <p>XORing the origin with a fixed value (because it is trivially reversible)</p>
+            </li>
           </ul>
-          
-          <p>
-            A <dfn id="distinctive-permanent-identifier">Distinctive Permanent Identifier</dfn> is a <a href="#permanent-identifier">Permanent Identifier</a> that is <a href="#distinctive-value">distinctive</a>.
-          </p>
-          <p>
-            When exposed outside the client, Distinctive Permanent Identifiers and values derived from or otherwise related to them MUST be <a href="#encrypt-identifiers">encrypted</a>.
-            Distinctive Permanent Identifiers MUST NOT ever be exposed to the application, even in encrypted form.
-          </p>
-          <p class="note">While a Distinctive Permanent Identifier is typically unique to a user or client device, a Distinctive Permanent Identifier does not need to be strictly unique to be distinctive.
-            For example, a Distinctive Permanent Identifier shared among a small number of users could still be distinctive.
-          </p>
-          <p class="note">
-            A Distinctive Permanent Identifier is <em>not</em> a <a def-id="distinctive-identifier"></a> because it is not derived or generated (within the scope of this specification).
-          </p>
-          <p class="note">
-            <a def-id="option-distinctiveIdentifier"></a> controls whether Distinctive Permanent Identifiers may be used.
-            Specifically, Distinctive Permanent Identifiers may only be used when the value of the <a def-id="option-distinctiveIdentifier"></a> member of the <a>MediaKeySystemAccess</a> used to create the <a>MediaKeys</a> object is <a def-id="requirement-required"></a>.
-          </p>
-        </dd>
-
-        <dt id="distinctive-identifier">Distinctive Identifier</dt>
-        <dd>
-          <div class="note">
-            <p>
-              A Distinctive Identifier is a value, including in opaque or encrypted form, for which it is possible for any entity external to the client to correlate or associate values beyond what a user may expect on the web platform (e.g., cookies and other site data).
-              For example, values that are <a href="#associable-by-entity">associable by an entity other than the application</a> across
-              a) <a def-id="origin">origins</a>,
-              b) <a def-id="browsing-profile">browsing profiles</a>,
-              or c) browsing sessions even after the user has attempted to protect his or her privacy by clearing browsing data
-              or values for which it is not easy for a user to break such association.
-              In particular, a value is a Distinctive Identifier if it is possible for a <a href="#associable-by-entity">central server, such as an individualization server, to associate</a> values across origins, such as because the <a href="#individualization">individualization</a> requests contained a common value, or because values provided in individualization requests are <a href="#associable-by-entity">associable by such server</a> even after attempts to clear browsing data. 
-              Possible causes of this include use of <a def-id="distinctive-permanent-identifier-maybe-plural"></a> in the individualization process.
-            </p>
-            <p>
-              Distinctive Identifiers exposed to the application, even in encrypted form, MUST adhere to the <a href="#identifier-requirements">identifier requirements</a>,
-              including being <a href="#encrypt-identifiers">encrypted</a>, <a href="#per-origin-per-profile-identifiers">unique per origin and profile</a>, and <a href="#allow-identifiers-cleared">clearable</a>.
-            </p>
-            <p>
-              While the instantiation or use of a Distinctive Identifier is triggered by the application's use of the APIs defined in this specification, the identifier need not be provided to the application to trigger conditions related to Distinctive Identifiers.
-              (The <a def-id="distinctive-permanent-identifier-maybe-plural"></a> MUST NOT ever be provided to the application, even in opaque or encrypted form.) 
-            </p>
-          </div>
-          <p class="note">
-            <a def-id="option-distinctiveIdentifier"></a> controls whether Distinctive Identifiers may be used.
-            Specifically, Distinctive Identifiers may only be used when the value of the <a def-id="option-distinctiveIdentifier"></a> member of the <a>MediaKeySystemAccess</a> used to create the <a>MediaKeys</a> object is <a def-id="requirement-required"></a>.
-          </p>
-          <p>A Distinctive Identifier is a value, piece of data, implication of the possession of a piece of data, or an observable behavior or timing for which all of the following criteria hold:</p>
+          <p>In contrast, two values that are completely unrelated or cryptographically distinct,
+            such as via a cryptographically strong non-reversible hash function, are <a
+              def-id="non-associable"></a>.</p>
+        </div>
+        <p>Two or more identifiers or other values are said to be <dfn id="associable-by-entity">
+            associable by an entity</dfn> if it is possible - with a reasonable amount of time and
+          effort - for the referenced entity or set of entities to correlate or associate them
+          without participation of additional entity(ies). Otherwise, the values are <dfn
+            id="non-associable-by-entity">non-associable by an entity</dfn>. </p>
+        <p>Two or more identifiers or other values are said to be <dfn
+            id="non-associable-by-application">non-associable by the application</dfn> if they are
+          <a href="#non-associable-by-entity">non-associable by an entity</a> where the entity is
+          set that includes the application, all other applications, and other entities such as
+          servers that they use or with which they communicate. Otherwise, the values would be
+          considered <dfn id="associable-by-application">associable by the application</dfn>, which
+          is forbidden. </p>
+      </dd>
+      <dt id="distinctive-value">Distinctive Value</dt>
+      <dd>
+        <p> A Distinctive Value is a value, piece of data, implication of the possession of a piece
+          of data, or an observable behavior or timing that is <em>not</em> shared across a large
+          population of users or client devices. A Distinctive Value may be in memory or persisted.
+        </p>
+        <div class="note">
+          <p>Examples of Distinctive Values include but are not limited to:</p>
           <ul>
             <li>
-              <p>It is <a href="#distinctive-value">distinctive</a>.</p>
-              <p class="note">While a Distinctive Identifier is typically unique to a user or client device, an identifier does not need to be strictly unique to be distinctive.
-                For example, an identifier shared among a small number of users could still be distinctive.
-              </p>
+              <p><a def-id="distinctive-identifiers"></a></p>
             </li>
             <li>
-              <p>It, information about it, or values derived from or otherwise related to it are exposed, even in encrypted form, outside the client.
-                This includes but is not limited to providing it to the application and/or license, <a href="#individualization">individualization</a>, or other server.
-              </p>
+              <p><a def-id="distinctive-permanent-identifiers"></a></p>
             </li>
-            <li><p>It has one or more the following properties:</p>
+            <li>
+              <p>Other identifiers</p>
+            </li>
+            <li>
+              <p><a def-id="session-id">Session IDs</a></p>
+            </li>
+            <li>
+              <p><a href="#license">Licenses</a></p>
+            </li>
+            <li>
+              <p>Other session data</p>
+            </li>
+          </ul>
+        </div>
+        <p class="note">While a Distinctive Value is typically unique to a user or client device, a
+          value does not need to be strictly unique to be distinctive. For example, a value shared
+          among a small number of users could still be distinctive. </p>
+      </dd>
+      <dt>Permanent Identifiers</dt>
+      <dd>
+        <p> A <dfn id="permanent-identifier">Permanent Identifier</dfn> is a value, piece of data,
+          implication of the possession of a piece of data, or an observable behavior or timing that
+          is indelible in some way or otherwise non-trivial for the user to remove, reset, or
+          change. This, includes but is not limited to: </p>
+        <ul>
+          <li>
+            <p>A hardware or hardware-based identifier</p>
+          </li>
+          <li>
+            <p>A value provisioned in the hardware device in the factory</p>
+          </li>
+          <li>
+            <p>A value associated with or derived from the operating system installation instance
+            </p>
+          </li>
+          <li>
+            <p>A value associated with or derived from the user agent installation instance</p>
+          </li>
+          <li>
+            <p>A value associated with or derived from the <a def-id="cdm"></a> or other software
+              component</p>
+          </li>
+          <li>
+            <p>A value in a configuration file or similar semi-permanent data, even if generated on
+              the client</p>
+          </li>
+          <li>
+            <p>Client or other user account values</p>
+          </li>
+        </ul>
+        <p> A <dfn id="distinctive-permanent-identifier">Distinctive Permanent Identifier</dfn> is a
+          <a href="#permanent-identifier">Permanent Identifier</a> that is <a
+            href="#distinctive-value">distinctive</a>. </p>
+        <p> When exposed outside the client, Distinctive Permanent Identifiers and values derived
+          from or otherwise related to them MUST be <a href="#encrypt-identifiers">encrypted</a>.
+          Distinctive Permanent Identifiers MUST NOT ever be exposed to the application, even in
+          encrypted form. </p>
+        <p class="note">While a Distinctive Permanent Identifier is typically unique to a user or
+          client device, a Distinctive Permanent Identifier does not need to be strictly unique to
+          be distinctive. For example, a Distinctive Permanent Identifier shared among a small
+          number of users could still be distinctive. </p>
+        <p class="note"> A Distinctive Permanent Identifier is <em>not</em> a <a
+            def-id="distinctive-identifier"></a> because it is not derived or generated (within the
+          scope of this specification). </p>
+        <p class="note">
+          <a def-id="option-distinctiveIdentifier"></a> controls whether Distinctive Permanent
+          Identifiers may be used. Specifically, Distinctive Permanent Identifiers may only be used
+          when the value of the <a def-id="option-distinctiveIdentifier"></a> member of the
+          <a>MediaKeySystemAccess</a> used to create the <a>MediaKeys</a> object is <a
+            def-id="requirement-required"></a>. </p>
+      </dd>
+      <dt id="distinctive-identifier">Distinctive Identifier</dt>
+      <dd>
+        <div class="note">
+          <p> A Distinctive Identifier is a value, including in opaque or encrypted form, for which
+            it is possible for any entity external to the client to correlate or associate values
+            beyond what a user may expect on the web platform (e.g., cookies and other site data).
+            For example, values that are <a href="#associable-by-entity">associable by an entity
+              other than the application</a> across a) <a def-id="origin">origins</a>, b) <a
+              def-id="browsing-profile">browsing profiles</a>, or c) browsing sessions even after
+            the user has attempted to protect his or her privacy by clearing browsing data or values
+            for which it is not easy for a user to break such association. In particular, a value is
+            a Distinctive Identifier if it is possible for a <a href="#associable-by-entity">central
+              server, such as an individualization server, to associate</a> values across origins,
+            such as because the <a href="#individualization">individualization</a> requests
+            contained a common value, or because values provided in individualization requests are
+            <a href="#associable-by-entity">associable by such server</a> even after attempts to
+            clear browsing data. Possible causes of this include use of <a
+              def-id="distinctive-permanent-identifier-maybe-plural"></a> in the individualization
+            process. </p>
+          <p> Distinctive Identifiers exposed to the application, even in encrypted form, MUST
+            adhere to the <a href="#identifier-requirements">identifier requirements</a>, including
+            being <a href="#encrypt-identifiers">encrypted</a>, <a
+              href="#per-origin-per-profile-identifiers">unique per origin and profile</a>, and <a
+              href="#allow-identifiers-cleared">clearable</a>. </p>
+          <p> While the instantiation or use of a Distinctive Identifier is triggered by the
+            application's use of the APIs defined in this specification, the identifier need not be
+            provided to the application to trigger conditions related to Distinctive Identifiers.
+            (The <a def-id="distinctive-permanent-identifier-maybe-plural"></a> MUST NOT ever be
+            provided to the application, even in opaque or encrypted form.) </p>
+        </div>
+        <p class="note">
+          <a def-id="option-distinctiveIdentifier"></a> controls whether Distinctive Identifiers may
+          be used. Specifically, Distinctive Identifiers may only be used when the value of the <a
+            def-id="option-distinctiveIdentifier"></a> member of the <a>MediaKeySystemAccess</a>
+          used to create the <a>MediaKeys</a> object is <a def-id="requirement-required"></a>. </p>
+        <p>A Distinctive Identifier is a value, piece of data, implication of the possession of a
+          piece of data, or an observable behavior or timing for which all of the following criteria
+          hold:</p>
+        <ul>
+          <li>
+            <p>It is <a href="#distinctive-value">distinctive</a>.</p>
+            <p class="note">While a Distinctive Identifier is typically unique to a user or client
+              device, an identifier does not need to be strictly unique to be distinctive. For
+              example, an identifier shared among a small number of users could still be
+              distinctive. </p>
+          </li>
+          <li>
+            <p>It, information about it, or values derived from or otherwise related to it are
+              exposed, even in encrypted form, outside the client. This includes but is not limited
+              to providing it to the application and/or license, <a
+                href="#individualization">individualization</a>, or other server. </p>
+          </li>
+          <li>
+            <p>It has one or more the following properties:</p>
+            <ul>
+              <li>
+                <p>It is derived from one or more <a
+                    def-id="distinctive-permanent-identifier-maybe-plural"></a>.</p>
+              </li>
+              <li>
+                <p>The generation, <a href="#individualization">individualization</a>, provisioning
+                  or other process that produced the value involved, used, provided, derived from,
+                  or similarly involved one or more <a
+                    def-id="distinctive-permanent-identifier-maybe-plural"></a> or another
+                  Distinctive Identifier.</p>
+              </li>
+              <li>
+                <p>It is <a href="#allow-identifiers-cleared">clearable</a> but not <a
+                    href="#allow-persistent-data-cleared-with-cookies">along with cookies and other
+                    site data</a>.</p>
+                <p class="note">For example, via some mechanism external to the user agent, such as
+                  an OS-level mechanism.</p>
+              </li>
+            </ul>
+            <div class="note">
+              <p>Other properties of concern that are normatively prohibited for values exposed to
+                the application include:</p>
               <ul>
-                <li><p>It is derived from one or more <a def-id="distinctive-permanent-identifier-maybe-plural"></a>.</p></li>
-                <li><p>The generation, <a href="#individualization">individualization</a>, provisioning or other process that produced the value involved, used, provided, derived from, or similarly involved one or more <a def-id="distinctive-permanent-identifier-maybe-plural"></a> or another Distinctive Identifier.</p></li>
                 <li>
-                  <p>It is <a href="#allow-identifiers-cleared">clearable</a> but not <a href="#allow-persistent-data-cleared-with-cookies">along with cookies and other site data</a>.</p>
-                  <p class="note">For example, via some mechanism external to the user agent, such as an OS-level mechanism.</p>
+                  <p>It is a <a def-id="distinctive-permanent-identifier"></a>.</p>
+                </li>
+                <li>
+                  <p>It is <em>not</em> <a href="#allow-identifiers-cleared">clearable</a>.</p>
+                </li>
+                <li>
+                  <p>Value(s) created after <a href="#allow-identifiers-cleared">clearing
+                      identifier(s)</a> may be <a href="#associable-by-application">associable by
+                      the application</a> with previous value(s).</p>
+                </li>
+                <li>
+                  <p>Values may not be <a href="#per-origin-per-profile-identifiers">unique per
+                      origin and profile</a>.</p>
+                </li>
+                <li>
+                  <p>Values for different origins may be <a
+                      href="#associable-by-application">associable by the application</a>.</p>
                 </li>
               </ul>
-              <div class="note">
-                <p>Other properties of concern that are normatively prohibited for values exposed to the application include:</p> 
-                <ul>
-                  <li><p>It is a <a def-id="distinctive-permanent-identifier"></a>.</p></li>
-                  <li><p>It is <em>not</em> <a href="#allow-identifiers-cleared">clearable</a>.</p></li>
-                  <li><p>Value(s) created after <a href="#allow-identifiers-cleared">clearing identifier(s)</a> may be <a href="#associable-by-application">associable by the application</a> with previous value(s).</p></li>
-                  <li><p>Values may not be <a href="#per-origin-per-profile-identifiers">unique per origin and profile</a>.</p></li>
-                  <li><p>Values for different origins may be <a href="#associable-by-application">associable by the application</a>.</p></li>
-                </ul>
-                <p>Examples of such normatively prohibited values include but is not limited to:</p>
-                <ul>
-                  <li><p>A single hardware-based value used for all origins.</p></li>
-                  <li><p>A single random based value used for all origins.</p></li>
-                  <li><p>A single value obtained from an <a href="#individualization">individualization</a> process that is used for all origins.</p></li>
-                  <li><p>Values that include all or part of any of the above values.</p></li>
-                  <li><p>A single value that is used for multiple but not all origins.</p></li>
-                  <li><p>A single value that is used for all origins on a domain. (Identifiers must be per-<a def-id="origin"></a>.)</p></li>
-                  <li><p>A pre-provisioned origin-specific value.</p></li>
-                  <li><p>Values generated by trivially-reversible means, which are thus <a href="#associable-by-application">associable by the application</a>, regardless of whether generated on the client or involving an a <a href="#individualization">individualization</a> process. For example, XORing or otherwise integrating (part of) the origin with a fixed value.</p></li>
-                </ul>
-              </div>
+              <p>Examples of such normatively prohibited values include but is not limited to:</p>
+              <ul>
+                <li>
+                  <p>A single hardware-based value used for all origins.</p>
+                </li>
+                <li>
+                  <p>A single random based value used for all origins.</p>
+                </li>
+                <li>
+                  <p>A single value obtained from an <a
+                      href="#individualization">individualization</a> process that is used for all
+                    origins.</p>
+                </li>
+                <li>
+                  <p>Values that include all or part of any of the above values.</p>
+                </li>
+                <li>
+                  <p>A single value that is used for multiple but not all origins.</p>
+                </li>
+                <li>
+                  <p>A single value that is used for all origins on a domain. (Identifiers must be
+                    per-<a def-id="origin"></a>.)</p>
+                </li>
+                <li>
+                  <p>A pre-provisioned origin-specific value.</p>
+                </li>
+                <li>
+                  <p>Values generated by trivially-reversible means, which are thus <a
+                      href="#associable-by-application">associable by the application</a>,
+                    regardless of whether generated on the client or involving an a <a
+                      href="#individualization">individualization</a> process. For example, XORing
+                    or otherwise integrating (part of) the origin with a fixed value.</p>
+                </li>
+              </ul>
+            </div>
+          </li>
+        </ul>
+        <p class="note"> While Distinctive Identifier are usually <a
+            href="#associable-by-entity">associable by the entity that generated them</a> they MUST
+          be <a def-id="non-associable-by-application"></a>. In other words, such correlation or
+          association is only possible by the entity, such as an <a
+            href="#individualization">individualization</a> server, that originally generated the
+          Distinctive Identifier values. Entities with access to the <a
+            def-id="distinctive-permanent-identifier-maybe-plural"></a> MUST NOT expose this
+          capability to applications, as this would make resulting Distinctive Identifiers <a
+            href="#associable-by-application">associable by the application</a>, and SHOULD take
+          care to avoid exposing such correlation to other entities or third parties. </p>
+        <div class="note">
+          <p>Examples of Distinctive Identifiers include but are not limited to:</p>
+          <ul>
+            <li>
+              <p>A series of bytes that is included in key requests, different from the series of
+                bytes included by other client devices, and based on or was acquired directly or
+                indirectly using a <a def-id="distinctive-permanent-identifier"></a>.</p>
+            </li>
+            <li>
+              <p>A public key included in key requests that is different from the public keys
+                included in the requests by other client devices and is based on or was acquired
+                directly or indirectly using a <a def-id="distinctive-permanent-identifier"></a>.
+              </p>
+            </li>
+            <li>
+              <p>Demonstration of possession of a private key (e.g., by signing some data) that
+                other client devices do not have and is based on or was acquired directly or
+                indirectly using a <a def-id="distinctive-permanent-identifier"></a>.</p>
+            </li>
+            <li>
+              <p>An identifier for such a key.</p>
+            </li>
+            <li>
+              <p>Such a value used to derive another value that is exposed even though the first
+                value is not directly exposed.</p>
+            </li>
+            <li>
+              <p>A value derived from another Distinctive Identifier.</p>
+            </li>
+            <li>
+              <p>A random value that was reported to a (e.g., <a
+                  href="#individualization">individualization</a>) server along with a <a
+                  def-id="distinctive-permanent-identifier"></a> or provided by such a server after
+                providing a <a def-id="distinctive-permanent-identifier"></a>.</p>
+            </li>
+            <li>
+              <p>A value derived from a unique value provisioned in the hardware device in the
+                factory.</p>
+            </li>
+            <li>
+              <p>A value derived from a unique hardware value (e.g., MAC address or serial number)
+                or software value (e.g., operating system installation instance or operating system
+                user account name) in the hardware device in the factory.</p>
+            </li>
+            <li>
+              <p>A value derived from a unique value embedded in the CDM binary or other file used
+                by the CDM.</p>
             </li>
           </ul>
-
-          <p class="note">
-            While Distinctive Identifier are usually <a href="#associable-by-entity">associable by the entity that generated them</a> they MUST be <a def-id="non-associable-by-application"></a>.
-            In other words, such correlation or association is only possible by the entity, such as an <a href="#individualization">individualization</a> server, that originally generated the Distinctive Identifier values.
-            Entities with access to the <a def-id="distinctive-permanent-identifier-maybe-plural"></a> MUST NOT expose this capability to applications, as this would make resulting Distinctive Identifiers <a href="#associable-by-application">associable by the application</a>, and SHOULD take care to avoid exposing such correlation to other entities or third parties.
-          </p>
-
-          <div class="note">
-            <p>Examples of Distinctive Identifiers include but are not limited to:</p>
-            <ul>
-              <li><p>A series of bytes that is included in key requests, different from the series of bytes included by other client devices, and based on or was acquired directly or indirectly using a <a def-id="distinctive-permanent-identifier"></a>.</p></li>
-              <li><p>A public key included in key requests that is different from the public keys included in the requests by other client devices and is based on or was acquired directly or indirectly using a <a def-id="distinctive-permanent-identifier"></a>.</p></li>
-              <li><p>Demonstration of possession of a private key (e.g., by signing some data) that other client devices do not have and is based on or was acquired directly or indirectly using a <a def-id="distinctive-permanent-identifier"></a>.</p></li>
-              <li><p>An identifier for such a key.</p></li>
-              <li><p>Such a value used to derive another value that is exposed even though the first value is not directly exposed.</p></li>
-              <li><p>A value derived from another Distinctive Identifier.</p></li>
-              <li><p>A random value that was reported to a (e.g., <a href="#individualization">individualization</a>) server along with a <a def-id="distinctive-permanent-identifier"></a> or provided by such a server after providing a <a def-id="distinctive-permanent-identifier"></a>.</p></li>
-              <li><p>A value derived from a unique value provisioned in the hardware device in the factory.</p></li>
-              <li><p>A value derived from a unique hardware value (e.g., MAC address or serial number) or software value (e.g., operating system installation instance or operating system user account name) in the hardware device in the factory.</p></li>
-              <li><p>A value derived from a unique value embedded in the CDM binary or other file used by the CDM.</p></li>
-            </ul>
-            <p>Examples of things that are <em>not</em> Distinctive Identifiers:</p>
-            <ul>
-              <li><p>A public key shared among all copies of a given CDM version if the installed base is large.</p></li>
-              <li><p>A nonce or ephemeral key that is unique but used in only one session.</p></li>
-              <li><p>A value that is not exposed, even in derived or similar ways, outside the client, including via <a href="#individualization">individualization</a> or similar.</p></li>
-              <li><p>Device-unique keys used in attestations between, for example, the video pipeline and the CDM when the CDM does not let these attestations further flow to the application and instead makes a new attestation on its own using a key that does not constitute a Distinctive Identifier.</p></li>
-              <li>
-                <p>A value that is fully cleared/clearable along with browsing data, such as cookies, after which it will be replaced by a value that is <a def-id="non-associable"></a> (not just <a def-id="non-associable-by-application"></a>), even by a central server such as an <a href="#individualization">individualization</a> server, AND one or more of the following:</p>
-                <ul>
-                  <li><p>No <a def-id="distinctive-permanent-identifier"></a> or Distinctive Identifier was involved in the generation of the value.</p></li>
-                  <li><p>It is a random value generated <em>without</em> inputs from the system.</p></li>
-                  <li><p>It is a value provided by a server without the use of or knowledge of another Distinctive Identifier.</p></li>
-                </ul>
-              </li>
-            </ul>
-          </div>
-        </dd>
-
-        <dt>Use of Distinctive Identifiers and Distinctive Permanent Identifiers</dt>
-        <dd>
-          <p>
-            An implementation, configuration, instance, or object <dfn id="uses-distinctive-identifiers">uses Distinctive Identifier(s)</dfn> if, at any time during its lifetime or the lifetime of related such entities,
-            it exposes, even in encrypted form, one or more <a def-id="distinctive-identifier-maybe-plural"></a>, information about them, or values derived from or otherwise related to them outside the client.
-            This includes but is not limited to providing such a value to the application and/or license, <a href="#individualization">individualization</a>, or other server.
-          </p>
-          <p>
-            An implementation, configuration, instance, or object <dfn id="uses-distinctive-permanent-identifiers">uses Distinctive Permanent Identifier(s)</dfn> if, at any time during its lifetime or the lifetime of related such entities,
-            it exposes, even in encrypted form, one or more <a def-id="distinctive-permanent-identifier-maybe-plural"></a>, information about them, or values derived from or otherwise related to them outside the client.
-            This includes but is not limited to providing such a value to an <a href="#individualization">individualization</a> server.
-            Such values MUST NOT be provided to the application.
-          </p>
-          <p>
-            An implementation, configuration, instance, or object <dfn id="uses-distinctive-identifiers-or-distinctive-permanent-identifiers">uses Distinctive Identifier(s) or Distinctive Permanent Identifier(s)</dfn> if it
-            <a href="#uses-distinctive-identifiers">uses Distinctive Identifier(s)</a> and/or <a href="#uses-distinctive-permanent-identifiers">uses Distinctive Permanent Identifier(s)</a>.
-          </p>
-          <p class="note">
-            <a def-id="option-distinctiveIdentifier"></a> controls whether <a def-id="distinctive-identifiers"></a> and <a def-id="distinctive-permanent-identifiers"></a> may be used.
-            Specifically, such identifiers may only be used when the value of the <a def-id="option-distinctiveIdentifier"></a> member of the <a>MediaKeySystemAccess</a> used to create the <a>MediaKeys</a> object is <a def-id="requirement-required"></a>.
-          </p>
-        </dd>
-
-        <dt id="cross-origin">Cross Origin Limitations</dt>
-        <dd>
-          <p>During playback, embedded media data is exposed to script in the embedding <a def-id="origin"></a>.
-          In order for the API to provide <a def-id="initialization-data"></a> in the <a def-id="encrypted"></a> event, <a def-id="media-data"></a> MUST be <a def-id="cors-same-origin"></a> with the embedding page.
-          If <a def-id="media-data"></a> is cross-origin with the embedding document, authors SHOULD use the <a def-id="media-crossorigin"></a> attribute
-          on the <a def-id="htmlmediaelement"></a> and CORS headers on the <a def-id="media-data"></a> response to make it <a def-id="cors-same-origin"></a>.
-          </p>
-        </dd>
-
-        <dt id="mixed-content">Mixed Content Limitations</dt>
-        <dd>
-          <p>During playback, embedded media data is exposed to script in the embedding <a def-id="origin"></a>.
-          In order for the API to provide <a def-id="initialization-data"></a> in the <a def-id="encrypted"></a> event, <a def-id="media-data"></a> MUST NOT be Mixed Content [[MIXED-CONTENT]].
-          </p>
-        </dd>
-
-        <dt id="time">Time</dt>
-        <dd>
-          <p>Time MUST be equivalent to that represented in <a class="external" href="https://tc39.github.io/ecma262/#sec-time-values-and-time-range">ECMAScript <span class="estype">Time Values and Time Range</span></a> [[ECMA-262]]. 
-          </p>    
-          <p>Time will equal <code>NaN</code> if no such time exists or if the time is indeterminate.  It should never have the value <code>Infinity</code>.
-          </p>
-          <p class="note">
-            Time generally represents an instant in time with millisecond accuracy; however, that alone is not a sufficient definition.  The defined Time Values and Time Range reference adds other important requirements.
-          </p>
-        </dd>
-
-        <dt id="expiration-time">Expiration Time</dt>
-        <dd>
-          <p>
-            The <a def-id="time">time</a> after which key(s) will no longer be <a def-id="usable-for-decryption"></a>.
-          </p>
-        </dd>
-
-        <dt id="browsing-profile">Browsing Profile</dt>
-        <dd>
-          <p>
-            A User Agent on a given machine may support execution in a variety of different contexts or modes or temporary states that are expected to behave independently
-            with respect to application-visible state and data.
-            In particular, all stored data is expected to be independent. In this specification we refer to such independent contexts or modes as "Browsing Profiles".
-          </p>
-          <p class="note">
-            Examples of such independent contexts include if the user agent is running in different operating system user accounts or if the user agent provides the capability to define
-            multiple independent profiles for a single account.
-          </p>
-        </dd>
-        <dt id="valid-media-mime-type">Valid Media MIME Type</dt>
-        <dd>
-          <p>
-            A valid media MIME type is a media <a def-id="mime-types">MIME type</a> that is also a <a def-id="valid-mime-type"></a> [[HTML]].
-            When a MIME type includes parameters, such as `"codecs"` [[RFC6381]], such parameters MUST also be valid per the relevant specification.
-          </p>
-          <p>
-            When used with the features defined in this specification, MIME type strings SHOULD explicitly specify codecs and codec constraints (e.g., per [[RFC6381]]) unless these are normatively implied by the container.
-          </p>
-        </dd>
-      </dl>
-    </section>
-
-    <section>
-      <h2>Obtaining Access to Key Systems</h2>
-      <p>This section defines the mechanism for obtaining access to a key system.
-        The inclusion of capabilities in the request also enables feature detection.
-      </p>
-      <p>The steps of an algorithm are always aborted when rejecting a promise.</p>
-
-      <section>
-        <h3>Feature Policy Integration</h3>
-        <p>
-          <a def-id="requestMediaKeySystemAccess"></a> is a <a
-          data-cite="!FEATURE-POLICY#policy-controlled-feature">policy-controlled feature</a>
-          identified by the string <dfn><code>encrypted-media</code></dfn>.  Its <a
-          data-cite="!FEATURE-POLICY#default-allowlist">default allowlist</a> is <code>'self'</code>
-          [[!FEATURE-POLICY]].
+          <p>Examples of things that are <em>not</em> Distinctive Identifiers:</p>
+          <ul>
+            <li>
+              <p>A public key shared among all copies of a given CDM version if the installed base
+                is large.</p>
+            </li>
+            <li>
+              <p>A nonce or ephemeral key that is unique but used in only one session.</p>
+            </li>
+            <li>
+              <p>A value that is not exposed, even in derived or similar ways, outside the client,
+                including via <a href="#individualization">individualization</a> or similar.</p>
+            </li>
+            <li>
+              <p>Device-unique keys used in attestations between, for example, the video pipeline
+                and the CDM when the CDM does not let these attestations further flow to the
+                application and instead makes a new attestation on its own using a key that does not
+                constitute a Distinctive Identifier.</p>
+            </li>
+            <li>
+              <p>A value that is fully cleared/clearable along with browsing data, such as cookies,
+                after which it will be replaced by a value that is <a def-id="non-associable"></a>
+                (not just <a def-id="non-associable-by-application"></a>), even by a central server
+                such as an <a href="#individualization">individualization</a> server, AND one or
+                more of the following:</p>
+              <ul>
+                <li>
+                  <p>No <a def-id="distinctive-permanent-identifier"></a> or Distinctive Identifier
+                    was involved in the generation of the value.</p>
+                </li>
+                <li>
+                  <p>It is a random value generated <em>without</em> inputs from the system.</p>
+                </li>
+                <li>
+                  <p>It is a value provided by a server without the use of or knowledge of another
+                    Distinctive Identifier.</p>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </div>
+      </dd>
+      <dt>Use of Distinctive Identifiers and Distinctive Permanent Identifiers</dt>
+      <dd>
+        <p> An implementation, configuration, instance, or object <dfn
+            id="uses-distinctive-identifiers">uses Distinctive Identifier(s)</dfn> if, at any time
+          during its lifetime or the lifetime of related such entities, it exposes, even in
+          encrypted form, one or more <a def-id="distinctive-identifier-maybe-plural"></a>,
+          information about them, or values derived from or otherwise related to them outside the
+          client. This includes but is not limited to providing such a value to the application
+          and/or license, <a href="#individualization">individualization</a>, or other server. </p>
+        <p> An implementation, configuration, instance, or object <dfn
+            id="uses-distinctive-permanent-identifiers">uses Distinctive Permanent Identifier(s)
+          </dfn> if, at any time during its lifetime or the lifetime of related such entities, it
+          exposes, even in encrypted form, one or more <a
+            def-id="distinctive-permanent-identifier-maybe-plural"></a>, information about them, or
+          values derived from or otherwise related to them outside the client. This includes but is
+          not limited to providing such a value to an <a
+            href="#individualization">individualization</a> server. Such values MUST NOT be provided
+          to the application. </p>
+        <p> An implementation, configuration, instance, or object <dfn
+            id="uses-distinctive-identifiers-or-distinctive-permanent-identifiers">uses Distinctive
+            Identifier(s) or Distinctive Permanent Identifier(s)</dfn> if it <a
+            href="#uses-distinctive-identifiers">uses Distinctive Identifier(s)</a> and/or <a
+            href="#uses-distinctive-permanent-identifiers">uses Distinctive Permanent
+            Identifier(s)</a>. </p>
+        <p class="note">
+          <a def-id="option-distinctiveIdentifier"></a> controls whether <a
+            def-id="distinctive-identifiers"></a> and <a
+            def-id="distinctive-permanent-identifiers"></a> may be used. Specifically, such
+          identifiers may only be used when the value of the <a
+            def-id="option-distinctiveIdentifier"></a> member of the <a>MediaKeySystemAccess</a>
+          used to create the <a>MediaKeys</a> object is <a def-id="requirement-required"></a>. </p>
+      </dd>
+      <dt id="cross-origin">Cross Origin Limitations</dt>
+      <dd>
+        <p>During playback, embedded media data is exposed to script in the embedding <a
+            def-id="origin"></a>. In order for the API to provide <a
+            def-id="initialization-data"></a> in the <a def-id="encrypted"></a> event, <a
+            def-id="media-data"></a> MUST be <a def-id="cors-same-origin"></a> with the embedding
+          page. If <a def-id="media-data"></a> is cross-origin with the embedding document, authors
+          SHOULD use the <a def-id="media-crossorigin"></a> attribute on the <a
+            def-id="htmlmediaelement"></a> and CORS headers on the <a def-id="media-data"></a>
+          response to make it <a def-id="cors-same-origin"></a>. </p>
+      </dd>
+      <dt id="mixed-content">Mixed Content Limitations</dt>
+      <dd>
+        <p>During playback, embedded media data is exposed to script in the embedding <a
+            def-id="origin"></a>. In order for the API to provide <a
+            def-id="initialization-data"></a> in the <a def-id="encrypted"></a> event, <a
+            def-id="media-data"></a> MUST NOT be Mixed Content [[MIXED-CONTENT]]. </p>
+      </dd>
+      <dt id="time">Time</dt>
+      <dd>
+        <p>Time MUST be equivalent to that represented in <a class="external"
+            href="https://tc39.github.io/ecma262/#sec-time-values-and-time-range">ECMAScript <span
+              class="estype">Time Values and Time Range</span></a> [[ECMA-262]]. </p>
+        <p>Time will equal <code>NaN</code> if no such time exists or if the time is indeterminate.
+          It should never have the value <code>Infinity</code>. </p>
+        <p class="note"> Time generally represents an instant in time with millisecond accuracy;
+          however, that alone is not a sufficient definition. The defined Time Values and Time Range
+          reference adds other important requirements. </p>
+      </dd>
+      <dt id="expiration-time">Expiration Time</dt>
+      <dd>
+        <p> The <a def-id="time">time</a> after which key(s) will no longer be <a
+            def-id="usable-for-decryption"></a>. </p>
+      </dd>
+      <dt id="browsing-profile">Browsing Profile</dt>
+      <dd>
+        <p> A User Agent on a given machine may support execution in a variety of different contexts
+          or modes or temporary states that are expected to behave independently with respect to
+          application-visible state and data. In particular, all stored data is expected to be
+          independent. In this specification we refer to such independent contexts or modes as
+          "Browsing Profiles". </p>
+        <p class="note"> Examples of such independent contexts include if the user agent is running
+          in different operating system user accounts or if the user agent provides the capability
+          to define multiple independent profiles for a single account. </p>
+      </dd>
+      <dt id="valid-media-mime-type">Valid Media MIME Type</dt>
+      <dd>
+        <p> A valid media MIME type is a media <a def-id="mime-types">MIME type</a> that is also a
+          <a def-id="valid-mime-type"></a> [[HTML]]. When a MIME type includes parameters, such as
+          `"codecs"` [[RFC6381]], such parameters MUST also be valid per the relevant specification.
         </p>
-      </section>
-
-      <section>
-        <h3><dfn>Navigator</dfn> Extension: <code>requestMediaKeySystemAccess()</code></h3>
-
-        <div><pre class="idl">[Exposed=Window]
+        <p> When used with the features defined in this specification, MIME type strings SHOULD
+          explicitly specify codecs and codec constraints (e.g., per [[RFC6381]]) unless these are
+          normatively implied by the container. </p>
+      </dd>
+    </dl>
+  </section>
+  <section>
+    <h2>Obtaining Access to Key Systems</h2>
+    <p>This section defines the mechanism for obtaining access to a key system. The inclusion of
+      capabilities in the request also enables feature detection. </p>
+    <p>The steps of an algorithm are always aborted when rejecting a promise.</p>
+    <section>
+      <h3>Feature Policy Integration</h3>
+      <p>
+        <a def-id="requestMediaKeySystemAccess"></a> is a <a
+          data-cite="!FEATURE-POLICY#policy-controlled-feature">policy-controlled feature</a>
+        identified by the string <dfn>
+          <code>encrypted-media</code>
+        </dfn>. Its <a data-cite="!FEATURE-POLICY#default-allowlist">default allowlist</a> is <code>
+          'self'</code> [[!FEATURE-POLICY]]. </p>
+    </section>
+    <section>
+      <h3>
+        <dfn>Navigator</dfn> Extension: <code>requestMediaKeySystemAccess()</code>
+      </h3>
+      <div>
+        <pre class="idl">[Exposed=Window]
 partial interface Navigator {
     [SecureContext] Promise&lt;MediaKeySystemAccess&gt; requestMediaKeySystemAccess (DOMString keySystem, sequence&lt;MediaKeySystemConfiguration&gt; supportedConfigurations);
-};</pre><section><h2>Methods</h2><dl class="methods" data-dfn-for="Navigator" data-link-for="Navigator"><dt><dfn><code>requestMediaKeySystemAccess</code></dfn></dt><dd>
-            <p class="note">Calling this method may have <em>user-visible effects</em>, including requests for user consent.
-            This method should only be called when the author intends to create and use a <a>MediaKeys</a> object with the provided configuration.
-            </p>
-            <p>Requests access to the specified <a def-id="keysystem"></a>.
-              When <code>supportedConfigurations</code> is specified, the configuration specified by at least one of its elements must be supported.
-              The resulting <a>MediaKeySystemAccess</a> will correspond to the first such element.
-            </p>
-            <p>Any permission checks or user interaction, such as a prompt for consent, MUST be performed before resolving the promise.</p>
-            <p>If the <code>keySystem</code> is not supported or not allowed (in at least one of the <code>supportedConfigurations</code>, if specified), the promise is rejected.
-              Otherwise, it is resolved with a new <a>MediaKeySystemAccess</a> object.
-            </p>
-            <div class="note">
-              <p>This method is only exposed to <a href="https://www.w3.org/TR/secure-contexts/#secure-context">secure contexts</a> [[SECURE-CONTEXTS]] as indicated by the <code>[SecureContext]</code> IDL attribute.</p>
-              <p>
-                Requiring Secure Contexts is <em>not</em> a replacement for other security- and privacy-related requirements and recommendations.
-                Implementations MUST meet all related requirements and SHOULD follow related recommendations such that the risks on in an secure context would be similar.
-              </p>
-            </div> 
-
-            <ol class="method-algorithm">
-              <!-- TODO: Convert all parameters to use <code>. -->
-
-              <li><p>If the <a data-cite="!FEATURE-POLICY#responsible-document">responsible
-              document</a> is not <a data-cite="!FEATURE-POLICY#allowed-to-use">allowed to use</a>
-              the <a><code>encrypted-media</code></a> feature, then throw a "<a
-              data-cite="!WEBIDL#securityerror">SecurityError</a>" <a
-              data-cite="!WEBIDL#dfn-DOMException">DOMException</a> and abort these steps.</p></li>
-
-              <li><p>If <var>keySystem</var> is the empty string, return a promise rejected with a newly created <a def-id="TypeError"></a>.</p></li>
-              <li><p>If <var>supportedConfigurations</var> is empty, return a promise rejected with a newly created <a def-id="TypeError"></a>.</p></li>
-              <li><p>Let <var>document</var> be the calling context's <a def-id="document-concept"></a>.</p></li>
-              <li><p>Let <var>origin</var> be the <a def-id="origin"></a> of <var>document</var>.</p></li>
-              <li><p>Let <var>promise</var> be a new promise.</p></li>
-              <li><p>Run the following steps in parallel:</p>
-                <ol>
-                  <li><p>If <var>keySystem</var> is not one of the <a def-id="keysystems"></a> supported by the user agent, reject <var>promise</var> with a <a def-id="NotSupportedError"></a>. String comparison is case-sensitive.</p></li>
-                  <li><p>Let <var>implementation</var> be the implementation of <var>keySystem</var>.</p></li>
-                  <li><p>For each value in <code>supportedConfigurations</code>:</p>
-                    <ol>
-                      <li><p>Let <var>candidate configuration</var> be the value.</p></li>
-                      <li><p>Let <var>supported configuration</var> be the result of executing the <a def-id="get-supported-configuration-algorithm"></a> algorithm on <var>implementation</var>, <var>candidate configuration</var>, and <var>origin</var>.</p></li>
-                      <li><p>If <var>supported configuration</var> is not <code>NotSupported</code>, run the following steps:</p>
-                        <ol>
-                          <li>
-                            <p>Let <var>access</var> be a new <a>MediaKeySystemAccess</a> object, and initialize it as follows:</p>
-                            <ol>
-                              <li><p>Set the <a def-id="keySystem-attribute"></a> attribute to <var>keySystem</var>.</p></li>
-                              <li><p>Let the <var>configuration</var> value be <var>supported configuration</var>.</p></li>
-                              <li><p>Let the <var>cdm implementation</var> value be <var>implementation</var>.</p></li>
-                            </ol>
-                          </li>
-                          <li><p>Resolve <var>promise</var> with <var>access</var> and abort the parallel steps of this algorithm.</p></li>
-                        </ol>
-                      </li>
-                    </ol>
-                  </li>
-                  <li><p>Reject <var>promise</var> with a <a def-id="NotSupportedError"></a>.</p>
-                    <p class="note"><code>keySystem</code> was not supported/allowed or none of the configurations in <code>supportedConfigurations</code> were supported/allowed.</p>
-                  </li>
-                </ol>
-              </li>
-              <li><p>Return <var>promise</var>.</p></li>
-            </ol>
-          <table class="parameters"><tbody><tr><th>Parameter</th><th>Type</th><th>Nullable</th><th>Optional</th><th>Description</th></tr><tr><td class="prmName">keySystem</td><td class="prmType"><code>DOMString</code></td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td><td class="prmDesc">
-                The <a def-id="keysystem"></a> for which access is being requested.
-              </td></tr><tr><td class="prmName">supportedConfigurations</td><td class="prmType"><code>sequence&lt;MediaKeySystemConfiguration&gt;</code></td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td><td class="prmDesc">
-                A sequence of <a>MediaKeySystemConfiguration</a> configurations to try in order.
-                The first element with a satisfiable configuration will be used.
-              </td></tr></tbody></table><div><em>Return type: </em><code>Promise&lt;MediaKeySystemAccess&gt;</code></div></dd></dl></section></div>
-
+};</pre>
         <section>
-          <h4>Algorithms</h4>
-
-          <section>
-            <h5>Get Supported Configuration</h5>
-            <p>Given a <a def-id="keysystems"></a> implementation <var>implementation</var>, <a>MediaKeySystemConfiguration</a> <var>candidate configuration</var>, and <var>origin</var>, this algorithm returns a supported configuration or <code>NotSupported</code> as appropriate.</p>
-            <p class="note">Unrecognized dictionary members in <var>candidate configuration</var> are ignored per [[WEBIDL]] and will never reach this algorithm. Thus, they cannot be considered as part of the configuration.
-            </p>
-            <div class="note">
-              <p>
-              For certain configurations, it may be required to obtain user consent or inform the user. User Agents have some flexibility to determine
-              whether consent is required for a specific configuration and whether such consent may also apply to other configurations. For example,
-              consent to one configuration may also imply consent for less powerful, more restricted configurations. Equally, a denial of consent for
-              one configuration may imply denial of consent for more powerful, less restricted configurations.
-              </p>
-              <p>
-              Supported configurations, including supported audio and video codecs, may depend on availability of optional capabilities such as
-              <a def-id="distinctive-identifier-maybe-plural"></a> and persistent state. The following algorithm iteratively tries to find a configuration
-              that is both supported and has user consent (or does not need consent).
-              </p>
-              <p>
-              User Agents should reuse earlier consent responses, when appropriate, at least for the duration of the <a def-id="requestMediaKeySystemAccess"></a>
-              algorithm in order to avoid repeated requests to the user for similar configurations.
-              </p>
-              <p>
-                The variable <var>restrictions</var> in the steps below represents the configurations for which consent has been denied during the
-                execution of this algorithm or based on persisted consent information for the origin. It is used to determine
-                whether user consent for a candidate configuration or accumulated configuration has been denied. Consent is denied for a accumulated configuration
-                if every derived configuration has already been denied. Internal representation of <var>restrictions</var> is implementation-specific.
-              </p>
-            </div>
-            <ol>
-              <li>
-                <p>Let <var>supported configuration</var> be <code>ConsentDenied</code>.</p>
-              </li>
-              <li>
-                <p>Initialize <var>restrictions</var> to indicate that no configurations have had user consent denied.</p>
-              </li>
-              <li>
-                <p>Repeat the following step while <var>supported configuration</var> is <code>ConsentDenied</code>:</p>
-                <ol>
-                  <li>
-                    <p>
-                    Let <var>supported configuration</var> and, if provided, <var>restrictions</var> be the result of executing the
-                    <a def-id="get-supported-configuration-and-consent-algorithm"></a> algorithm
-                    with <var>implementation</var>, <var>candidate configuration</var>, <var>restrictions</var> and <var>origin</var>.
-                    </p>
-                  </li>
-                </ol>
-              </li>
-              <li>
-                <p>Return <var>supported configuration</var>.</p>
-              </li>
-            </ol>
-          </section>
-          <section>
-            <h5>Get Supported Configuration and Consent</h5>
-            <p>Given a <a def-id="keysystems"></a> implementation <var>implementation</var>, <a>MediaKeySystemConfiguration</a> <var>candidate configuration</var>,
-              <var>restrictions</var> and <var>origin</var>, this algorithm returns a supported configuration, <code>NotSupported</code>, or <code>ConsentDenied</code> as appropriate and, in the <code>ConsentDenied</code> case, <var>restrictions</var>.
-            </p>
-            <ol>
-              <li><p>Let <var>accumulated configuration</var> be a new <a>MediaKeySystemConfiguration</a> dictionary.</p></li>
-
-              <li>
-                <p>
-                  Set the <a def-id="option-label"></a> member of <var>accumulated configuration</var> to equal the <a def-id="option-label"></a> member of <var>candidate configuration</var>.
-                </p>
-              </li>
-
-              <li><p>If the <a def-id="option-initDataTypes"></a> member of <var>candidate configuration</var> is non-empty, run the following steps:</p>
-                <ol>
-                  <li><p>Let <var>supported types</var> be an empty sequence of DOMStrings.</p></li>
-                  <li><p>For each value in <var>candidate configuration</var>'s <a def-id="option-initDataTypes"></a> member:</p>
-                    <ol>
-                      <li><p>Let <var>initDataType</var> be the value.</p></li>
-                      <li>
-                        <p>If the <var>implementation</var> supports generating requests based on <var>initDataType</var>, add <var>initDataType</var> to <var>supported types</var>.
-                          String comparison is case-sensitive.
-                          The empty string is never supported.
-                        </p>
-                        <p class="note">The <var>initDataType</var> MUST be supported independent of content types in order to avoid unexpectedly rejecting the configuration in later steps.
-                          Support for <var>initDataType</var> includes both license generation and, when appropriate, extraction from media data.
-                          See <a href="#initialization-data-type-support-requirements">Initialization Data Type Support requirements</a>.
-                        </p>
-                      </li>
-                    </ol>
-                  </li>
-                  <li><p>If <var>supported types</var> is empty, return <code>NotSupported</code>.</p></li>
-                  <li><p>Set the <a def-id="option-initDataTypes"></a> member of <var>accumulated configuration</var> to <var>supported types</var>.</p></li>
-                </ol>
-              </li>
-
-              <!-- Table of results for MediaKeysRequirement members based on implementation capabilities:
+          <h2>Methods</h2>
+          <dl class="methods" data-dfn-for="Navigator" data-link-for="Navigator">
+            <dt>
+              <dfn>
+                <code>requestMediaKeySystemAccess</code>
+              </dfn>
+            </dt>
+            <dd>
+              <p class="note">Calling this method may have <em>user-visible effects</em>, including
+                requests for user consent. This method should only be called when the author intends
+                to create and use a <a>MediaKeys</a> object with the provided configuration. </p>
+              <p>Requests access to the specified <a def-id="keysystem"></a>. When <code>
+                  supportedConfigurations</code> is specified, the configuration specified by at
+                least one of its elements must be supported. The resulting
+                <a>MediaKeySystemAccess</a> will correspond to the first such element. </p>
+              <p>Any permission checks or user interaction, such as a prompt for consent, MUST be
+                performed before resolving the promise.</p>
+              <p>If the <code>keySystem</code> is not supported or not allowed (in at least one of
+                the <code>supportedConfigurations</code>, if specified), the promise is rejected.
+                Otherwise, it is resolved with a new <a>MediaKeySystemAccess</a> object. </p>
+              <div class="note">
+                <p>This method is only exposed to <a
+                    href="https://www.w3.org/TR/secure-contexts/#secure-context">secure contexts</a>
+                  [[SECURE-CONTEXTS]] as indicated by the <code>[SecureContext]</code> IDL
+                  attribute.</p>
+                <p> Requiring Secure Contexts is <em>not</em> a replacement for other security- and
+                  privacy-related requirements and recommendations. Implementations MUST meet all
+                  related requirements and SHOULD follow related recommendations such that the risks
+                  on in an secure context would be similar. </p>
+              </div>
+              <ol class="method-algorithm">
+                <!-- TODO: Convert all parameters to use <code>. -->
+                <li>
+                  <p>If the <a data-cite="!FEATURE-POLICY#responsible-document">responsible
+                      document</a> is not <a data-cite="!FEATURE-POLICY#allowed-to-use">allowed to
+                      use</a> the <a>
+                      <code>encrypted-media</code>
+                    </a> feature, then throw a "<a
+                      data-cite="!WEBIDL#securityerror">SecurityError</a>" <a
+                      data-cite="!WEBIDL#dfn-DOMException">DOMException</a> and abort these steps.
+                  </p>
+                </li>
+                <li>
+                  <p>If <var>keySystem</var> is the empty string, return a promise rejected with a
+                    newly created <a def-id="TypeError"></a>.</p>
+                </li>
+                <li>
+                  <p>If <var>supportedConfigurations</var> is empty, return a promise rejected with
+                    a newly created <a def-id="TypeError"></a>.</p>
+                </li>
+                <li>
+                  <p>Let <var>document</var> be the calling context's <a
+                      def-id="document-concept"></a>.</p>
+                </li>
+                <li>
+                  <p>Let <var>origin</var> be the <a def-id="origin"></a> of <var>document</var>.
+                  </p>
+                </li>
+                <li>
+                  <p>Let <var>promise</var> be a new promise.</p>
+                </li>
+                <li>
+                  <p>Run the following steps in parallel:</p>
+                  <ol>
+                    <li>
+                      <p>If <var>keySystem</var> is not one of the <a def-id="keysystems"></a>
+                        supported by the user agent, reject <var>promise</var> with a <a
+                          def-id="NotSupportedError"></a>. String comparison is case-sensitive.</p>
+                    </li>
+                    <li>
+                      <p>Let <var>implementation</var> be the implementation of <var>keySystem</var>
+                        .</p>
+                    </li>
+                    <li>
+                      <p>For each value in <code>supportedConfigurations</code>:</p>
+                      <ol>
+                        <li>
+                          <p>Let <var>candidate configuration</var> be the value.</p>
+                        </li>
+                        <li>
+                          <p>Let <var>supported configuration</var> be the result of executing the
+                            <a def-id="get-supported-configuration-algorithm"></a> algorithm on
+                            <var>implementation</var>, <var>candidate configuration</var>, and <var>
+                              origin</var>.</p>
+                        </li>
+                        <li>
+                          <p>If <var>supported configuration</var> is not <code>NotSupported</code>,
+                            run the following steps:</p>
+                          <ol>
+                            <li>
+                              <p>Let <var>access</var> be a new <a>MediaKeySystemAccess</a> object,
+                                and initialize it as follows:</p>
+                              <ol>
+                                <li>
+                                  <p>Set the <a def-id="keySystem-attribute"></a> attribute to <var>
+                                      keySystem</var>.</p>
+                                </li>
+                                <li>
+                                  <p>Let the <var>configuration</var> value be <var>supported
+                                      configuration</var>.</p>
+                                </li>
+                                <li>
+                                  <p>Let the <var>cdm implementation</var> value be <var>
+                                      implementation</var>.</p>
+                                </li>
+                              </ol>
+                            </li>
+                            <li>
+                              <p>Resolve <var>promise</var> with <var>access</var> and abort the
+                                parallel steps of this algorithm.</p>
+                            </li>
+                          </ol>
+                        </li>
+                      </ol>
+                    </li>
+                    <li>
+                      <p>Reject <var>promise</var> with a <a def-id="NotSupportedError"></a>.</p>
+                      <p class="note">
+                        <code>keySystem</code> was not supported/allowed or none of the
+                        configurations in <code>supportedConfigurations</code> were
+                        supported/allowed.
+                      </p>
+                    </li>
+                  </ol>
+                </li>
+                <li>
+                  <p>Return <var>promise</var>.</p>
+                </li>
+              </ol>
+              <table class="parameters">
+                <tbody>
+                  <tr>
+                    <th>Parameter</th>
+                    <th>Type</th>
+                    <th>Nullable</th>
+                    <th>Optional</th>
+                    <th>Description</th>
+                  </tr>
+                  <tr>
+                    <td class="prmName">keySystem</td>
+                    <td class="prmType">
+                      <code>DOMString</code>
+                    </td>
+                    <td class="prmNullFalse">
+                      <span role="img" aria-label="False">✘</span>
+                    </td>
+                    <td class="prmOptFalse">
+                      <span role="img" aria-label="False">✘</span>
+                    </td>
+                    <td class="prmDesc"> The <a def-id="keysystem"></a> for which access is being
+                      requested. </td>
+                  </tr>
+                  <tr>
+                    <td class="prmName">supportedConfigurations</td>
+                    <td class="prmType">
+                      <code>sequence&lt;MediaKeySystemConfiguration&gt;</code>
+                    </td>
+                    <td class="prmNullFalse">
+                      <span role="img" aria-label="False">✘</span>
+                    </td>
+                    <td class="prmOptFalse">
+                      <span role="img" aria-label="False">✘</span>
+                    </td>
+                    <td class="prmDesc"> A sequence of <a>MediaKeySystemConfiguration</a>
+                      configurations to try in order. The first element with a satisfiable
+                      configuration will be used. </td>
+                  </tr>
+                </tbody>
+              </table>
+              <div>
+                <em>Return type: </em>
+                <code>Promise&lt;MediaKeySystemAccess&gt;</code>
+              </div>
+            </dd>
+          </dl>
+        </section>
+      </div>
+      <section>
+        <h4>Algorithms</h4>
+        <section>
+          <h5>Get Supported Configuration</h5>
+          <p>Given a <a def-id="keysystems"></a> implementation <var>implementation</var>,
+            <a>MediaKeySystemConfiguration</a>
+            <var>candidate configuration</var>, and <var>origin</var>, this algorithm returns a
+            supported configuration or <code>NotSupported</code> as appropriate.
+          </p>
+          <p class="note">Unrecognized dictionary members in <var>candidate configuration</var> are
+            ignored per [[WEBIDL]] and will never reach this algorithm. Thus, they cannot be
+            considered as part of the configuration. </p>
+          <div class="note">
+            <p> For certain configurations, it may be required to obtain user consent or inform the
+              user. User Agents have some flexibility to determine whether consent is required for a
+              specific configuration and whether such consent may also apply to other
+              configurations. For example, consent to one configuration may also imply consent for
+              less powerful, more restricted configurations. Equally, a denial of consent for one
+              configuration may imply denial of consent for more powerful, less restricted
+              configurations. </p>
+            <p> Supported configurations, including supported audio and video codecs, may depend on
+              availability of optional capabilities such as <a
+                def-id="distinctive-identifier-maybe-plural"></a> and persistent state. The
+              following algorithm iteratively tries to find a configuration that is both supported
+              and has user consent (or does not need consent). </p>
+            <p> User Agents should reuse earlier consent responses, when appropriate, at least for
+              the duration of the <a def-id="requestMediaKeySystemAccess"></a> algorithm in order to
+              avoid repeated requests to the user for similar configurations. </p>
+            <p> The variable <var>restrictions</var> in the steps below represents the
+              configurations for which consent has been denied during the execution of this
+              algorithm or based on persisted consent information for the origin. It is used to
+              determine whether user consent for a candidate configuration or accumulated
+              configuration has been denied. Consent is denied for a accumulated configuration if
+              every derived configuration has already been denied. Internal representation of <var>
+                restrictions</var> is implementation-specific. </p>
+          </div>
+          <ol>
+            <li>
+              <p>Let <var>supported configuration</var> be <code>ConsentDenied</code>.</p>
+            </li>
+            <li>
+              <p>Initialize <var>restrictions</var> to indicate that no configurations have had user
+                consent denied.</p>
+            </li>
+            <li>
+              <p>Repeat the following step while <var>supported configuration</var> is <code>
+                  ConsentDenied</code>:</p>
+              <ol>
+                <li>
+                  <p> Let <var>supported configuration</var> and, if provided, <var>restrictions
+                    </var> be the result of executing the <a
+                      def-id="get-supported-configuration-and-consent-algorithm"></a> algorithm with
+                    <var>implementation</var>, <var>candidate configuration</var>, <var>restrictions
+                    </var> and <var>origin</var>. </p>
+                </li>
+              </ol>
+            </li>
+            <li>
+              <p>Return <var>supported configuration</var>.</p>
+            </li>
+          </ol>
+        </section>
+        <section>
+          <h5>Get Supported Configuration and Consent</h5>
+          <p>Given a <a def-id="keysystems"></a> implementation <var>implementation</var>,
+            <a>MediaKeySystemConfiguration</a>
+            <var>candidate configuration</var>, <var>restrictions</var> and <var>origin</var>, this
+            algorithm returns a supported configuration, <code>NotSupported</code>, or <code>
+              ConsentDenied</code> as appropriate and, in the <code>ConsentDenied</code> case, <var>
+              restrictions</var>.
+          </p>
+          <ol>
+            <li>
+              <p>Let <var>accumulated configuration</var> be a new
+                <a>MediaKeySystemConfiguration</a> dictionary.</p>
+            </li>
+            <li>
+              <p> Set the <a def-id="option-label"></a> member of <var>accumulated configuration
+                </var> to equal the <a def-id="option-label"></a> member of <var>candidate
+                  configuration</var>. </p>
+            </li>
+            <li>
+              <p>If the <a def-id="option-initDataTypes"></a> member of <var>candidate configuration
+                </var> is non-empty, run the following steps:</p>
+              <ol>
+                <li>
+                  <p>Let <var>supported types</var> be an empty sequence of DOMStrings.</p>
+                </li>
+                <li>
+                  <p>For each value in <var>candidate configuration</var>'s <a
+                      def-id="option-initDataTypes"></a> member:</p>
+                  <ol>
+                    <li>
+                      <p>Let <var>initDataType</var> be the value.</p>
+                    </li>
+                    <li>
+                      <p>If the <var>implementation</var> supports generating requests based on
+                        <var>initDataType</var>, add <var>initDataType</var> to <var>supported types
+                        </var>. String comparison is case-sensitive. The empty string is never
+                        supported. </p>
+                      <p class="note">The <var>initDataType</var> MUST be supported independent of
+                        content types in order to avoid unexpectedly rejecting the configuration in
+                        later steps. Support for <var>initDataType</var> includes both license
+                        generation and, when appropriate, extraction from media data. See <a
+                          href="#initialization-data-type-support-requirements">Initialization Data
+                          Type Support requirements</a>. </p>
+                    </li>
+                  </ol>
+                </li>
+                <li>
+                  <p>If <var>supported types</var> is empty, return <code>NotSupported</code>.</p>
+                </li>
+                <li>
+                  <p>Set the <a def-id="option-initDataTypes"></a> member of <var>accumulated
+                      configuration</var> to <var>supported types</var>.</p>
+                </li>
+              </ol>
+            </li>
+            <!-- Table of results for MediaKeysRequirement members based on implementation capabilities:
                               ||                        Implementation Capabilities                       |
                   Input Value ||     Only Supported     |   Only Not Supported   |          Both          |
                 ===========================================================================================
@@ -832,470 +1118,649 @@ partial interface Navigator {
                 "optional"    ||       "required"       |      "not-allowed"     | Depends on combination |
                 "not-allowed" ||       Return null      |      "not-allowed"     |      "not-allowed"     |
                -->
-              <li>
-                <p>
-                  Let <var>distinctive identifier requirement</var> be the value of <var>candidate configuration</var>'s <a def-id="option-distinctiveIdentifier"></a> member.
-                </p>
-              </li>
-              <li>
-                <p>
-                  If <var>distinctive identifier requirement</var> is <a def-id="requirement-optional"></a> and
-                  <a def-id="distinctive-identifiers"></a> are not allowed according to <var>restrictions</var>, set <var>distinctive identifier requirement</var>
-                  to <a def-id="requirement-not-allowed"></a>.
-                </p>
-              </li>
-              <li>
-                <p>Follow the steps for <var>distinctive identifier requirement</var> from the following list:</p>
-                <dl class="switch">
-                  <dt><a def-id="requirement-required"></a></dt>
-                  <dd>
-                    <p>If the <var>implementation</var> does not support <a href="#uses-distinctive-identifiers">use of Distinctive Identifier(s)</a> in combination with <var>accumulated configuration</var> and <var>restrictions</var>, return <code>NotSupported</code>.</p>
-                    <!-- TODO: Find a better descriptive model for this than "combination."
-                         See the first three comment threads starting with https://github.com/w3c/encrypted-media/pull/165#discussion_r63112757. -->
-                  </dd>
-                  <dt><a def-id="requirement-optional"></a></dt>
-                  <dd>
-                    <p>Continue with the following steps.</p>
-                  </dd>
-                  <dt><a def-id="requirement-not-allowed"></a></dt>
-                  <dd>
-                    <p>If the <var>implementation</var> requires <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">use Distinctive Identifier(s) or Distinctive Permanent Identifier(s)</a> in combination with <var>accumulated configuration</var> and <var>restrictions</var>, return <code>NotSupported</code>.</p>
-                  </dd>
-                </dl>
-                <div class="note">
-                  <p>
-                    The combination of <var>accumulated configuration</var> and <var>restrictions</var> means all the possible configurations that
-                    include everything in <var>accumulated configuration</var> and that are not denied according to <var>restrictions</var>.
-                  </p>
-                  <p>
-                    A feature is supported by an implementation with this combination if the implementation supports at least one of the configurations
-                    in the combination with the feature.
-                  </p>
-                  <p>
-                    A feature is required by an implementtion with this combination if all configurations in the combination that are suported by the implementation
-                    include the feature.
-                  </p>
-                </div>
-              </li>
-              <li>
-                <p>
-                  Set the <a def-id="option-distinctiveIdentifier"></a> member of <var>accumulated configuration</var> to equal <var>distinctive identifier requirement</var>.
-                </p>
-              </li>
-              <li>
-                <p>
-                  Let <var>persistent state requirement</var> be equal to the value of <var>candidate configuration</var>'s <a def-id="option-persistentState"></a> member.
-                </p>
-              </li>
-              <li>
-                <p>
-                  If <var>persistent state requirement</var> is <a def-id="requirement-optional"></a> and persisting state is not allowed according to
-                  <var>restrictions</var>, set <var>persistent state requirement</var> to <a def-id="requirement-not-allowed"></a>.
-                </p>
-              </li>
-              <li><p>Follow the steps for <var>persistent state requirement</var> from the following list:</p>
-                <dl class="switch">
-                  <dt><a def-id="requirement-required"></a></dt>
-                  <dd>
-                    <p>If the <var>implementation</var> does not support persisting state in combination with <var>accumulated configuration</var> and <var>restrictions</var>, return <code>NotSupported</code>.</p>
-                  </dd>
-                  <dt><a def-id="requirement-optional"></a></dt>
-                  <dd>
-                    <p>
-                      Continue with the following steps.
-                    </p>
-                  </dd>
-                  <dt><a def-id="requirement-not-allowed"></a></dt>
-                  <dd>
-                    <p>If the <var>implementation</var> requires persisting state in combination with <var>accumulated configuration</var> and <var>restrictions</var>, return <code>NotSupported</code>.</p>
-                  </dd>
-                </dl>
-              </li>
-              <li>
-                <p>
-                  Set the <a def-id="option-persistentState"></a> member of <var>accumulated configuration</var> to equal the value of <var>persistent state requirement</var>.
-                </p>
-              </li>
-              <li><p>Follow the steps for the first matching condition from the following list:</p>
-                <dl class="switch">
-                  <dt>If the <a def-id="option-sessionTypes"></a> member is <a def-id="present-dictionary-member"></a> [[WEBIDL]] in <var>candidate configuration</var></dt>
-                  <dd>
-                    <p>Let <var>session types</var> be <var>candidate configuration</var>'s <a def-id="option-sessionTypes"></a> member.</p>
-                  </dd>
-                  <dt>Otherwise</dt>
-                  <dd>
-                    <p>Let <var>session types</var> be <code>[ <a def-id="temporary-session"></a> ]</code>.</p>
-                  </dd>
-                </dl>
-              </li>
-              <li><p>For each value in <var>session types</var>:</p>
-                <ol>
-                  <li><p>Let <var>session type</var> be the value.</p></li>
-                  <li>
-                    <p>
-                      If <var>accumulated configuration</var>'s <a def-id="option-persistentState"></a> value is <a def-id="requirement-not-allowed"></a> and the <a def-id="is-persistent-session-type-algorithm"></a> algorithm returns <code>true</code> for <var>session type</var> return <code>NotSupported</code>.
-                    </p>
-                  </li>
-                  <li>
-                    <p>If the <var>implementation</var> does not support <var>session type</var> in combination with <var>accumulated configuration</var> and <var>restrictions</var> for other reasons, return <code>NotSupported</code>.</p>
-                  </li>
-                  <li><p>If <var>accumulated configuration</var>'s <a def-id="option-persistentState"></a> value is <a def-id="requirement-optional"></a> and the result of running the <a def-id="is-persistent-session-type-algorithm"></a> algorithm on <var>session type</var> is <code>true</code>, change <var>accumulated configuration</var>'s <a def-id="option-persistentState"></a> value to <a def-id="requirement-required"></a>.</p></li>
-                </ol>
-              </li>
-              <li><p>Set the <a def-id="option-sessionTypes"></a> member of <var>accumulated configuration</var> to <var>session types</var>.</p></li>
-              
-              <li>
-                <p>
-                  If the <a def-id="option-videoCapabilities"></a> and <a def-id="option-audioCapabilities"></a> members in <var>candidate configuration</var>
-                  are both empty, return <code>NotSupported</code>.
-                </p>
-              </li>
-
-              <li>
-                <dl class="switch">
-                  <dt>If the <a def-id="option-videoCapabilities"></a> member in <var>candidate configuration</var> is non-empty:</dt>
-                  <dd>
-                    <ol>
-                      <li><p>Let <var>video capabilities</var> be the result of executing the <a def-id="get-supported-capabilities-for-audio-video-type-algorithm"></a> algorithm on Video, <var>candidate configuration</var>'s <a def-id="option-videoCapabilities"></a> member, <var>accumulated configuration</var>, and <var>restrictions</var>.</p></li>
-                      <li><p>If <var>video capabilities</var> is <code>null</code>, return <code>NotSupported</code>.</p></li><!-- Video capabilities were specified, but none were supported. -->
-                      <li><p>Set the <a def-id="option-videoCapabilities"></a> member of <var>accumulated configuration</var> to <var>video capabilities</var>.</p></li>
-                    </ol>
-                  </dd>
-                  <dt>Otherwise:</dt>
-                  <dd><p>Set the <a def-id="option-videoCapabilities"></a> member of <var>accumulated configuration</var> to an empty sequence.</p></dd>
-                </dl>
-              </li>
-
-              <li>
-                <dl class="switch">
-                  <dt>If the <a def-id="option-audioCapabilities"></a> member in <var>candidate configuration</var> is non-empty:</dt>
-                  <dd>
-                    <ol>
-                      <li><p>Let <var>audio capabilities</var> be the result of executing the <a def-id="get-supported-capabilities-for-audio-video-type-algorithm"></a> algorithm on Audio, <var>candidate configuration</var>'s <a def-id="option-audioCapabilities"></a> member, <var>accumulated configuration</var>, and <var>restrictions</var>.</p></li>
-                      <li><p>If <var>audio capabilities</var> is <code>null</code>, return <code>NotSupported</code>.</p></li><!-- Audio capabilities were specified, but none were supported. -->
-                      <li><p>Set the <a def-id="option-audioCapabilities"></a> member of <var>accumulated configuration</var> to <var>audio capabilities</var>.</p></li>
-                    </ol>
-                  </dd>
-                  <dt>Otherwise:</dt>
-                  <dd><p>Set the <a def-id="option-audioCapabilities"></a> member of <var>accumulated configuration</var> to an empty sequence.</p></dd>
-                </dl>
-              </li>
-
-              <!-- Replace "optional" values in the combined configuration before checking permissions and for the value exposed by MediaKeySystemAccess. -->
-              <li><p>If <var>accumulated configuration</var>'s <a def-id="option-distinctiveIdentifier"></a> value is <a def-id="requirement-optional"></a>, follow the steps for the first matching condition from the following list:</p>
-                <dl class="switch">
-                  <dt>If the <var>implementation</var> requires <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">use Distinctive Identifier(s) or Distinctive Permanent Identifier(s)</a> for any of the combinations in <var>accumulated configuration</var></dt>
-                  <dd>
-                    <p>Change <var>accumulated configuration</var>'s <a def-id="option-distinctiveIdentifier"></a> value to <a def-id="requirement-required"></a>.</p>
-                  </dd>
-                  <dt>Otherwise</dt>
-                  <dd>
-                    <p>Change <var>accumulated configuration</var>'s <a def-id="option-distinctiveIdentifier"></a> value to <a def-id="requirement-not-allowed"></a>.</p>
-                  </dd>
-                </dl>
-              </li>
-
-              <li><p>If <var>accumulated configuration</var>'s <a def-id="option-persistentState"></a> value is <a def-id="requirement-optional"></a>, follow the steps for the first matching condition from the following list:</p>
-                <dl class="switch">
-                  <dt>If the <var>implementation</var> requires persisting state for any of the combinations in <var>accumulated configuration</var></dt>
-                  <dd>
-                    <p>Change <var>accumulated configuration</var>'s <a def-id="option-persistentState"></a> value to <a def-id="requirement-required"></a>.</p>
-                  </dd>
-                  <dt>Otherwise</dt>
-                  <dd>
-                    <p>Change <var>accumulated configuration</var>'s <a def-id="option-persistentState"></a> value to <a def-id="requirement-not-allowed"></a>.</p>
-                  </dd>
-                </dl>
-              </li>
-
-              <li><p>If <var>implementation</var> in the configuration specified by the combination of the values in <var>accumulated configuration</var> is not supported or not allowed in the <var>origin</var>, return <code>NotSupported</code>.</p>
-                <p class="note">In this step, "supported" includes the implementation being available for use when this algorithm returns, not just user agent support for such an implementation.</p>
-              </li>
-
-              <li>
-                <p>
-                  If <var>accumulated configuration</var>'s <a def-id="option-distinctiveIdentifier"></a> value is <a def-id="requirement-required"></a> and
-                  the <a def-id="distinctive-identifier-maybe-plural"></a> associated with <var>accumulated configuration</var> are not <a href="#per-origin-per-profile-identifiers">unique per origin and profile</a> and
-                  <a href="#allow-identifiers-cleared">clearable</a>:
-                </p>
-                <ol>
-                  <li>
-                    <p>
-                      Update <var>restrictions</var> to reflect that all configurations described by <var>accumulated configuration</var>
-                      do not have user consent.
-                    </p>
-                  </li>
-                  <li>
-                    <p>Return <code>ConsentDenied</code> and <var>restrictions</var>.</p>
-                  </li>
-                </ol>
-                <div class="note">
-                  <p>
-                  The "unique per origin and profile" and "clearable" conditions cannot be false in a compliant implementation because implementations MUST <a href="#per-origin-per-profile-identifiers">use per-origin per-profile identifiers</a> and <a href="#allow-identifiers-cleared">allow the user to clear identifier</a>.
-                  </p>
-                </div>
-              </li>
-              <li>
-                <p>
-                  Let <var>consent status</var> and <var>updated restrictions</var> be the result of running the <a def-id="get-consent-status-algorithm"></a> algorithm on <var>accumulated configuration</var>, <var>restrictions</var> and <var>origin</var> and follow the steps for the value of <var>consent status</var> from the following list:
-                </p>
-
-                <dl class="switch">
-                  <dt><code>ConsentDenied</code>:</dt>
-                  <dd>
-                    <p>
-                      Return <code>ConsentDenied</code> and <var>updated restrictions</var>.
-                    </p>
-                  </dd><dt><code>InformUser</code>:</dt>
-                  <dd>
-                    <p>
-                      Inform the user that <var>accumulated configuration</var> is in use in the <var>origin</var> including, specifically, the information
-                      that <a def-id="distinctive-identifier-maybe-plural"></a> and/or <a def-id="distinctive-permanent-identifier-maybe-plural"></a> as appropriate will be used if the <a def-id="option-distinctiveIdentifier"></a>
-                      member of <var>accumulated configuration</var> is <a def-id="requirement-required"></a>. Continue to the next step.
-                    </p>
-                  </dd>
-                  <dt><code>Allowed</code>:</dt>
-                  <dd>
-                    <p>
-                      Continue to the next step.
-                    </p>
-                  </dd>
-                </dl>
-              </li>
-
-              <li><p>Return <var>accumulated configuration</var>.</p></li>
-            </ol>
-          </section>
-
-          <section>
-            <h5>Get Supported Capabilities for Audio/Video Type</h5>
-            <p>Given an <var>audio/video type</var>, <a>MediaKeySystemMediaCapability</a> sequence <var>requested media capabilities</var>, <a>MediaKeySystemConfiguration</a> <var>accumulated configuration</var>, and <var>restrictions</var>, this algorithm returns a sequence of supported <a>MediaKeySystemMediaCapability</a> values for this audio/video type or <code>null</code> as appropriate.</p>
-            <ol>
-              <li><p>Let <var>local accumulated configuration</var> be a local copy of <var>accumulated configuration</var>.</p></li>
-              <li><p>Let <var>supported media capabilities</var> be an empty sequence of <a>MediaKeySystemMediaCapability</a> dictionaries.</p></li>
-              <li><p>For each <var>requested media capability</var> in <var>requested media capabilities</var>:</p>
-                <ol>
-                  <li><p>Let <var>content type</var> be <var>requested media capability</var>'s <a def-id="capability-contentType"></a> member.</p></li>
-                  <li><p>Let <var>encryption scheme</var> be <var>requested media capability</var>’s <a def-id="capability-encryptionScheme"></a> member.</p></li>
-                  <li><p>Let <var>robustness</var> be <var>requested media capability</var>'s <a def-id="capability-robustness"></a> member.</p></li>
-                  <li><p>If <var>content type</var> is the empty string, return <code>null</code>.</p></li><!-- Invalid input. -->
-                  <li><p>If <var>content type</var> is not a <a def-id="valid-media-mime-type"></a> or is unrecognized, continue to the next iteration.</p></li>
-                  <li><p>Let <var>container</var> be the container type specified by <var>content type</var>.</p></li>
-                  <li><p>If the user agent does not support <var>container</var>, continue to the next iteration. The case-sensitivity of string comparisons is determined by the appropriate RFC.</p>
-                    <p class="note">Per RFC 6838 [[RFC6838]], "Both top-level type and subtype names are case-insensitive."</p>
-                  </li>
-                  <li><p>Let <var>parameters</var> be the RFC 6381 [[RFC6381]] parameters, if any, specified by <var>content type</var>.</p></li>
-                  <li><p>If the user agent does not recognize one or more <var>parameters</var>, continue to the next iteration.</p></li>
-                  <li><p>Let <var>media types</var> be the set of codecs and codec constraints specified by <var>parameters</var>. The case-sensitivity of string comparisons is determined by the appropriate RFC or other specification.</p>
-                    <p class="note">Case-sensitive string comparison is RECOMMENDED because RFC 6381 [[RFC6381]] says, "Values are case sensitive" for some formats.</p>
-                  </li>
-                  <li>
-                    <p>
-                      If <var>media types</var> is empty:
-                    </p>
-                    <dl class="switch">
-                      <dt>If <var>container</var> normatively implies a specific set of codecs and codec constraints:</dt>
-                      <dd>
-                        <p>
-                          Let <var>parameters</var> be that set.
-                        </p>
-                      </dd>
-                      <dt>Otherwise:</dt>
-                      <dd>
-                        <p>
-                          Continue to the next iteration.
-                        </p>
-                      </dd>
-                    </dl>
-                  </li>
-                  <li><p>If <var>content type</var> is not strictly a <var>audio/video type</var>, continue to the next iteration.</p>
-                    <p class="note">For example, if <var>audio/video type</var> is Video and the top-level type is not "video" or <var>media types</var> contains non-video codecs.</p>
-                  </li>
-                  <li><p>If <var>encryption scheme</var> is non-null and is not recognized or not supported by <var>implementation</var>, continue to the next iteration.</p></li>
-                  <li><p>If <var>robustness</var> is not the empty string and contains an unrecognized value or a value not supported by <var>implementation</var>, continue to the next iteration. String comparison is case-sensitive.</p></li>
-                  <li><p>If the user agent and <var>implementation</var> definitely support playback of encrypted <a def-id="media-data"></a> for the combination of <var>container</var>, <var>media types</var>, <var>encryption scheme</var>, <var>robustness</var> and <var>local accumulated configuration</var> in combination with <var>restrictions</var>:</p>
-                    <p class="note"><var>requested media capability</var> (content type and robustness) must be supported when used together with all previously added requested media capabilities.</p>
-                    <ol>
-                      <li>
-                        <p>
-                          Add <var>requested media capability</var> to <var>supported media capabilities</var>.
-                        </p>
-                        <p class="note">
-                          This step ensures that the values of the members of entries in <var>supported media capabilities</var> are exactly the strings supplied in
-                          <var>requested media capability</var> without modification by the User Agent.
-                        </p>
-                      </li>
-                      <li>
-                        <dl class="switch">
-                          <dt>If <var>audio/video type</var> is Video:</dt>
-                          <dd>
-                            <p>
-                              Add <var>requested media capability</var> to the <a def-id="option-videoCapabilities"></a> member of <var>local accumulated configuration</var>.
-                            </p>
-                          </dd>
-                          <dt>If <var>audio/video type</var> is Audio:</dt>
-                          <dd>
-                            <p>
-                              Add <var>requested media capability</var> to the <a def-id="option-audioCapabilities"></a> member of <var>local accumulated configuration</var>.
-                            </p>
-                          </dd>
-                        </dl>
-                        <p class="note">
-                          This step ensures that configurations are always checked with configurations from previous iterations, including from previous calls to this algorithm.
-                          Otherwise, only configurations from previous calls to this algorithm would be checked in subsequent calls.
-                        </p>
-                      </li>
-                    </ol>
-                  </li>
-                </ol>
-              </li>
-              <li><p>If <var>supported media capabilities</var> is empty, return <code>null</code>.</p>
-                <p class="note">None of the <a>MediaKeySystemMediaCapability</a> elements in <var>requested media capabilities</var> is supported in combination with <var>accumulated configuration</var>.</p>
-              </li>
-              <li><p>Return <var>supported media capabilities</var>.</p></li>
-            </ol>
-          </section>
-
-          <section>
-            <h5>Get Consent Status</h5>
-            <p>
-              Given an <var>accumulated configuration</var>, <var>restrictions</var> and <var>origin</var>, this algorithm returns the consent status for
-              <var>accumulated configuration</var> and <var>origin</var> as one of <code>ConsentDenied</code>, <code>InformUser</code> or <code>Allowed</code>,
-              together with an updated value for <var>restrictions</var> in the <code>ConsentDenied</code> case.
-            </p>
-            <div class="note">
-              <p>
-                Consent status for <var>accumulated configuration</var> depends at least on the value of the <a def-id="option-distinctiveIdentifier"></a> member of
-                <var>accumulated configuration</var>.
+            <li>
+              <p> Let <var>distinctive identifier requirement</var> be the value of <var>candidate
+                  configuration</var>'s <a def-id="option-distinctiveIdentifier"></a> member. </p>
+            </li>
+            <li>
+              <p> If <var>distinctive identifier requirement</var> is <a
+                  def-id="requirement-optional"></a> and <a def-id="distinctive-identifiers"></a>
+                are not allowed according to <var>restrictions</var>, set <var>distinctive
+                  identifier requirement</var> to <a def-id="requirement-not-allowed"></a>. </p>
+            </li>
+            <li>
+              <p>Follow the steps for <var>distinctive identifier requirement</var> from the
+                following list:</p>
+              <dl class="switch">
+                <dt><a def-id="requirement-required"></a></dt>
+                <dd>
+                  <p>If the <var>implementation</var> does not support <a
+                      href="#uses-distinctive-identifiers">use of Distinctive Identifier(s)</a> in
+                    combination with <var>accumulated configuration</var> and <var>restrictions
+                    </var>, return <code>NotSupported</code>.</p>
+                  <!-- TODO: Find a better descriptive model for this than "combination."
+                       See the first three comment threads starting with
+                       https://github.com/w3c/encrypted-media/pull/165#discussion_r63112757. -->
+                </dd>
+                <dt><a def-id="requirement-optional"></a></dt>
+                <dd>
+                  <p>Continue with the following steps.</p>
+                </dd>
+                <dt><a def-id="requirement-not-allowed"></a></dt>
+                <dd>
+                  <p>If the <var>implementation</var> requires <a
+                      href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">use
+                      Distinctive Identifier(s) or Distinctive Permanent Identifier(s)</a> in
+                    combination with <var>accumulated configuration</var> and <var>restrictions
+                    </var>, return <code>NotSupported</code>.</p>
+                </dd>
+              </dl>
+              <div class="note">
+                <p> The combination of <var>accumulated configuration</var> and <var>restrictions
+                  </var> means all the possible configurations that include everything in <var>
+                    accumulated configuration</var> and that are not denied according to <var>
+                    restrictions</var>. </p>
+                <p> A feature is supported by an implementation with this combination if the
+                  implementation supports at least one of the configurations in the combination with
+                  the feature. </p>
+                <p> A feature is required by an implementtion with this combination if all
+                  configurations in the combination that are suported by the implementation include
+                  the feature. </p>
+              </div>
+            </li>
+            <li>
+              <p> Set the <a def-id="option-distinctiveIdentifier"></a> member of <var>accumulated
+                  configuration</var> to equal <var>distinctive identifier requirement</var>. </p>
+            </li>
+            <li>
+              <p> Let <var>persistent state requirement</var> be equal to the value of <var>
+                  candidate configuration</var>'s <a def-id="option-persistentState"></a> member.
               </p>
-              <p>
-                Previous consent for <var>accumulated configuration</var> with <a def-id="option-distinctiveIdentifier"></a>
-                set to <a def-id="requirement-not-allowed"></a> does not imply consent for the same configuration with <a def-id="option-distinctiveIdentifier"></a>
-                set to <a def-id="requirement-optional"></a> or <a def-id="requirement-required"></a>.
+            </li>
+            <li>
+              <p> If <var>persistent state requirement</var> is <a
+                  def-id="requirement-optional"></a> and persisting state is not allowed according
+                to <var>restrictions</var>, set <var>persistent state requirement</var> to <a
+                  def-id="requirement-not-allowed"></a>. </p>
+            </li>
+            <li>
+              <p>Follow the steps for <var>persistent state requirement</var> from the following
+                list:</p>
+              <dl class="switch">
+                <dt><a def-id="requirement-required"></a></dt>
+                <dd>
+                  <p>If the <var>implementation</var> does not support persisting state in
+                    combination with <var>accumulated configuration</var> and <var>restrictions
+                    </var>, return <code>NotSupported</code>.</p>
+                </dd>
+                <dt><a def-id="requirement-optional"></a></dt>
+                <dd>
+                  <p> Continue with the following steps. </p>
+                </dd>
+                <dt><a def-id="requirement-not-allowed"></a></dt>
+                <dd>
+                  <p>If the <var>implementation</var> requires persisting state in combination with
+                    <var>accumulated configuration</var> and <var>restrictions</var>, return <code>
+                      NotSupported</code>.</p>
+                </dd>
+              </dl>
+            </li>
+            <li>
+              <p> Set the <a def-id="option-persistentState"></a> member of <var>accumulated
+                  configuration</var> to equal the value of <var>persistent state requirement</var>.
               </p>
-            </div>
-            <ol>
-              <li>
-                <p>
-                  If there is persisted denial for <var>origin</var> indicating that <var>accumulated configuration</var> is not allowed, run the following steps:
-                </p>
-                <ol>
-                  <li>
-                    <p>Update <var>restrictions</var> to reflect the configurations for which consent has been denied.</p>
-                  </li>
-                  <li>
-                    <p>Return <code>ConsentDenied</code> and <var>restrictions</var>.</p>
-                  </li>
-                </ol>
-              </li>
-              <li>
-                <p>
-                  If there is persisted consent for <var>origin</var> indicating <var>accumulated configuration</var> is allowed, return <code>Allowed</code>.
-                </p>
-              </li>
-              <li>
-                <p>
-                  If any of the following are true:
-                </p>
-                <ul>
-                  <li>
-                    <p>
-                      The <a def-id="option-distinctiveIdentifier"></a> member of <var>accumulated configuration</var> is not
-                      <a def-id="requirement-not-allowed"></a> and the combination of the User Agent, <var>implementation</var>
-                      and <var>accumulated configuration</var> does not follow all the recommendations of
-                      <a href="#allow-persistent-data-cleared">Allow Persistent Data to Be Cleared</a> with respect to
-                      <a def-id="distinctive-identifier-maybe-plural"></a>.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      The user agent requires explicit user consent for the <var>accumulated configuration</var> for other reasons.
-                    </p>
-                    <p class="note">
-                      Another reason for requiring explicit user consent may be due to the security properties of the CDM implementation.
-                    </p>
-                  </li>
-                </ul>
-                <p>then run the following steps:</p>
-                <ol>
-                  <li>
-                    <p>
-                      Request user consent to use <var>accumulated configuration</var> in the <var>origin</var> and wait for the user response.
-                    </p>
-                    <p>
-                      The consent MUST include consent to use a <a def-id="distinctive-identifier-maybe-plural"></a> and/or <a def-id="distinctive-permanent-identifier-maybe-plural"></a> as appropriate if
-                      <var>accumulated configuration</var>'s <a def-id="option-distinctiveIdentifier"></a> member is <a def-id="requirement-required"></a>.
-                    </p>
-                    <div class="note">
-
-                      <p>User consent to use <var>accumulated configuration</var> is specific to the <var>origin</var> and may be limited to configurations sharing certain properties with <var>accumulated configuration</var>.</p>
-                    </div>
-                  </li>
-                  <li>
-                    <p>
-                      If consent was denied, run the following steps:
-                    </p>
-                    <ol>
-                      <li><p>Update <var>restrictions</var> to reflect the configurations for which consent was denied.</p></li>
-                      <li><p>Return <code>ConsentDenied</code> and <var>restrictions</var>.</p></li>
-                    </ol>
-                  </li>
-                </ol>
-              </li>
-              <li>
-                <p>
-                  If the <a def-id="option-distinctiveIdentifier"></a> member of <var>accumulated configuration</var> is not
-                  <a def-id="requirement-not-allowed"></a>, return <code>InformUser</code>.
-                </p>
-              </li>
-              <li>
-                <p>
-                  If the user agent requires informing the user for the <var>accumulated configuration</var> for other reasons, return <code>InformUser</code>.
-                </p>
-              </li>
-              <li>
-                <p>Return <code>Allowed</code>.</p>
-              </li>
-            </ol>
-          </section>
+            </li>
+            <li>
+              <p>Follow the steps for the first matching condition from the following list:</p>
+              <dl class="switch">
+                <dt>If the <a def-id="option-sessionTypes"></a> member is <a
+                    def-id="present-dictionary-member"></a> [[WEBIDL]] in <var>candidate
+                    configuration</var>
+                </dt>
+                <dd>
+                  <p>Let <var>session types</var> be <var>candidate configuration</var>'s <a
+                      def-id="option-sessionTypes"></a> member.</p>
+                </dd>
+                <dt>Otherwise</dt>
+                <dd>
+                  <p>Let <var>session types</var> be <code>[ <a def-id="temporary-session"></a> ]
+                    </code>.</p>
+                </dd>
+              </dl>
+            </li>
+            <li>
+              <p>For each value in <var>session types</var>:</p>
+              <ol>
+                <li>
+                  <p>Let <var>session type</var> be the value.</p>
+                </li>
+                <li>
+                  <p> If <var>accumulated configuration</var>'s <a
+                      def-id="option-persistentState"></a> value is <a
+                      def-id="requirement-not-allowed"></a> and the <a
+                      def-id="is-persistent-session-type-algorithm"></a> algorithm returns <code>
+                      true</code> for <var>session type</var> return <code>NotSupported</code>. </p>
+                </li>
+                <li>
+                  <p>If the <var>implementation</var> does not support <var>session type</var> in
+                    combination with <var>accumulated configuration</var> and <var>restrictions
+                    </var> for other reasons, return <code>NotSupported</code>.</p>
+                </li>
+                <li>
+                  <p>If <var>accumulated configuration</var>'s <a
+                      def-id="option-persistentState"></a> value is <a
+                      def-id="requirement-optional"></a> and the result of running the <a
+                      def-id="is-persistent-session-type-algorithm"></a> algorithm on <var>session
+                      type</var> is <code>true</code>, change <var>accumulated configuration</var>'s
+                    <a def-id="option-persistentState"></a> value to <a
+                      def-id="requirement-required"></a>.</p>
+                </li>
+              </ol>
+            </li>
+            <li>
+              <p>Set the <a def-id="option-sessionTypes"></a> member of <var>accumulated
+                  configuration</var> to <var>session types</var>.</p>
+            </li>
+            <li>
+              <p> If the <a def-id="option-videoCapabilities"></a> and <a
+                  def-id="option-audioCapabilities"></a> members in <var>candidate configuration
+                </var> are both empty, return <code>NotSupported</code>. </p>
+            </li>
+            <li>
+              <dl class="switch">
+                <dt>If the <a def-id="option-videoCapabilities"></a> member in <var>candidate
+                    configuration</var> is non-empty:</dt>
+                <dd>
+                  <ol>
+                    <li>
+                      <p>Let <var>video capabilities</var> be the result of executing the <a
+                          def-id="get-supported-capabilities-for-audio-video-type-algorithm"></a>
+                        algorithm on Video, <var>candidate configuration</var>'s <a
+                          def-id="option-videoCapabilities"></a> member, <var>accumulated
+                          configuration</var>, and <var>restrictions</var>.</p>
+                    </li>
+                    <li>
+                      <p>If <var>video capabilities</var> is <code>null</code>, return <code>
+                          NotSupported</code>.</p>
+                    </li><!-- Video capabilities were specified, but none were supported. -->
+                    <li>
+                      <p>Set the <a def-id="option-videoCapabilities"></a> member of <var>
+                          accumulated configuration</var> to <var>video capabilities</var>.</p>
+                    </li>
+                  </ol>
+                </dd>
+                <dt>Otherwise:</dt>
+                <dd>
+                  <p>Set the <a def-id="option-videoCapabilities"></a> member of <var>accumulated
+                      configuration</var> to an empty sequence.</p>
+                </dd>
+              </dl>
+            </li>
+            <li>
+              <dl class="switch">
+                <dt>If the <a def-id="option-audioCapabilities"></a> member in <var>candidate
+                    configuration</var> is non-empty:</dt>
+                <dd>
+                  <ol>
+                    <li>
+                      <p>Let <var>audio capabilities</var> be the result of executing the <a
+                          def-id="get-supported-capabilities-for-audio-video-type-algorithm"></a>
+                        algorithm on Audio, <var>candidate configuration</var>'s <a
+                          def-id="option-audioCapabilities"></a> member, <var>accumulated
+                          configuration</var>, and <var>restrictions</var>.</p>
+                    </li>
+                    <li>
+                      <p>If <var>audio capabilities</var> is <code>null</code>, return <code>
+                          NotSupported</code>.</p>
+                    </li><!-- Audio capabilities were specified, but none were supported. -->
+                    <li>
+                      <p>Set the <a def-id="option-audioCapabilities"></a> member of <var>
+                          accumulated configuration</var> to <var>audio capabilities</var>.</p>
+                    </li>
+                  </ol>
+                </dd>
+                <dt>Otherwise:</dt>
+                <dd>
+                  <p>Set the <a def-id="option-audioCapabilities"></a> member of <var>accumulated
+                      configuration</var> to an empty sequence.</p>
+                </dd>
+              </dl>
+            </li>
+            <!-- Replace "optional" values in the combined configuration before checking permissions
+                 and for the value exposed by MediaKeySystemAccess. -->
+            <li>
+              <p>If <var>accumulated configuration</var>'s <a
+                  def-id="option-distinctiveIdentifier"></a> value is <a
+                  def-id="requirement-optional"></a>, follow the steps for the first matching
+                condition from the following list:</p>
+              <dl class="switch">
+                <dt>If the <var>implementation</var> requires <a
+                    href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">use
+                    Distinctive Identifier(s) or Distinctive Permanent Identifier(s)</a> for any of
+                  the combinations in <var>accumulated configuration</var>
+                </dt>
+                <dd>
+                  <p>Change <var>accumulated configuration</var>'s <a
+                      def-id="option-distinctiveIdentifier"></a> value to <a
+                      def-id="requirement-required"></a>.</p>
+                </dd>
+                <dt>Otherwise</dt>
+                <dd>
+                  <p>Change <var>accumulated configuration</var>'s <a
+                      def-id="option-distinctiveIdentifier"></a> value to <a
+                      def-id="requirement-not-allowed"></a>.</p>
+                </dd>
+              </dl>
+            </li>
+            <li>
+              <p>If <var>accumulated configuration</var>'s <a def-id="option-persistentState"></a>
+                value is <a def-id="requirement-optional"></a>, follow the steps for the first
+                matching condition from the following list:</p>
+              <dl class="switch">
+                <dt>If the <var>implementation</var> requires persisting state for any of the
+                  combinations in <var>accumulated configuration</var>
+                </dt>
+                <dd>
+                  <p>Change <var>accumulated configuration</var>'s <a
+                      def-id="option-persistentState"></a> value to <a
+                      def-id="requirement-required"></a>.</p>
+                </dd>
+                <dt>Otherwise</dt>
+                <dd>
+                  <p>Change <var>accumulated configuration</var>'s <a
+                      def-id="option-persistentState"></a> value to <a
+                      def-id="requirement-not-allowed"></a>.</p>
+                </dd>
+              </dl>
+            </li>
+            <li>
+              <p>If <var>implementation</var> in the configuration specified by the combination of
+                the values in <var>accumulated configuration</var> is not supported or not allowed
+                in the <var>origin</var>, return <code>NotSupported</code>.</p>
+              <p class="note">In this step, "supported" includes the implementation being available
+                for use when this algorithm returns, not just user agent support for such an
+                implementation.</p>
+            </li>
+            <li>
+              <p> If <var>accumulated configuration</var>'s <a
+                  def-id="option-distinctiveIdentifier"></a> value is <a
+                  def-id="requirement-required"></a> and the <a
+                  def-id="distinctive-identifier-maybe-plural"></a> associated with <var>accumulated
+                  configuration</var> are not <a href="#per-origin-per-profile-identifiers">unique
+                  per origin and profile</a> and <a href="#allow-identifiers-cleared">clearable</a>:
+              </p>
+              <ol>
+                <li>
+                  <p> Update <var>restrictions</var> to reflect that all configurations described by
+                    <var>accumulated configuration</var> do not have user consent. </p>
+                </li>
+                <li>
+                  <p>Return <code>ConsentDenied</code> and <var>restrictions</var>.</p>
+                </li>
+              </ol>
+              <div class="note">
+                <p> The "unique per origin and profile" and "clearable" conditions cannot be false
+                  in a compliant implementation because implementations MUST <a
+                    href="#per-origin-per-profile-identifiers">use per-origin per-profile
+                    identifiers</a> and <a href="#allow-identifiers-cleared">allow the user to clear
+                    identifier</a>. </p>
+              </div>
+            </li>
+            <li>
+              <p> Let <var>consent status</var> and <var>updated restrictions</var> be the result of
+                running the <a def-id="get-consent-status-algorithm"></a> algorithm on <var>
+                  accumulated configuration</var>, <var>restrictions</var> and <var>origin</var> and
+                follow the steps for the value of <var>consent status</var> from the following list:
+              </p>
+              <dl class="switch">
+                <dt>
+                  <code>ConsentDenied</code>:
+                </dt>
+                <dd>
+                  <p> Return <code>ConsentDenied</code> and <var>updated restrictions</var>. </p>
+                </dd>
+                <dt>
+                  <code>InformUser</code>:
+                </dt>
+                <dd>
+                  <p> Inform the user that <var>accumulated configuration</var> is in use in the
+                    <var>origin</var> including, specifically, the information that <a
+                      def-id="distinctive-identifier-maybe-plural"></a> and/or <a
+                      def-id="distinctive-permanent-identifier-maybe-plural"></a> as appropriate
+                    will be used if the <a def-id="option-distinctiveIdentifier"></a> member of
+                    <var>accumulated configuration</var> is <a def-id="requirement-required"></a>.
+                    Continue to the next step. </p>
+                </dd>
+                <dt>
+                  <code>Allowed</code>:
+                </dt>
+                <dd>
+                  <p> Continue to the next step. </p>
+                </dd>
+              </dl>
+            </li>
+            <li>
+              <p>Return <var>accumulated configuration</var>.</p>
+            </li>
+          </ol>
+        </section>
+        <section>
+          <h5>Get Supported Capabilities for Audio/Video Type</h5>
+          <p>Given an <var>audio/video type</var>, <a>MediaKeySystemMediaCapability</a> sequence
+            <var>requested media capabilities</var>, <a>MediaKeySystemConfiguration</a>
+            <var>accumulated configuration</var>, and <var>restrictions</var>, this algorithm
+            returns a sequence of supported <a>MediaKeySystemMediaCapability</a> values for this
+            audio/video type or <code>null</code> as appropriate.
+          </p>
+          <ol>
+            <li>
+              <p>Let <var>local accumulated configuration</var> be a local copy of <var>accumulated
+                  configuration</var>.</p>
+            </li>
+            <li>
+              <p>Let <var>supported media capabilities</var> be an empty sequence of
+                <a>MediaKeySystemMediaCapability</a> dictionaries.</p>
+            </li>
+            <li>
+              <p>For each <var>requested media capability</var> in <var>requested media capabilities
+                </var>:</p>
+              <ol>
+                <li>
+                  <p>Let <var>content type</var> be <var>requested media capability</var>'s <a
+                      def-id="capability-contentType"></a> member.</p>
+                </li>
+                <li>
+                  <p>Let <var>encryption scheme</var> be <var>requested media capability</var>’s <a
+                      def-id="capability-encryptionScheme"></a> member.</p>
+                </li>
+                <li>
+                  <p>Let <var>robustness</var> be <var>requested media capability</var>'s <a
+                      def-id="capability-robustness"></a> member.</p>
+                </li>
+                <li>
+                  <p>If <var>content type</var> is the empty string, return <code>null</code>.</p>
+                </li><!-- Invalid input. -->
+                <li>
+                  <p>If <var>content type</var> is not a <a def-id="valid-media-mime-type"></a> or
+                    is unrecognized, continue to the next iteration.</p>
+                </li>
+                <li>
+                  <p>Let <var>container</var> be the container type specified by <var>content type
+                    </var>.</p>
+                </li>
+                <li>
+                  <p>If the user agent does not support <var>container</var>, continue to the next
+                    iteration. The case-sensitivity of string comparisons is determined by the
+                    appropriate RFC.</p>
+                  <p class="note">Per RFC 6838 [[RFC6838]], "Both top-level type and subtype names
+                    are case-insensitive."</p>
+                </li>
+                <li>
+                  <p>Let <var>parameters</var> be the RFC 6381 [[RFC6381]] parameters, if any,
+                    specified by <var>content type</var>.</p>
+                </li>
+                <li>
+                  <p>If the user agent does not recognize one or more <var>parameters</var>,
+                    continue to the next iteration.</p>
+                </li>
+                <li>
+                  <p>Let <var>media types</var> be the set of codecs and codec constraints specified
+                    by <var>parameters</var>. The case-sensitivity of string comparisons is
+                    determined by the appropriate RFC or other specification.</p>
+                  <p class="note">Case-sensitive string comparison is RECOMMENDED because RFC 6381
+                    [[RFC6381]] says, "Values are case sensitive" for some formats.</p>
+                </li>
+                <li>
+                  <p> If <var>media types</var> is empty: </p>
+                  <dl class="switch">
+                    <dt>If <var>container</var> normatively implies a specific set of codecs and
+                      codec constraints:</dt>
+                    <dd>
+                      <p> Let <var>parameters</var> be that set. </p>
+                    </dd>
+                    <dt>Otherwise:</dt>
+                    <dd>
+                      <p> Continue to the next iteration. </p>
+                    </dd>
+                  </dl>
+                </li>
+                <li>
+                  <p>If <var>content type</var> is not strictly a <var>audio/video type</var>,
+                    continue to the next iteration.</p>
+                  <p class="note">For example, if <var>audio/video type</var> is Video and the
+                    top-level type is not "video" or <var>media types</var> contains non-video
+                    codecs.</p>
+                </li>
+                <li>
+                  <p>If <var>encryption scheme</var> is non-null and is not recognized or not
+                    supported by <var>implementation</var>, continue to the next iteration.</p>
+                </li>
+                <li>
+                  <p>If <var>robustness</var> is not the empty string and contains an unrecognized
+                    value or a value not supported by <var>implementation</var>, continue to the
+                    next iteration. String comparison is case-sensitive.</p>
+                </li>
+                <li>
+                  <p>If the user agent and <var>implementation</var> definitely support playback of
+                    encrypted <a def-id="media-data"></a> for the combination of <var>container
+                    </var>, <var>media types</var>, <var>encryption scheme</var>, <var>robustness
+                    </var> and <var>local accumulated configuration</var> in combination with <var>
+                      restrictions</var>:</p>
+                  <p class="note">
+                    <var>requested media capability</var> (content type and robustness) must be
+                    supported when used together with all previously added requested media
+                    capabilities.
+                  </p>
+                  <ol>
+                    <li>
+                      <p> Add <var>requested media capability</var> to <var>supported media
+                          capabilities</var>. </p>
+                      <p class="note"> This step ensures that the values of the members of entries
+                        in <var>supported media capabilities</var> are exactly the strings supplied
+                        in <var>requested media capability</var> without modification by the User
+                        Agent. </p>
+                    </li>
+                    <li>
+                      <dl class="switch">
+                        <dt>If <var>audio/video type</var> is Video:</dt>
+                        <dd>
+                          <p> Add <var>requested media capability</var> to the <a
+                              def-id="option-videoCapabilities"></a> member of <var>local
+                              accumulated configuration</var>. </p>
+                        </dd>
+                        <dt>If <var>audio/video type</var> is Audio:</dt>
+                        <dd>
+                          <p> Add <var>requested media capability</var> to the <a
+                              def-id="option-audioCapabilities"></a> member of <var>local
+                              accumulated configuration</var>. </p>
+                        </dd>
+                      </dl>
+                      <p class="note"> This step ensures that configurations are always checked with
+                        configurations from previous iterations, including from previous calls to
+                        this algorithm. Otherwise, only configurations from previous calls to this
+                        algorithm would be checked in subsequent calls. </p>
+                    </li>
+                  </ol>
+                </li>
+              </ol>
+            </li>
+            <li>
+              <p>If <var>supported media capabilities</var> is empty, return <code>null</code>.</p>
+              <p class="note">None of the <a>MediaKeySystemMediaCapability</a> elements in <var>
+                  requested media capabilities</var> is supported in combination with <var>
+                  accumulated configuration</var>.</p>
+            </li>
+            <li>
+              <p>Return <var>supported media capabilities</var>.</p>
+            </li>
+          </ol>
+        </section>
+        <section>
+          <h5>Get Consent Status</h5>
+          <p> Given an <var>accumulated configuration</var>, <var>restrictions</var> and <var>origin
+            </var>, this algorithm returns the consent status for <var>accumulated configuration
+            </var> and <var>origin</var> as one of <code>ConsentDenied</code>, <code>InformUser
+            </code> or <code>Allowed</code>, together with an updated value for <var>restrictions
+            </var> in the <code>ConsentDenied</code> case. </p>
+          <div class="note">
+            <p> Consent status for <var>accumulated configuration</var> depends at least on the
+              value of the <a def-id="option-distinctiveIdentifier"></a> member of <var>accumulated
+                configuration</var>. </p>
+            <p> Previous consent for <var>accumulated configuration</var> with <a
+                def-id="option-distinctiveIdentifier"></a> set to <a
+                def-id="requirement-not-allowed"></a> does not imply consent for the same
+              configuration with <a def-id="option-distinctiveIdentifier"></a> set to <a
+                def-id="requirement-optional"></a> or <a def-id="requirement-required"></a>. </p>
+          </div>
+          <ol>
+            <li>
+              <p> If there is persisted denial for <var>origin</var> indicating that <var>
+                  accumulated configuration</var> is not allowed, run the following steps: </p>
+              <ol>
+                <li>
+                  <p>Update <var>restrictions</var> to reflect the configurations for which consent
+                    has been denied.</p>
+                </li>
+                <li>
+                  <p>Return <code>ConsentDenied</code> and <var>restrictions</var>.</p>
+                </li>
+              </ol>
+            </li>
+            <li>
+              <p> If there is persisted consent for <var>origin</var> indicating <var>accumulated
+                  configuration</var> is allowed, return <code>Allowed</code>. </p>
+            </li>
+            <li>
+              <p> If any of the following are true: </p>
+              <ul>
+                <li>
+                  <p> The <a def-id="option-distinctiveIdentifier"></a> member of <var>accumulated
+                      configuration</var> is not <a def-id="requirement-not-allowed"></a> and the
+                    combination of the User Agent, <var>implementation</var> and <var>accumulated
+                      configuration</var> does not follow all the recommendations of <a
+                      href="#allow-persistent-data-cleared">Allow Persistent Data to Be Cleared</a>
+                    with respect to <a def-id="distinctive-identifier-maybe-plural"></a>. </p>
+                </li>
+                <li>
+                  <p> The user agent requires explicit user consent for the <var>accumulated
+                      configuration</var> for other reasons. </p>
+                  <p class="note"> Another reason for requiring explicit user consent may be due to
+                    the security properties of the CDM implementation. </p>
+                </li>
+              </ul>
+              <p>then run the following steps:</p>
+              <ol>
+                <li>
+                  <p> Request user consent to use <var>accumulated configuration</var> in the <var>
+                      origin</var> and wait for the user response. </p>
+                  <p> The consent MUST include consent to use a <a
+                      def-id="distinctive-identifier-maybe-plural"></a> and/or <a
+                      def-id="distinctive-permanent-identifier-maybe-plural"></a> as appropriate if
+                    <var>accumulated configuration</var>'s <a
+                      def-id="option-distinctiveIdentifier"></a> member is <a
+                      def-id="requirement-required"></a>. </p>
+                  <div class="note">
+                    <p>User consent to use <var>accumulated configuration</var> is specific to the
+                      <var>origin</var> and may be limited to configurations sharing certain
+                      properties with <var>accumulated configuration</var>.</p>
+                  </div>
+                </li>
+                <li>
+                  <p> If consent was denied, run the following steps: </p>
+                  <ol>
+                    <li>
+                      <p>Update <var>restrictions</var> to reflect the configurations for which
+                        consent was denied.</p>
+                    </li>
+                    <li>
+                      <p>Return <code>ConsentDenied</code> and <var>restrictions</var>.</p>
+                    </li>
+                  </ol>
+                </li>
+              </ol>
+            </li>
+            <li>
+              <p> If the <a def-id="option-distinctiveIdentifier"></a> member of <var>accumulated
+                  configuration</var> is not <a def-id="requirement-not-allowed"></a>, return <code>
+                  InformUser</code>. </p>
+            </li>
+            <li>
+              <p> If the user agent requires informing the user for the <var>accumulated
+                  configuration</var> for other reasons, return <code>InformUser</code>. </p>
+            </li>
+            <li>
+              <p>Return <code>Allowed</code>.</p>
+            </li>
+          </ol>
         </section>
       </section>
-
-      <section>
-        <h3><a>MediaKeySystemConfiguration</a> dictionary</h3>
-
-        <div><pre class="idl">enum MediaKeysRequirement {
+    </section>
+    <section>
+      <h3><a>MediaKeySystemConfiguration</a> dictionary</h3>
+      <div>
+        <pre class="idl">enum MediaKeysRequirement {
     "required",
     "optional",
     "not-allowed"
 };</pre>
-<p>
-The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows:
-</p>
-<table class="simple" data-dfn-for="MediaKeysRequirement" data-link-for="MediaKeysRequirement"><tbody><tr><th colspan="2">Enumeration description</th></tr><tr><td><dfn><code id="idl-def-MediaKeysRequirement.required">required</code></dfn></td><td>
-            <dl>
-              <dt>When used in a call to <a def-id="requestMediaKeySystemAccess"></a></dt>
-              <dd>The returned object MUST support this feature.</dd>
-              <dt>When returned by a <a>MediaKeySystemAccess</a> object</dt>
-              <dd>CDM instances created by the object MAY use this feature.</dd>
-            </dl>
-          </td></tr><tr><td><dfn><code id="idl-def-MediaKeysRequirement.optional">optional</code></dfn></td><td>
-            <dl>
-              <dt>When used in a call to <a def-id="requestMediaKeySystemAccess"></a></dt>
-              <dd>The returned object MAY support and use this feature.</dd>
-              <dt>When returned by a <a>MediaKeySystemAccess</a> object</dt>
-              <dd>This value cannot and MUST NOT be present in such an object.</dd>
-            </dl>
-          </td></tr><tr><td><dfn><code id="idl-def-MediaKeysRequirement.not-allowed">not-allowed</code></dfn></td><td>
-            <dl>
-              <dt>When used in a call to <a def-id="requestMediaKeySystemAccess"></a></dt>
-              <dd>The returned object MUST function without using this feature and MUST NOT use it at any time.</dd>
-              <dt>When returned by a <a>MediaKeySystemAccess</a> object</dt>
-              <dd>CDM instances created by the object MUST NOT use this feature.</dd>
-            </dl>
-          </td></tr></tbody></table></div>
-
-        <div><pre class="idl">dictionary MediaKeySystemConfiguration {
+        <p> The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows: </p>
+        <table class="simple" data-dfn-for="MediaKeysRequirement"
+          data-link-for="MediaKeysRequirement">
+          <tbody>
+            <tr>
+              <th colspan="2">Enumeration description</th>
+            </tr>
+            <tr>
+              <td>
+                <dfn>
+                  <code id="idl-def-MediaKeysRequirement.required">required</code>
+                </dfn>
+              </td>
+              <td>
+                <dl>
+                  <dt>When used in a call to <a def-id="requestMediaKeySystemAccess"></a></dt>
+                  <dd>The returned object MUST support this feature.</dd>
+                  <dt>When returned by a <a>MediaKeySystemAccess</a> object</dt>
+                  <dd>CDM instances created by the object MAY use this feature.</dd>
+                </dl>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <dfn>
+                  <code id="idl-def-MediaKeysRequirement.optional">optional</code>
+                </dfn>
+              </td>
+              <td>
+                <dl>
+                  <dt>When used in a call to <a def-id="requestMediaKeySystemAccess"></a></dt>
+                  <dd>The returned object MAY support and use this feature.</dd>
+                  <dt>When returned by a <a>MediaKeySystemAccess</a> object</dt>
+                  <dd>This value cannot and MUST NOT be present in such an object.</dd>
+                </dl>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <dfn>
+                  <code id="idl-def-MediaKeysRequirement.not-allowed">not-allowed</code>
+                </dfn>
+              </td>
+              <td>
+                <dl>
+                  <dt>When used in a call to <a def-id="requestMediaKeySystemAccess"></a></dt>
+                  <dd>The returned object MUST function without using this feature and MUST NOT use
+                    it at any time.</dd>
+                  <dt>When returned by a <a>MediaKeySystemAccess</a> object</dt>
+                  <dd>CDM instances created by the object MUST NOT use this feature.</dd>
+                </dl>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div>
+        <pre class="idl">dictionary MediaKeySystemConfiguration {
              DOMString                               label = "";
              sequence&lt;DOMString&gt;                     initDataTypes = [];
              sequence&lt;MediaKeySystemMediaCapability&gt; audioCapabilities = [];
@@ -1304,487 +1769,825 @@ The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows:
              MediaKeysRequirement                    persistentState = "optional";
              sequence&lt;DOMString&gt;                     sessionTypes;
 };</pre>
-<p>
-  The dictionary <dfn>MediaKeySystemConfiguration</dfn> contains the following members:
-</p>
-  <dl class="dictionary-members" data-dfn-for="MediaKeySystemConfiguration" data-link-for="MediaKeySystemConfiguration"><dt><dfn><code>label</code></dfn> of type <span class="idlMemberType">{{DOMString}}</span>, defaulting to <code>""</code></dt><dd>
-            An optional label that will be preserved in the <a>MediaKeySystemConfiguration</a> returned from the <a def-id="getConfiguration"></a> method of <a>MediaKeySystemAccess</a>.
-          </dd><dt><dfn><code>initDataTypes</code></dfn> of type <span class="idlMemberType">sequence&lt;{{DOMString}}&gt;</span>, defaulting to <code>[]</code></dt><dd>
-            A list of supported <a def-id="initialization-data-type"></a> names.
-            The <a def-id="initialization-data-type"></a> capability of this object is considered supported if the list is empty or contains one or more values that are supported with all other members (as determined by the algorithm).
-            Values in the sequence MUST not be the empty string.
-          </dd><dt><dfn><code>audioCapabilities</code></dfn> of type <span class="idlMemberType">sequence&lt;<a>MediaKeySystemMediaCapability</a>&gt;</span>, defaulting to <code>[]</code></dt><dd>
-            A list of supported audio type and capability pairs.
-            The audio capability of this object is considered supported if the list is empty or contains one or more values that are supported with all other members (as determined by the algorithm).
-            When there is a conflict between values, the earlier value will be selected. An empty list indicates that no audio capabilities are supported.
-            In this case, the <a def-id="option-videoCapabilities"></a> element must not be empty.
-          </dd><dt><dfn><code>videoCapabilities</code></dfn> of type <span class="idlMemberType">sequence&lt;<a>MediaKeySystemMediaCapability</a>&gt;</span>, defaulting to <code>[]</code></dt><dd>
-            A list of supported video type and capability pairs.
-            The video capability of this object is considered supported if the list is empty or contains one or more values that are supported with all other members (as determined by the algorithm).
-            When there is a conflict between values, the earlier value will be selected. An empty list indicates that no video capabilities are supported.
-            In this case, the <a def-id="option-audioCapabilities"></a> element must not be empty.
-          </dd><dt><dfn><code>distinctiveIdentifier</code></dfn> of type <span class="idlMemberType"><a>MediaKeysRequirement</a></span>, defaulting to <code>"optional"</code></dt><dd>
-            Whether use of a <a def-id="distinctive-identifier-maybe-plural"></a> is required.
-            <p>When this member is <a def-id="requirement-not-allowed"></a>, the implementation MUST NOT <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">use Distinctive Identifier(s) or Distinctive Permanent Identifier(s)</a> for any operations associated with any object created from this configuration.
+        <p> The dictionary <dfn>MediaKeySystemConfiguration</dfn> contains the following members:
+        </p>
+        <dl class="dictionary-members" data-dfn-for="MediaKeySystemConfiguration"
+          data-link-for="MediaKeySystemConfiguration">
+          <dt>
+            <dfn>
+              <code>label</code>
+            </dfn> of type <span class="idlMemberType">{{DOMString}}</span>, defaulting to <code>""
+            </code>
+          </dt>
+          <dd> An optional label that will be preserved in the <a>MediaKeySystemConfiguration</a>
+            returned from the <a def-id="getConfiguration"></a> method of
+            <a>MediaKeySystemAccess</a>. </dd>
+          <dt>
+            <dfn>
+              <code>initDataTypes</code>
+            </dfn> of type <span class="idlMemberType">sequence&lt;{{DOMString}}&gt;</span>,
+            defaulting to <code>[]</code>
+          </dt>
+          <dd> A list of supported <a def-id="initialization-data-type"></a> names. The <a
+              def-id="initialization-data-type"></a> capability of this object is considered
+            supported if the list is empty or contains one or more values that are supported with
+            all other members (as determined by the algorithm). Values in the sequence MUST not be
+            the empty string. </dd>
+          <dt>
+            <dfn>
+              <code>audioCapabilities</code>
+            </dfn> of type <span class="idlMemberType">
+              sequence&lt;<a>MediaKeySystemMediaCapability</a>&gt;</span>, defaulting to <code>[]
+            </code>
+          </dt>
+          <dd> A list of supported audio type and capability pairs. The audio capability of this
+            object is considered supported if the list is empty or contains one or more values that
+            are supported with all other members (as determined by the algorithm). When there is a
+            conflict between values, the earlier value will be selected. An empty list indicates
+            that no audio capabilities are supported. In this case, the <a
+              def-id="option-videoCapabilities"></a> element must not be empty. </dd>
+          <dt>
+            <dfn>
+              <code>videoCapabilities</code>
+            </dfn> of type <span class="idlMemberType">
+              sequence&lt;<a>MediaKeySystemMediaCapability</a>&gt;</span>, defaulting to <code>[]
+            </code>
+          </dt>
+          <dd> A list of supported video type and capability pairs. The video capability of this
+            object is considered supported if the list is empty or contains one or more values that
+            are supported with all other members (as determined by the algorithm). When there is a
+            conflict between values, the earlier value will be selected. An empty list indicates
+            that no video capabilities are supported. In this case, the <a
+              def-id="option-audioCapabilities"></a> element must not be empty. </dd>
+          <dt>
+            <dfn>
+              <code>distinctiveIdentifier</code>
+            </dfn> of type <span class="idlMemberType"><a>MediaKeysRequirement</a></span>,
+            defaulting to <code>"optional"</code>
+          </dt>
+          <dd> Whether use of a <a def-id="distinctive-identifier-maybe-plural"></a> is required.
+            <p>When this member is <a def-id="requirement-not-allowed"></a>, the implementation MUST
+              NOT <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">use
+                Distinctive Identifier(s) or Distinctive Permanent Identifier(s)</a> for any
+              operations associated with any object created from this configuration. </p>
+          </dd>
+          <dt>
+            <dfn>
+              <code>persistentState</code>
+            </dfn> of type <span class="idlMemberType"><a>MediaKeysRequirement</a></span>,
+            defaulting to <code>"optional"</code>
+          </dt>
+          <dd> Whether the ability to persist state is required. This includes session data and any
+            other type of state. <p>The CDM MUST NOT persist any state related to the application or
+              <a def-id="origin"></a> of this object's <a def-id="document-concept"></a> when this
+              member is <a def-id="requirement-not-allowed"></a>.</p>
+            <p class="note">For the purposes of this member, persistent state does not include
+              persistent unique identifiers (<a def-id="distinctive-identifiers"></a>) controlled by
+              the <a def-id="keysystem"></a> implementation. <a
+                def-id="option-distinctiveIdentifier"></a> independently reflects this requirement.
             </p>
-          </dd><dt><dfn><code>persistentState</code></dfn> of type <span class="idlMemberType"><a>MediaKeysRequirement</a></span>, defaulting to <code>"optional"</code></dt><dd>
-            Whether the ability to persist state is required. This includes session data and any other type of state.
-            <p>The CDM MUST NOT persist any state related to the application or <a def-id="origin"></a> of this object's <a def-id="document-concept"></a> when this member is <a def-id="requirement-not-allowed"></a>.</p>
-            <p class="note">For the purposes of this member, persistent state does not include persistent unique identifiers (<a def-id="distinctive-identifiers"></a>) controlled by the <a def-id="keysystem"></a> implementation. <a def-id="option-distinctiveIdentifier"></a> independently reflects this requirement.</p>
-            <p>Only <a def-id="temporary-session"></a> sessions may be created when persistent state is not supported.</p>
-            <p class="note">For <a def-id="temporary-session"></a> sessions, the need and ability to store state is <a def-id="keysystem"></a> implementation-specific and may vary by feature used.</p>
-            <p class="note">Applications intending to create non-<a def-id="temporary-session"></a> sessions, should set this member to <a def-id="requirement-required"></a> when calling <a def-id="requestMediaKeySystemAccess"></a>.</p>
-          </dd><dt><dfn><code>sessionTypes</code></dfn> of type <span class="idlMemberType">sequence&lt;{{DOMString}}&gt;</span></dt><dd>
-            A list of <a>MediaKeySessionType</a>s that must be supported. All values must be supported.
-            <p>If this member is <a def-id="not-present-dictionary-member"></a> [[WEBIDL]] when the dictionary is passed to <a def-id="requestMediaKeySystemAccess"></a>, the dictionary will be treated as if this member is set to <code>[ <a def-id="temporary-session"></a> ]</code>.</p>
-          </dd></dl>
-
-        <p>Implementations SHOULD NOT add members to this dictionary.
-          Should member(s) be added, they MUST be of type <a>MediaKeysRequirement</a>, and it is RECOMMENDED that they have default values of <a def-id="requirement-optional"></a> to support the widest range of application and client combinations.
-        </p>
-        <p class="note">Dictionary members not recognized by a user agent implementation are ignored per [[WEBIDL]] and will not be considered in the <a def-id="requestMediaKeySystemAccess"></a> algorithm.
-          Should an application use non-standard dictionary member(s), it MUST NOT rely on user agent implementations rejecting a configuration that includes such dictionary members.
-        </p>
+            <p>Only <a def-id="temporary-session"></a> sessions may be created when persistent state
+              is not supported.</p>
+            <p class="note">For <a def-id="temporary-session"></a> sessions, the need and ability to
+              store state is <a def-id="keysystem"></a> implementation-specific and may vary by
+              feature used.</p>
+            <p class="note">Applications intending to create non-<a def-id="temporary-session"></a>
+              sessions, should set this member to <a def-id="requirement-required"></a> when calling
+              <a def-id="requestMediaKeySystemAccess"></a>.</p>
+          </dd>
+          <dt>
+            <dfn>
+              <code>sessionTypes</code>
+            </dfn> of type <span class="idlMemberType">sequence&lt;{{DOMString}}&gt;</span>
+          </dt>
+          <dd> A list of <a>MediaKeySessionType</a>s that must be supported. All values must be
+            supported. <p>If this member is <a def-id="not-present-dictionary-member"></a>
+              [[WEBIDL]] when the dictionary is passed to <a
+                def-id="requestMediaKeySystemAccess"></a>, the dictionary will be treated as if this
+              member is set to <code>[ <a def-id="temporary-session"></a> ]</code>.</p>
+          </dd>
+        </dl>
+        <p>Implementations SHOULD NOT add members to this dictionary. Should member(s) be added,
+          they MUST be of type <a>MediaKeysRequirement</a>, and it is RECOMMENDED that they have
+          default values of <a def-id="requirement-optional"></a> to support the widest range of
+          application and client combinations. </p>
+        <p class="note">Dictionary members not recognized by a user agent implementation are ignored
+          per [[WEBIDL]] and will not be considered in the <a
+            def-id="requestMediaKeySystemAccess"></a> algorithm. Should an application use
+          non-standard dictionary member(s), it MUST NOT rely on user agent implementations
+          rejecting a configuration that includes such dictionary members. </p>
         <p>This dictionary MUST NOT be used to pass state or data to the CDM.</p>
-
-      </section>
-
-      <section>
-        <h3><dfn>MediaKeySystemMediaCapability</dfn> dictionary</h3>
-        <div>
-          <pre class="idl">dictionary MediaKeySystemMediaCapability {
+    </section>
+    <section>
+      <h3>
+        <dfn>MediaKeySystemMediaCapability</dfn> dictionary
+      </h3>
+      <div>
+        <pre class="idl">dictionary MediaKeySystemMediaCapability {
              DOMString contentType = "";
              DOMString? encryptionScheme = null;
              DOMString robustness = "";
           };</pre>
         <section>
           <h2>Dictionary <a class="idlType">MediaKeySystemMediaCapability</a> Members</h2>
-          <dl class="dictionary-members" data-dfn-for="MediaKeySystemMediaCapability" data-link-for="MediaKeySystemMediaCapability">
-            <dt><dfn><code>contentType</code></dfn> of type <span class="idlMemberType">{{DOMString}}</span>, defaulting to <code>""</code></dt>
+          <dl class="dictionary-members" data-dfn-for="MediaKeySystemMediaCapability"
+            data-link-for="MediaKeySystemMediaCapability">
+            <dt>
+              <dfn>
+                <code>contentType</code>
+              </dfn> of type <span class="idlMemberType">{{DOMString}}</span>, defaulting to <code>
+                ""</code>
+            </dt>
             <dd>
-              <p>
-                The type of the <a def-id="media-resource"></a>.
-                Its value must be a <a def-id="valid-media-mime-type"></a>.
-                The empty string is invalid.
-              </p>
+              <p> The type of the <a def-id="media-resource"></a>. Its value must be a <a
+                  def-id="valid-media-mime-type"></a>. The empty string is invalid. </p>
             </dd>
-            <dt><dfn><code>encryptionScheme</code></dfn> of type <span class="idlMemberType">{{DOMString}}</span>, defaulting to <code>null</code></dt>
+            <dt>
+              <dfn>
+                <code>encryptionScheme</code>
+              </dfn> of type <span class="idlMemberType">{{DOMString}}</span>, defaulting to <code>
+                null</code>
+            </dt>
             <dd>
-              <p>
-                The encryption scheme associated with the content type.
-                A value which is null or not present indicates to the user agent
-                that no specific encryption scheme is required by the
-                application, and therefore any encryption scheme is acceptable.
-              </p>
+              <p> The encryption scheme associated with the content type. A value which is null or
+                not present indicates to the user agent that no specific encryption scheme is
+                required by the application, and therefore any encryption scheme is acceptable. </p>
               <div class="note">
-                <p>
-                  Applications that are aware of this field SHOULD specify the
-                  encryption schemes they require, since different encryption
-                  schemes are generally incompatible with one another. It is
-                  unrealistic for an application to be accepting of "any"
-                  encryption scheme, but the default of null and the
-                  interpretation of null as "any" provide backward
-                  compatibility for unaware applications and a path to a
-                  polyfill for older user agents.
-                </p>
+                <p> Applications that are aware of this field SHOULD specify the encryption schemes
+                  they require, since different encryption schemes are generally incompatible with
+                  one another. It is unrealistic for an application to be accepting of "any"
+                  encryption scheme, but the default of null and the interpretation of null as "any"
+                  provide backward compatibility for unaware applications and a path to a polyfill
+                  for older user agents. </p>
               </div>
               <div class="note">
-                <p>
-                  NOTE: The empty string is distinct from null or not present,
-                  and so would be treated as an unrecognized encryption scheme.
-                </p>
+                <p> NOTE: The empty string is distinct from null or not present, and so would be
+                  treated as an unrecognized encryption scheme. </p>
               </div>
               <div class="note">
-                <p>
-                  Well-known values for encryptionScheme are:
-                  <ul>
-                    <li><dfn id="scheme-cenc"><code>cenc</code></dfn>:
-                      The "cenc" mode, defined in [[CENC]], section 4.2a. AES-CTR
-                      mode full sample and video NAL subsample encryption.
+                <p> Well-known values for encryptionScheme are: <ul>
+                    <li>
+                      <dfn id="scheme-cenc">
+                        <code>cenc</code>
+                      </dfn>: The "cenc" mode, defined in [[CENC]], section 4.2a. AES-CTR mode full
+                      sample and video NAL subsample encryption.
                     </li>
-                    <li><dfn id="scheme-cbcs"><code>cbcs</code></dfn>:
-                      The "cbcs" mode, defined in [[CENC]], section 4.2d. AES-CBC
-                      mode partial video NAL pattern encryption.  For video, the
-                      spec allows various encryption patterns.
+                    <li>
+                      <dfn id="scheme-cbcs">
+                        <code>cbcs</code>
+                      </dfn>: The "cbcs" mode, defined in [[CENC]], section 4.2d. AES-CBC mode
+                      partial video NAL pattern encryption. For video, the spec allows various
+                      encryption patterns.
                     </li>
-                    <li><dfn id="scheme-cbcs-1-9"><code>cbcs-1-9</code></dfn>:
-                      The same as <a def-id="scheme-cbcs"></a> mode, but with a
-                      specific encrypt:skip pattern of 1:9 for video, as
-                      recommended in [[CENC]], section 10.4.2.
+                    <li>
+                      <dfn id="scheme-cbcs-1-9">
+                        <code>cbcs-1-9</code>
+                      </dfn>: The same as <a def-id="scheme-cbcs"></a> mode, but with a specific
+                      encrypt:skip pattern of 1:9 for video, as recommended in [[CENC]], section
+                      10.4.2.
                     </li>
                   </ul>
                 </p>
               </div>
             </dd>
-            <dt><dfn><code>robustness</code></dfn> of type <span class="idlMemberType">{{DOMString}}</span>, defaulting to <code>""</code></dt>
+            <dt>
+              <dfn>
+                <code>robustness</code>
+              </dfn> of type <span class="idlMemberType">{{DOMString}}</span>, defaulting to <code>
+                ""</code>
+            </dt>
             <dd>
-              <p>
-                The robustness level associated with the content type.
-                The empty string indicates that any ability to decrypt and decode the content type is acceptable.
-              </p>
+              <p> The robustness level associated with the content type. The empty string indicates
+                that any ability to decrypt and decode the content type is acceptable. </p>
               <div class="note">
-                <p>
-                  Implementations MUST configure the CDM to support at least the robustness levels specified in the configuration of the MediaKeySystemAccess object used to create the MediaKeys object.
-                  Exact configuration of the CDM is implementation-specific, and implementations MAY configure the CDM to use the highest robustness level in the configuration even if a higher robustness level is available.
-                  If only the empty string is specified, implementations MAY be configured to use the lowest robustness level the implementation supports.
-                </p>
-                <p>
-                  Applications SHOULD specify the robustness level(s) they require to avoid unexpected client incompatibilities.
-                </p>
+                <p> Implementations MUST configure the CDM to support at least the robustness levels
+                  specified in the configuration of the MediaKeySystemAccess object used to create
+                  the MediaKeys object. Exact configuration of the CDM is implementation-specific,
+                  and implementations MAY configure the CDM to use the highest robustness level in
+                  the configuration even if a higher robustness level is available. If only the
+                  empty string is specified, implementations MAY be configured to use the lowest
+                  robustness level the implementation supports. </p>
+                <p> Applications SHOULD specify the robustness level(s) they require to avoid
+                  unexpected client incompatibilities. </p>
               </div>
             </dd>
           </dl>
-        </section></div>
-
-        <p>In order for the capability represented by this object to be considered supported, <a def-id="capability-contentType"></a> MUST NOT be the empty string and its entire value, including all codecs, MUST be supported with <a def-id="capability-robustness"></a>.</p>
-        <p class="note">If any of a set of codecs is acceptable, use a separate instances of this dictionary for each codec.</p>
-      </section>
+        </section>
+      </div>
+      <p>In order for the capability represented by this object to be considered supported, <a
+          def-id="capability-contentType"></a> MUST NOT be the empty string and its entire value,
+        including all codecs, MUST be supported with <a def-id="capability-robustness"></a>.</p>
+      <p class="note">If any of a set of codecs is acceptable, use a separate instances of this
+        dictionary for each codec.</p>
     </section>
-
-
-    <section>
-      <h2><dfn>MediaKeySystemAccess</dfn> Interface</h2>
-      <p>The MediaKeySystemAccess object provides access to a <a def-id="keysystem"></a>.</p>
-
-      <div><pre class="idl">[Exposed=Window, SecureContext] interface MediaKeySystemAccess {
+  </section>
+  <section>
+    <h2>
+      <dfn>MediaKeySystemAccess</dfn> Interface
+    </h2>
+    <p>The MediaKeySystemAccess object provides access to a <a def-id="keysystem"></a>.</p>
+    <div>
+      <pre class="idl">[Exposed=Window, SecureContext] interface MediaKeySystemAccess {
     readonly        attribute DOMString keySystem;
     MediaKeySystemConfiguration getConfiguration ();
     Promise&lt;MediaKeys&gt;          createMediaKeys ();
-};</pre><section><h2>Attributes</h2><dl class="attributes" data-dfn-for="MediaKeySystemAccess" data-link-for="MediaKeySystemAccess"><dt><dfn><code>keySystem</code></dfn> of type <span class="idlAttrType">{{DOMString}}</span>, readonly       </dt><dd>
-          Identifies the <a def-id="keysystem"></a> being used.
-        </dd></dl></section><section><h2>Methods</h2><dl class="methods" data-dfn-for="MediaKeySystemAccess" data-link-for="MediaKeySystemAccess"><dt><dfn><code>getConfiguration</code></dfn></dt><dd>
-          <p>Returns the supported combination of configuration options selected by the <a def-id="requestMediaKeySystemAccess"></a> algorithm.
-          </p>
-          <p>The returned object is a non-strict subset (plus any implied defaults) of the first satisfiable <a>MediaKeySystemConfiguration</a> configuration passed to the <a def-id="requestMediaKeySystemAccess"></a> call that returned the promise that was resolved with this object.
-            It does not contain values capabilities not specified in that single configuration (other than implied defaults) and thus may not reflect all capabilities of the <a def-id="keysystem"></a> implementation.
-            All values in the configuration may be used in any combination.
-            Members of type <a>MediaKeysRequirement</a> reflect whether the capability is required for any combination. They will not have the value <a def-id="requirement-optional"></a>.
-          </p>
-
-          <ol class="method-algorithm">
-            <li>
-              <p>
-                Return this object's <var>configuration</var> value.
-              </p>
-              <p class="note">
-                This results in a new object being created and initialized from <var>configuration</var> each time this method is called.
-              </p>
-              <p class="note">
-                If <a def-id="capability-encryptionScheme"></a> was not given by the application, the accumulated <var>configuration</var> MUST still contain a <a def-id="capability-encryptionScheme"></a> field with a value of <code>null</code>, so that polyfills can detect the user agent's support for the field without specifying specific values.
-              </p>
-            </li>
-          </ol>
-        <div><em>No parameters.</em></div><div><em>Return type: </em><code>MediaKeySystemConfiguration</code></div></dd><dt><dfn><code>createMediaKeys</code></dfn></dt><dd>
-          <p>Creates a new <a>MediaKeys</a> object for <var>keySystem</var>.</p>
-
-          <ol class="method-algorithm">
-            <li><p>Let <var>promise</var> be a new promise.</p></li>
-            <li><p>Run the following steps in parallel:</p>
-              <ol>
-                <li><p>Let <var>configuration</var> be the value of this object's <var>configuration</var> value.</p></li>
-                <li>
-                  <p>
-                    Let <var>use distinctive identifier</var> be <code>true</code> if the value of <var>configuration</var>'s <a def-id="option-distinctiveIdentifier"></a>
-                    member is <a def-id="requirement-required"></a> and <code>false</code> otherwise.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let <var>persistent state allowed</var> be <code>true</code> if the value of <var>configuration</var>'s <a def-id="option-persistentState"></a>
-                    member is <a def-id="requirement-required"></a> and <code>false</code> otherwise.
-                  <p>
-                </li>
-                <li><p>Load and initialize the <a def-id="keysystem"></a> implementation represented by this object's <var>cdm implementation</var> value if necessary.</p></li>
-                <li><p>Let <var>instance</var> be a new instance of the <a def-id="keysystem"></a> implementation represented by this object's <var>cdm implementation</var> value.</p></li>
-                <li><p>Initialize <var>instance</var> to enable, disable and/or select <a def-id="keysystem"></a> features using <var>configuration</var>.</p></li>
-                <li><p>If <var>use distinctive identifier</var> is <code>false</code>, prevent <var>instance</var> from <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">using Distinctive Identifier(s) and Distinctive Permanent Identifier(s)</a>.</p></li>
-                <li><p>If <var>persistent state allowed</var> is <code>false</code>, prevent <var>instance</var> from persisting any state related to the application or <a def-id="origin"></a> of this object's <a def-id="document-concept"></a>.</p></li>
-                <li><p>If any of the preceding steps failed, reject <var>promise</var> with <a def-id="new-domexception-named"></a> <a def-id="appropriate-error-name"></a>.</p></li>
-                <li><p>Let <var>media keys</var> be a new <a>MediaKeys</a> object, and initialize it as follows:</p>
-                  <ol>
-                    <li><p>Let the <var>use distinctive identifier</var> value be <var>use distinctive identifier</var>.</p></li>
-                    <li><p>Let the <var>persistent state allowed</var> value be <var>persistent state allowed</var>.</p></li>
-                    <li><p>Let the <var>supported session types</var> value be be the value of <var>configuration</var>'s <a def-id="option-sessionTypes"></a> member.</p></li>
-                    <li><p>Let the <var>cdm implementation</var> value be this object's <var>cdm implementation</var> value.</p></li>
-                    <li><p>Let the <var>cdm instance</var> value be <var>instance</var>.</p></li>
-                  </ol>
-                </li>
-                <li><p>Resolve <var>promise</var> with <var>media keys</var>.</p></li>
-              </ol>
-            </li>
-            <li><p>Return <var>promise</var>.</p></li>
-          </ol>
-        <div><em>No parameters.</em></div><div><em>Return type: </em><code>Promise&lt;MediaKeys&gt;</code></div></dd></dl></section></div>
-    </section>
-
-
-    <section>
-      <h2><dfn>MediaKeys</dfn> Interface</h2>
-      <p>The MediaKeys object represents a set of keys that an associated HTMLMediaElement can use for decryption of <a def-id="media-data"></a> during playback.
-        It also represents a <a def-id="cdm"></a> instance.
-      </p>
-      <p>A <a>MediaKeys</a> object may be destroyed by the user agent when it is no longer accessible</p>
-      <p class="note">For example, when there are no script references and no attached media element.</p>
-      <p>For methods that return a promise, all errors are reported asynchronously by rejecting the returned Promise. This includes [[WEBIDL]] type mapping errors.</p>
-      <p>The steps of an algorithm are always aborted when rejecting a promise.</p>
-
-      <div><pre class="idl">enum MediaKeySessionType {
+};</pre>
+      <section>
+        <h2>Attributes</h2>
+        <dl class="attributes" data-dfn-for="MediaKeySystemAccess"
+          data-link-for="MediaKeySystemAccess">
+          <dt>
+            <dfn>
+              <code>keySystem</code>
+            </dfn> of type <span class="idlAttrType">{{DOMString}}</span>, readonly
+          </dt>
+          <dd> Identifies the <a def-id="keysystem"></a> being used. </dd>
+        </dl>
+      </section>
+      <section>
+        <h2>Methods</h2>
+        <dl class="methods" data-dfn-for="MediaKeySystemAccess"
+          data-link-for="MediaKeySystemAccess">
+          <dt>
+            <dfn>
+              <code>getConfiguration</code>
+            </dfn>
+          </dt>
+          <dd>
+            <p>Returns the supported combination of configuration options selected by the <a
+                def-id="requestMediaKeySystemAccess"></a> algorithm. </p>
+            <p>The returned object is a non-strict subset (plus any implied defaults) of the first
+              satisfiable <a>MediaKeySystemConfiguration</a> configuration passed to the <a
+                def-id="requestMediaKeySystemAccess"></a> call that returned the promise that was
+              resolved with this object. It does not contain values capabilities not specified in
+              that single configuration (other than implied defaults) and thus may not reflect all
+              capabilities of the <a def-id="keysystem"></a> implementation. All values in the
+              configuration may be used in any combination. Members of type
+              <a>MediaKeysRequirement</a> reflect whether the capability is required for any
+              combination. They will not have the value <a def-id="requirement-optional"></a>. </p>
+            <ol class="method-algorithm">
+              <li>
+                <p> Return this object's <var>configuration</var> value. </p>
+                <p class="note"> This results in a new object being created and initialized from
+                  <var>configuration</var> each time this method is called. </p>
+                <p class="note"> If <a def-id="capability-encryptionScheme"></a> was not given by
+                  the application, the accumulated <var>configuration</var> MUST still contain a <a
+                    def-id="capability-encryptionScheme"></a> field with a value of <code>null
+                  </code>, so that polyfills can detect the user agent's support for the field
+                  without specifying specific values. </p>
+              </li>
+            </ol>
+            <div>
+              <em>No parameters.</em>
+            </div>
+            <div>
+              <em>Return type: </em>
+              <code>MediaKeySystemConfiguration</code>
+            </div>
+          </dd>
+          <dt>
+            <dfn>
+              <code>createMediaKeys</code>
+            </dfn>
+          </dt>
+          <dd>
+            <p>Creates a new <a>MediaKeys</a> object for <var>keySystem</var>.</p>
+            <ol class="method-algorithm">
+              <li>
+                <p>Let <var>promise</var> be a new promise.</p>
+              </li>
+              <li>
+                <p>Run the following steps in parallel:</p>
+                <ol>
+                  <li>
+                    <p>Let <var>configuration</var> be the value of this object's <var>configuration
+                      </var> value.</p>
+                  </li>
+                  <li>
+                    <p> Let <var>use distinctive identifier</var> be <code>true</code> if the value
+                      of <var>configuration</var>'s <a def-id="option-distinctiveIdentifier"></a>
+                      member is <a def-id="requirement-required"></a> and <code>false</code>
+                      otherwise. </p>
+                  </li>
+                  <li>
+                    <p> Let <var>persistent state allowed</var> be <code>true</code> if the value of
+                      <var>configuration</var>'s <a def-id="option-persistentState"></a> member is
+                      <a def-id="requirement-required"></a> and <code>false</code> otherwise. <p>
+                  </li>
+                  <li>
+                    <p>Load and initialize the <a def-id="keysystem"></a> implementation represented
+                      by this object's <var>cdm implementation</var> value if necessary.</p>
+                  </li>
+                  <li>
+                    <p>Let <var>instance</var> be a new instance of the <a def-id="keysystem"></a>
+                      implementation represented by this object's <var>cdm implementation</var>
+                      value.</p>
+                  </li>
+                  <li>
+                    <p>Initialize <var>instance</var> to enable, disable and/or select <a
+                        def-id="keysystem"></a> features using <var>configuration</var>.</p>
+                  </li>
+                  <li>
+                    <p>If <var>use distinctive identifier</var> is <code>false</code>, prevent <var>
+                        instance</var> from <a
+                        href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">using
+                        Distinctive Identifier(s) and Distinctive Permanent Identifier(s)</a>.</p>
+                  </li>
+                  <li>
+                    <p>If <var>persistent state allowed</var> is <code>false</code>, prevent <var>
+                        instance</var> from persisting any state related to the application or <a
+                        def-id="origin"></a> of this object's <a def-id="document-concept"></a>.</p>
+                  </li>
+                  <li>
+                    <p>If any of the preceding steps failed, reject <var>promise</var> with <a
+                        def-id="new-domexception-named"></a> <a
+                        def-id="appropriate-error-name"></a>.</p>
+                  </li>
+                  <li>
+                    <p>Let <var>media keys</var> be a new <a>MediaKeys</a> object, and initialize it
+                      as follows:</p>
+                    <ol>
+                      <li>
+                        <p>Let the <var>use distinctive identifier</var> value be <var>use
+                            distinctive identifier</var>.</p>
+                      </li>
+                      <li>
+                        <p>Let the <var>persistent state allowed</var> value be <var>persistent
+                            state allowed</var>.</p>
+                      </li>
+                      <li>
+                        <p>Let the <var>supported session types</var> value be be the value of <var>
+                            configuration</var>'s <a def-id="option-sessionTypes"></a> member.</p>
+                      </li>
+                      <li>
+                        <p>Let the <var>cdm implementation</var> value be this object's <var>cdm
+                            implementation</var> value.</p>
+                      </li>
+                      <li>
+                        <p>Let the <var>cdm instance</var> value be <var>instance</var>.</p>
+                      </li>
+                    </ol>
+                  </li>
+                  <li>
+                    <p>Resolve <var>promise</var> with <var>media keys</var>.</p>
+                  </li>
+                </ol>
+              </li>
+              <li>
+                <p>Return <var>promise</var>.</p>
+              </li>
+            </ol>
+            <div>
+              <em>No parameters.</em>
+            </div>
+            <div>
+              <em>Return type: </em>
+              <code>Promise&lt;MediaKeys&gt;</code>
+            </div>
+          </dd>
+        </dl>
+      </section>
+    </div>
+  </section>
+  <section>
+    <h2>
+      <dfn>MediaKeys</dfn> Interface
+    </h2>
+    <p>The MediaKeys object represents a set of keys that an associated HTMLMediaElement can use for
+      decryption of <a def-id="media-data"></a> during playback. It also represents a <a
+        def-id="cdm"></a> instance. </p>
+    <p>A <a>MediaKeys</a> object may be destroyed by the user agent when it is no longer accessible
+    </p>
+    <p class="note">For example, when there are no script references and no attached media element.
+    </p>
+    <p>For methods that return a promise, all errors are reported asynchronously by rejecting the
+      returned Promise. This includes [[WEBIDL]] type mapping errors.</p>
+    <p>The steps of an algorithm are always aborted when rejecting a promise.</p>
+    <div>
+      <pre class="idl">enum MediaKeySessionType {
     "temporary",
     "persistent-license",
     "persistent-usage-record"
 };</pre>
-   <p>The <dfn>MediaKeySessionType</dfn> enumeration is defined as follows:</p>
-      <table class="simple" data-dfn-for="MediaKeySessionType" data-link-for="MediaKeySessionType"><tbody>
-        <tr><th colspan="2">Enumeration description</th></tr>
-        <tr><td><dfn><code id="idl-def-MediaKeySessionType.temporary">temporary</code></dfn></td><td>
-          <p>
-            A session for which the license, key(s) and record of or data related to the session are not persisted.
-          </p>
-          <p>
-            The application need not worry about managing such storage.
-            Support for this session type is REQUIRED.
-          </p>
-        </td></tr>
-        <tr><td><dfn><code id="idl-def-MediaKeySessionType.persistent-license">persistent-license</code></dfn></td><td>
-          <p>
-            A session for which the license (and potentially other data related to the session) will be persisted.
-            A <a def-id="record-of-license-destruction"></a> SHALL be persisted when the license and key(s) it contains are destroyed.
-            The <dfn id="record-of-license-destruction">record of license destruction</dfn> is a <a def-id="keysystem"></a>-specific attestation that the license and key(s) it contains are no longer usable by the client.
-            Support for this session type is OPTIONAL.
-          </p>
-          <p>
-            Sessions of this type can only be created if the configuration associated with the <a>MediaKeySystemAccess</a> object that created this object has a <a def-id="option-persistentState"></a> value of <a def-id="requirement-required"></a>.
-            The session MUST be loadable via its <a def-id="session-id"></a> once <a def-id="update"></a> is called successfully.
-            A <a def-id="message"></a> of type <a def-id="message-type-license-release"></a> containing the <a def-id="record-of-license-destruction"></a> will be generated when <a def-id="remove"></a> is called until the record is acknowledged by a response passed to <a def-id="update"></a>.
-          </p>
-          <p>
-            The application is responsible for ensuring that data persisted for such sessions is removed when the application no longer needs it.
-            See <a def-id="session-storage"></a>.
-          </p>
-        </td></tr>
-        <tr><td><code id="idl-def-MediaKeySessionType.persistent-usage-record"><dfn>persistent-usage-record</dfn></code></td><td>
-          <p>
-            A session for which the license and key(s) are not persisted and for which a <a def-id="record-of-key-usage"></a> is persisted when
-            the keys available within the session are destroyed.
-            The <dfn id="record-of-key-usage">record of key usage</dfn> consists of:
-          </p>
-          <ul>
-            <li>
-              <p>A record of the <a def-id="key-id">key IDs</a> of all the key(s) that were at any time <a href="#known-key">known</a> to the session,</p>
-            </li>
-            <li>
-              <p>
-                <var>first decryption time</var> - The <dfn id="first-decryption-time">first decryption time</dfn>, defined as the time at which the session was first used to decrypt content, accurate to <var><a def-id="key-usage-accuracy"></a></var> and
-              </p>
-            </li>
-            <li>
-              <p>
-                <var>latest decryption time</var> - The <dfn id="latest-decryption-time">latest decryption time</dfn>, defined as the latest time at which the session was used to decrypt content, accurate to <var><a def-id="key-usage-accuracy"></a></var>.
-              </p>
-            </li>
-          </ul>
-          <p>
-            A <a def-id="message"></a> of type <a def-id="message-type-license-release"></a> containing the <a def-id="record-of-key-usage"></a> will be generated each time <a def-id="remove"></a> is called, until the record is acknowledged by a response passed to <a def-id="update"></a>.
-          </p>
-          <p>
-            The <dfn id="key-usage-accuracy"><var>key usage accuracy</var></dfn> is implementation-dependant but SHALL NOT be greater than 60 seconds.
-          </p>
-          <p class="note">
-            Because the license and keys are not persisted, this record implicitly proves that the keys are no longer available in the session.
-          </p>
-          <p class="note">
-            User agents MAY implement this mechanism by means other than persisting data on key destruction - for example by persisting data during playback which is later used
-            to infer the fact of key destruction - provided the observable behavior is compliant to this specification.
-          </p>
-          <p>
-            The session MUST be loadable via its <a def-id="session-id"></a> once <a def-id="update"></a> is called successfully.
-            The application is responsible for managing any such storage that may be generated by the CDM.
-            See <a def-id="session-storage"></a>.
-            Can only be created if the configuration associated with the <a>MediaKeySystemAccess</a> object that created this object has a <a def-id="option-persistentState"></a> value of <a def-id="requirement-required"></a>.
-            Support for this session type is OPTIONAL.
-          </p>
-        </td></tr>
-      </tbody></table></div>
-
-      <div><pre class="idl">[Exposed=Window, SecureContext] interface MediaKeys {
-    MediaKeySession  createSession (optional MediaKeySessionType sessionType = "temporary");
-    Promise&lt;boolean&gt; setServerCertificate (BufferSource serverCertificate);
-};</pre><section><h2>Methods</h2><dl class="methods" data-dfn-for="MediaKeys" data-link-for="MediaKeys"><dt><dfn><code>createSession</code></dfn></dt><dd>
-          <p>Returns a new <a>MediaKeySession</a> object.</p>
-
-          
-
-          <ol class="method-algorithm">
-            <li><p>If this object's <var>supported session types</var> value does not contain <var>sessionType</var>, <a def-id="throw"></a> [[WEBIDL]] a <a def-id="NotSupportedError"></a>.</p>
-              <p class="note"><var>sessionType</var> values for which the <a def-id="is-persistent-session-type-algorithm"></a> algorithm returns <code>true</code> will fail if this object's <var>persistent state allowed</var> value is <code>false</code>.</p>
-            </li>
-            <li><p>If the implementation does not support <a>MediaKeySession</a> operations in the current state, <a def-id="throw"></a> [[WEBIDL]] an <a def-id="InvalidStateError"></a>.</p> 
-              <p class="note">Some implementations are unable to execute <a>MediaKeySession</a> algorithms until this <a>MediaKeys</a> object is associated with a media element using <a def-id="setMediaKeys"></a>.
-              This step enables applications to detect this uncommon behavior before attempting to perform such operations.
-              </p>
-            </li>
-            <li><p>Let <var>session</var> be a new <a>MediaKeySession</a> object, and initialize it as follows:</p>
-              <ol>
-                <li><p>Let the <a def-id="sessionId"></a> attribute be the empty string.</p></li>
-                <li><p>Let the <a def-id="expiration"></a> attribute be <code>NaN</code>.</p></li>
-                <li><p>Let the <a def-id="closed"></a> attribute be a new promise.</p></li>
-                <li><p>Let <var>key status</var> be a new empty <a>MediaKeyStatusMap</a> object, and initialize it as follows:</p>
-                  <ol>
-                    <li><p>Let the <a def-id="statusmap-size"></a> attribute be 0.</p></li>
-                  </ol>
+      <p>The <dfn>MediaKeySessionType</dfn> enumeration is defined as follows:</p>
+      <table class="simple" data-dfn-for="MediaKeySessionType" data-link-for="MediaKeySessionType">
+        <tbody>
+          <tr>
+            <th colspan="2">Enumeration description</th>
+          </tr>
+          <tr>
+            <td>
+              <dfn>
+                <code id="idl-def-MediaKeySessionType.temporary">temporary</code>
+              </dfn>
+            </td>
+            <td>
+              <p> A session for which the license, key(s) and record of or data related to the
+                session are not persisted. </p>
+              <p> The application need not worry about managing such storage. Support for this
+                session type is REQUIRED. </p>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>
+                <code id="idl-def-MediaKeySessionType.persistent-license">persistent-license</code>
+              </dfn>
+            </td>
+            <td>
+              <p> A session for which the license (and potentially other data related to the
+                session) will be persisted. A <a def-id="record-of-license-destruction"></a> SHALL
+                be persisted when the license and key(s) it contains are destroyed. The <dfn
+                  id="record-of-license-destruction">record of license destruction</dfn> is a <a
+                  def-id="keysystem"></a>-specific attestation that the license and key(s) it
+                contains are no longer usable by the client. Support for this session type is
+                OPTIONAL. </p>
+              <p> Sessions of this type can only be created if the configuration associated with the
+                <a>MediaKeySystemAccess</a> object that created this object has a <a
+                  def-id="option-persistentState"></a> value of <a
+                  def-id="requirement-required"></a>. The session MUST be loadable via its <a
+                  def-id="session-id"></a> once <a def-id="update"></a> is called successfully. A <a
+                  def-id="message"></a> of type <a def-id="message-type-license-release"></a>
+                containing the <a def-id="record-of-license-destruction"></a> will be generated when
+                <a def-id="remove"></a> is called until the record is acknowledged by a response
+                passed to <a def-id="update"></a>. </p>
+              <p> The application is responsible for ensuring that data persisted for such sessions
+                is removed when the application no longer needs it. See <a
+                  def-id="session-storage"></a>. </p>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code id="idl-def-MediaKeySessionType.persistent-usage-record">
+                <dfn>persistent-usage-record</dfn>
+              </code>
+            </td>
+            <td>
+              <p> A session for which the license and key(s) are not persisted and for which a <a
+                  def-id="record-of-key-usage"></a> is persisted when the keys available within the
+                session are destroyed. The <dfn id="record-of-key-usage">record of key usage</dfn>
+                consists of: </p>
+              <ul>
+                <li>
+                  <p>A record of the <a def-id="key-id">key IDs</a> of all the key(s) that were at
+                    any time <a href="#known-key">known</a> to the session,</p>
                 </li>
-                <li><p>Let the <var>session type</var> value be <var>sessionType</var>.</p></li>
-                <li><p>Let the <var>uninitialized</var> value be true.</p></li>
-                <li><p>Let the <var>callable</var> value be false.</p></li>
-                <li><p>Let the <var>closing or closed</var> value be false.</p></li>
-                <li><p>Let the <var>use distinctive identifier</var> value be this object's <var>use distinctive identifier</var> value.</p></li>
-                <li><p>Let the <var>cdm implementation</var> value be this object's <var>cdm implementation</var>.</p></li>
-                <li><p>Let the <var>cdm instance</var> value be this object's <var>cdm instance</var>.</p></li>
-              </ol>
-            </li>
-            <li><p>Return <var>session</var>.</p></li>
-          </ol>
-        <table class="parameters"><tbody><tr><th>Parameter</th><th>Type</th><th>Nullable</th><th>Optional</th><th>Description</th></tr><tr><td class="prmName">sessionType</td><td class="prmType"><code>MediaKeySessionType = "temporary"</code></td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptTrue"><span role="img" aria-label="True">✔</span></td><td class="prmDesc">
-              The type of session to create. The session type affects the behavior of the returned object.
-            </td></tr></tbody></table><div><em>Return type: </em><code>MediaKeySession</code></div></dd><dt><dfn><code>setServerCertificate</code></dfn></dt><dd>
-          <p id="server-certificate">Provides a server certificate to be used to encrypt messages to the license server.</p>
-          <p>Key Systems that use such certificates MUST also support requesting the certificate from the server via the <a def-id="queue-message-algorithm"></a> algorithm.</p>
-          <p class="note">This method allows an application to proactively provide a server certificate to implementations that support it to avoid the additional round trip should the CDM request it.
-            It is intended as an optimization, and applications are not required to use it.
-          </p>
-
-          
-
-          <ol class="method-algorithm">
-            <li><p>If the <a def-id="keysystem"></a> implementation represented by this object's <var>cdm implementation</var> value does not support server certificates, return a promise resolved with <code>false</code>.</p></li>
-            <li><p>If <var>serverCertificate</var> is an empty array, return a promise rejected with a new a newly created <a def-id="TypeError"></a>.</p></li>
-
-            <li><p>Let <var>certificate</var> be a copy of the contents of the <var>serverCertificate</var> parameter.</p></li>
-            <li><p>Let <var>promise</var> be a new promise.</p></li>
-            <li><p>Run the following steps in parallel:</p>
-              <ol>
-                <li><p>Let <var>sanitized certificate</var> be a validated and/or sanitized version of <var>certificate</var>.</p>
-                  <p class="note">The user agent should thoroughly validate the certificate before passing it to the CDM.
-                    This may include verifying values are within reasonable limits, stripping irrelevant data or fields, pre-parsing it, sanitizing it, and/or generating a fully sanitized version.
-                    The user agent should check that the length and values of fields are reasonable.
-                    Unknown fields should be rejected or removed.
+                <li>
+                  <p>
+                    <var>first decryption time</var> - The <dfn id="first-decryption-time">first
+                      decryption time</dfn>, defined as the time at which the session was first used
+                    to decrypt content, accurate to <var><a def-id="key-usage-accuracy"></a></var>
+                    and
                   </p>
                 </li>
-                <li><p>Use this object's <var>cdm instance</var> to process <var>sanitized certificate</var>.</p></li>
-                <li><p>If the preceding step failed, reject <var>promise</var> with <a def-id="new-domexception-named"></a> <a def-id="appropriate-error-name"></a>.</p></li>
-                <li><p>Resolve <var>promise</var> with <code>true</code>.</p></li>
-              </ol>
-            </li>
-            <li><p>Return <var>promise</var>.</p></li>
-          </ol>
-        <table class="parameters"><tbody><tr><th>Parameter</th><th>Type</th><th>Nullable</th><th>Optional</th><th>Description</th></tr><tr><td class="prmName">serverCertificate</td><td class="prmType"><code>BufferSource</code></td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td><td class="prmDesc">
-              The server certificate.
-              The contents are <a def-id="keysystem"></a>-specific.
-              It MUST NOT contain executable code.
-            </td></tr></tbody></table><div><em>Return type: </em><code>Promise&lt;boolean&gt;</code></div></dd></dl></section></div>
-
-      <section id="">
-        <h3>Algorithms</h3>
-        <section id="is-persistent-session-type">
-          <h4>Is persistent session type?</h4>
-          <p>The Is persistent session type? algorithm is run to determine whether the specified session type supports persistence of any kind.
-            Requests to run this algorithm include a <a>MediaKeySessionType</a> value.
-          </p>
-          <p>The following steps are run:</p>
-          <ol>
-            <li><p>Let the <var>session type</var> be the specified <a>MediaKeySessionType</a> value.</p></li>
-            <li><p>Follow the steps for the value of <var>session type</var> from the following list:</p>
-              <dl class="switch">
-                <dt><a def-id="temporary-session"></a></dt>
-                <dd>Return <code>false</code>.</dd>
-                <dt><a def-id="persistent-license-session"></a></dt>
-                <dd>Return <code>true</code>.</dd>
-                <dt><a def-id="persistent-usage-record-session"></a></dt>
-                <dd>Return <code>true</code>.</dd>
-              </dl>
-            </li>
-          </ol>
-        </section>
-        
-        <section id="cdm-unavailable">
-          <h4>CDM Unavailable</h4>
-          <p>
-            The CDM unavailable algorithm is run to close all <a>MediaKeySession</a> objects associated with a <a>MediaKeys</a> object, <var>media keys</var>
-            when the CDM instance becomes unavailable.
-          </p>
-          <p>The following step is run:</p>
-          <ol>
-            <li>
-              <p>For each <a>MediaKeySession</a> created by the <var>media keys</var> that is not <a def-id="media-key-session-closed"></a>, <a def-id="queue-a-task"></a> to run the <a def-id="session-closed-algorithm"></a> algorithm on the session.</p>
-            </li>
-          </ol>
-        </section>
+                <li>
+                  <p>
+                    <var>latest decryption time</var> - The <dfn id="latest-decryption-time">latest
+                      decryption time</dfn>, defined as the latest time at which the session was
+                    used to decrypt content, accurate to <var><a def-id="key-usage-accuracy"></a>
+                    </var>.
+                  </p>
+                </li>
+              </ul>
+              <p> A <a def-id="message"></a> of type <a def-id="message-type-license-release"></a>
+                containing the <a def-id="record-of-key-usage"></a> will be generated each time <a
+                  def-id="remove"></a> is called, until the record is acknowledged by a response
+                passed to <a def-id="update"></a>. </p>
+              <p> The <dfn id="key-usage-accuracy">
+                  <var>key usage accuracy</var>
+                </dfn> is implementation-dependant but SHALL NOT be greater than 60 seconds. </p>
+              <p class="note"> Because the license and keys are not persisted, this record
+                implicitly proves that the keys are no longer available in the session. </p>
+              <p class="note"> User agents MAY implement this mechanism by means other than
+                persisting data on key destruction - for example by persisting data during playback
+                which is later used to infer the fact of key destruction - provided the observable
+                behavior is compliant to this specification. </p>
+              <p> The session MUST be loadable via its <a def-id="session-id"></a> once <a
+                  def-id="update"></a> is called successfully. The application is responsible for
+                managing any such storage that may be generated by the CDM. See <a
+                  def-id="session-storage"></a>. Can only be created if the configuration associated
+                with the <a>MediaKeySystemAccess</a> object that created this object has a <a
+                  def-id="option-persistentState"></a> value of <a
+                  def-id="requirement-required"></a>. Support for this session type is OPTIONAL.
+              </p>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div>
+      <pre class="idl">[Exposed=Window, SecureContext] interface MediaKeys {
+    MediaKeySession  createSession (optional MediaKeySessionType sessionType = "temporary");
+    Promise&lt;boolean&gt; setServerCertificate (BufferSource serverCertificate);
+};</pre>
+      <section>
+        <h2>Methods</h2>
+        <dl class="methods" data-dfn-for="MediaKeys" data-link-for="MediaKeys">
+          <dt>
+            <dfn>
+              <code>createSession</code>
+            </dfn>
+          </dt>
+          <dd>
+            <p>Returns a new <a>MediaKeySession</a> object.</p>
+            <ol class="method-algorithm">
+              <li>
+                <p>If this object's <var>supported session types</var> value does not contain <var>
+                    sessionType</var>, <a def-id="throw"></a> [[WEBIDL]] a <a
+                    def-id="NotSupportedError"></a>.</p>
+                <p class="note">
+                  <var>sessionType</var> values for which the <a
+                    def-id="is-persistent-session-type-algorithm"></a> algorithm returns <code>true
+                  </code> will fail if this object's <var>persistent state allowed</var> value is
+                  <code>false</code>.
+                </p>
+              </li>
+              <li>
+                <p>If the implementation does not support <a>MediaKeySession</a> operations in the
+                  current state, <a def-id="throw"></a> [[WEBIDL]] an <a
+                    def-id="InvalidStateError"></a>.</p>
+                <p class="note">Some implementations are unable to execute <a>MediaKeySession</a>
+                  algorithms until this <a>MediaKeys</a> object is associated with a media element
+                  using <a def-id="setMediaKeys"></a>. This step enables applications to detect this
+                  uncommon behavior before attempting to perform such operations. </p>
+              </li>
+              <li>
+                <p>Let <var>session</var> be a new <a>MediaKeySession</a> object, and initialize it
+                  as follows:</p>
+                <ol>
+                  <li>
+                    <p>Let the <a def-id="sessionId"></a> attribute be the empty string.</p>
+                  </li>
+                  <li>
+                    <p>Let the <a def-id="expiration"></a> attribute be <code>NaN</code>.</p>
+                  </li>
+                  <li>
+                    <p>Let the <a def-id="closed"></a> attribute be a new promise.</p>
+                  </li>
+                  <li>
+                    <p>Let <var>key status</var> be a new empty <a>MediaKeyStatusMap</a> object, and
+                      initialize it as follows:</p>
+                    <ol>
+                      <li>
+                        <p>Let the <a def-id="statusmap-size"></a> attribute be 0.</p>
+                      </li>
+                    </ol>
+                  </li>
+                  <li>
+                    <p>Let the <var>session type</var> value be <var>sessionType</var>.</p>
+                  </li>
+                  <li>
+                    <p>Let the <var>uninitialized</var> value be true.</p>
+                  </li>
+                  <li>
+                    <p>Let the <var>callable</var> value be false.</p>
+                  </li>
+                  <li>
+                    <p>Let the <var>closing or closed</var> value be false.</p>
+                  </li>
+                  <li>
+                    <p>Let the <var>use distinctive identifier</var> value be this object's <var>use
+                        distinctive identifier</var> value.</p>
+                  </li>
+                  <li>
+                    <p>Let the <var>cdm implementation</var> value be this object's <var>cdm
+                        implementation</var>.</p>
+                  </li>
+                  <li>
+                    <p>Let the <var>cdm instance</var> value be this object's <var>cdm instance
+                      </var>.</p>
+                  </li>
+                </ol>
+              </li>
+              <li>
+                <p>Return <var>session</var>.</p>
+              </li>
+            </ol>
+            <table class="parameters">
+              <tbody>
+                <tr>
+                  <th>Parameter</th>
+                  <th>Type</th>
+                  <th>Nullable</th>
+                  <th>Optional</th>
+                  <th>Description</th>
+                </tr>
+                <tr>
+                  <td class="prmName">sessionType</td>
+                  <td class="prmType">
+                    <code>MediaKeySessionType = "temporary"</code>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptTrue">
+                    <span role="img" aria-label="True">✔</span>
+                  </td>
+                  <td class="prmDesc"> The type of session to create. The session type affects the
+                    behavior of the returned object. </td>
+                </tr>
+              </tbody>
+            </table>
+            <div>
+              <em>Return type: </em>
+              <code>MediaKeySession</code>
+            </div>
+          </dd>
+          <dt>
+            <dfn>
+              <code>setServerCertificate</code>
+            </dfn>
+          </dt>
+          <dd>
+            <p id="server-certificate">Provides a server certificate to be used to encrypt messages
+              to the license server.</p>
+            <p>Key Systems that use such certificates MUST also support requesting the certificate
+              from the server via the <a def-id="queue-message-algorithm"></a> algorithm.</p>
+            <p class="note">This method allows an application to proactively provide a server
+              certificate to implementations that support it to avoid the additional round trip
+              should the CDM request it. It is intended as an optimization, and applications are not
+              required to use it. </p>
+            <ol class="method-algorithm">
+              <li>
+                <p>If the <a def-id="keysystem"></a> implementation represented by this object's
+                  <var>cdm implementation</var> value does not support server certificates, return a
+                  promise resolved with <code>false</code>.</p>
+              </li>
+              <li>
+                <p>If <var>serverCertificate</var> is an empty array, return a promise rejected with
+                  a new a newly created <a def-id="TypeError"></a>.</p>
+              </li>
+              <li>
+                <p>Let <var>certificate</var> be a copy of the contents of the <var>
+                    serverCertificate</var> parameter.</p>
+              </li>
+              <li>
+                <p>Let <var>promise</var> be a new promise.</p>
+              </li>
+              <li>
+                <p>Run the following steps in parallel:</p>
+                <ol>
+                  <li>
+                    <p>Let <var>sanitized certificate</var> be a validated and/or sanitized version
+                      of <var>certificate</var>.</p>
+                    <p class="note">The user agent should thoroughly validate the certificate before
+                      passing it to the CDM. This may include verifying values are within reasonable
+                      limits, stripping irrelevant data or fields, pre-parsing it, sanitizing it,
+                      and/or generating a fully sanitized version. The user agent should check that
+                      the length and values of fields are reasonable. Unknown fields should be
+                      rejected or removed. </p>
+                  </li>
+                  <li>
+                    <p>Use this object's <var>cdm instance</var> to process <var>sanitized
+                        certificate</var>.</p>
+                  </li>
+                  <li>
+                    <p>If the preceding step failed, reject <var>promise</var> with <a
+                        def-id="new-domexception-named"></a> <a
+                        def-id="appropriate-error-name"></a>.</p>
+                  </li>
+                  <li>
+                    <p>Resolve <var>promise</var> with <code>true</code>.</p>
+                  </li>
+                </ol>
+              </li>
+              <li>
+                <p>Return <var>promise</var>.</p>
+              </li>
+            </ol>
+            <table class="parameters">
+              <tbody>
+                <tr>
+                  <th>Parameter</th>
+                  <th>Type</th>
+                  <th>Nullable</th>
+                  <th>Optional</th>
+                  <th>Description</th>
+                </tr>
+                <tr>
+                  <td class="prmName">serverCertificate</td>
+                  <td class="prmType">
+                    <code>BufferSource</code>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc"> The server certificate. The contents are <a
+                      def-id="keysystem"></a>-specific. It MUST NOT contain executable code. </td>
+                </tr>
+              </tbody>
+            </table>
+            <div>
+              <em>Return type: </em>
+              <code>Promise&lt;boolean&gt;</code>
+            </div>
+          </dd>
+        </dl>
       </section>
-      <section id="media-keys-storage">
-        <h3>Storage and Persistence</h3>
-        <p>This section describes general requirements related to storage and persistence.</p>
-        
-        <p>
-          If a <a>MediaKeys</a> object's <var>persistent state allowed</var> value is <code>false</code> then the object's <var>cdm instance</var>
-          SHALL NOT persist state or access previously persisted state as a result of operations on this object or any sessions that it creates.
-        </p>
-        <p>
-          If a <a>MediaKeys</a> object's <var>persistent state allowed</var> value is <code>true</code> then the object's <var>cdm instance</var>
-          MAY persist state or access previously persisted state as a result of operations on this object or any sessions that it creates.
-        </p>
-        
-        <p>Persisted data MUST always be stored such that only the <a def-id="origin"></a> of this object's <a def-id="document-concept"></a> can access it.
-          In addition, the data MUST only be accessible by the current <a def-id="browsing-profile"></a>; other browsing profiles, user agents, and applications MUST NOT be able to access the stored data.
-          See <a href="#privacy-storedinfo">Information Stored on User Devices</a>.
-        </p>
-        
-        <p>See <a href="#security"></a> and <a href="#privacy"></a> for additional considerations when supporting persistent storage.</p>
-
+    </div>
+    <section id="">
+      <h3>Algorithms</h3>
+      <section id="is-persistent-session-type">
+        <h4>Is persistent session type?</h4>
+        <p>The Is persistent session type? algorithm is run to determine whether the specified
+          session type supports persistence of any kind. Requests to run this algorithm include a
+          <a>MediaKeySessionType</a> value. </p>
+        <p>The following steps are run:</p>
+        <ol>
+          <li>
+            <p>Let the <var>session type</var> be the specified <a>MediaKeySessionType</a> value.
+            </p>
+          </li>
+          <li>
+            <p>Follow the steps for the value of <var>session type</var> from the following list:
+            </p>
+            <dl class="switch">
+              <dt><a def-id="temporary-session"></a></dt>
+              <dd>Return <code>false</code>.</dd>
+              <dt><a def-id="persistent-license-session"></a></dt>
+              <dd>Return <code>true</code>.</dd>
+              <dt><a def-id="persistent-usage-record-session"></a></dt>
+              <dd>Return <code>true</code>.</dd>
+            </dl>
+          </li>
+        </ol>
+      </section>
+      <section id="cdm-unavailable">
+        <h4>CDM Unavailable</h4>
+        <p> The CDM unavailable algorithm is run to close all <a>MediaKeySession</a> objects
+          associated with a <a>MediaKeys</a> object, <var>media keys</var> when the CDM instance
+          becomes unavailable. </p>
+        <p>The following step is run:</p>
+        <ol>
+          <li>
+            <p>For each <a>MediaKeySession</a> created by the <var>media keys</var> that is not <a
+                def-id="media-key-session-closed"></a>, <a def-id="queue-a-task"></a> to run the <a
+                def-id="session-closed-algorithm"></a> algorithm on the session.</p>
+          </li>
+        </ol>
       </section>
     </section>
-
-
-    <section>
-      <h2><dfn>MediaKeySession</dfn> Interface</h2>
-      <p>The MediaKeySession object represents a <a href="#key-session">key session</a>.</p>
-      <p>
-        A <a>MediaKeySession</a> object is <dfn id="media-key-session-closed">closed</dfn> if and only if the object's <a def-id="closed"></a> attribute has been resolved.
+    <section id="media-keys-storage">
+      <h3>Storage and Persistence</h3>
+      <p>This section describes general requirements related to storage and persistence.</p>
+      <p> If a <a>MediaKeys</a> object's <var>persistent state allowed</var> value is <code>false
+        </code> then the object's <var>cdm instance</var> SHALL NOT persist state or access
+        previously persisted state as a result of operations on this object or any sessions that it
+        creates. </p>
+      <p> If a <a>MediaKeys</a> object's <var>persistent state allowed</var> value is <code>true
+        </code> then the object's <var>cdm instance</var> MAY persist state or access previously
+        persisted state as a result of operations on this object or any sessions that it creates.
       </p>
-      <p>
-        The User Agent SHALL execute the <a def-id="monitor-cdm-algorithm"></a> algorithm continuously for each <a>MediaKeySession</a> object
-        that is not <a def-id="media-key-session-closed"></a>.
-        The <a def-id="monitor-cdm-algorithm"></a> algorithm MUST be run in parallel to the main event loop but not in parallel to other procedures defined
-        in this specification that are also defined to be run in parallel.
-      </p>
-      <p>
-        A <a>MediaKeySession</a> object SHALL NOT be destroyed and SHALL continue to receive events if it is
-        not <a def-id="media-key-session-closed"></a> and the <a>MediaKeys</a> object that created it remains accessible.
-        Otherwise, a <a>MediaKeySession</a> object that is no longer accessible SHALL NOT receive further
-        events and MAY be destroyed.
-      </p>
-      <p class="note">
-        The above rule implies that the CDM instance must not be destroyed until all <a>MediaKeys</a>
-        objects and all <a>MediaKeySession</a> objects associated with the CDM instance are destroyed.
-      </p>
-      <p>
-        If a <a>MediaKeySession</a> object is not <a def-id="media-key-session-closed"></a> when it becomes inaccessible to the page, the CDM SHALL close the <a href="#key-session">key session</a> associated with the object.
-      </p>
-      <p class="note">Closing the key session results in the destruction of any license(s) and key(s) that have not been explicitly stored.</p>
-      <p class="note">
-        Exactly when the key session is closed is an implementation detail, and applications SHOULD NOT rely on specific timing.
-        <!-- TODO: Replace and/or expand on this with an implementation of Issue #360. --> 
-        Applications that want to ensure a session is closed before taking some other action SHOULD call <a def-id="close"></a> and wait for the returned promise to be resolved.
-      </p>
-      <p>
-        If a <a>MediaKeySession</a> object becomes inaccessible to the page
-        and is not <a def-id="media-key-session-closed"></a>, the User Agent
-        MUST run the <a def-id="media-key-session-destroyed-algorithm"></a> algorithm before User Agent state
-        associated with the <a href="#key-session">session</a> is deleted.
-      </p>
-      <p>For methods that return a promise, all errors are reported asynchronously by rejecting the returned Promise. This includes [[WEBIDL]] type mapping errors.</p>
-      <p>The following steps of an algorithm are always aborted when rejecting a promise.</p>
-
-      <div><pre class="idl">[Exposed=Window, SecureContext] interface MediaKeySession : EventTarget {
+      <p>Persisted data MUST always be stored such that only the <a def-id="origin"></a> of this
+        object's <a def-id="document-concept"></a> can access it. In addition, the data MUST only be
+        accessible by the current <a def-id="browsing-profile"></a>; other browsing profiles, user
+        agents, and applications MUST NOT be able to access the stored data. See <a
+          href="#privacy-storedinfo">Information Stored on User Devices</a>. </p>
+      <p>See <a href="#security"></a> and <a href="#privacy"></a> for additional considerations when
+        supporting persistent storage.</p>
+    </section>
+  </section>
+  <section>
+    <h2>
+      <dfn>MediaKeySession</dfn> Interface
+    </h2>
+    <p>The MediaKeySession object represents a <a href="#key-session">key session</a>.</p>
+    <p> A <a>MediaKeySession</a> object is <dfn id="media-key-session-closed">closed</dfn> if and
+      only if the object's <a def-id="closed"></a> attribute has been resolved. </p>
+    <p> The User Agent SHALL execute the <a def-id="monitor-cdm-algorithm"></a> algorithm
+      continuously for each <a>MediaKeySession</a> object that is not <a
+        def-id="media-key-session-closed"></a>. The <a def-id="monitor-cdm-algorithm"></a> algorithm
+      MUST be run in parallel to the main event loop but not in parallel to other procedures defined
+      in this specification that are also defined to be run in parallel. </p>
+    <p> A <a>MediaKeySession</a> object SHALL NOT be destroyed and SHALL continue to receive events
+      if it is not <a def-id="media-key-session-closed"></a> and the <a>MediaKeys</a> object that
+      created it remains accessible. Otherwise, a <a>MediaKeySession</a> object that is no longer
+      accessible SHALL NOT receive further events and MAY be destroyed. </p>
+    <p class="note"> The above rule implies that the CDM instance must not be destroyed until all
+      <a>MediaKeys</a> objects and all <a>MediaKeySession</a> objects associated with the CDM
+      instance are destroyed. </p>
+    <p> If a <a>MediaKeySession</a> object is not <a def-id="media-key-session-closed"></a> when it
+      becomes inaccessible to the page, the CDM SHALL close the <a href="#key-session">key
+        session</a> associated with the object. </p>
+    <p class="note">Closing the key session results in the destruction of any license(s) and key(s)
+      that have not been explicitly stored.</p>
+    <p class="note"> Exactly when the key session is closed is an implementation detail, and
+      applications SHOULD NOT rely on specific timing.
+      <!-- TODO: Replace and/or expand on this with an implementation of Issue #360. -->
+      Applications that want to ensure a session is closed before taking some other action SHOULD
+      call <a def-id="close"></a> and wait for the returned promise to be resolved. </p>
+    <p> If a <a>MediaKeySession</a> object becomes inaccessible to the page and is not <a
+        def-id="media-key-session-closed"></a>, the User Agent MUST run the <a
+        def-id="media-key-session-destroyed-algorithm"></a> algorithm before User Agent state
+      associated with the <a href="#key-session">session</a> is deleted. </p>
+    <p>For methods that return a promise, all errors are reported asynchronously by rejecting the
+      returned Promise. This includes [[WEBIDL]] type mapping errors.</p>
+    <p>The following steps of an algorithm are always aborted when rejecting a promise.</p>
+    <div>
+      <pre class="idl">[Exposed=Window, SecureContext] interface MediaKeySession : EventTarget {
     readonly        attribute DOMString           sessionId;
     readonly        attribute unrestricted double expiration;
     readonly        attribute Promise&lt;void&gt;       closed;
@@ -1796,603 +2599,1199 @@ The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows:
     Promise&lt;void&gt;    update (BufferSource response);
     Promise&lt;void&gt;    close ();
     Promise&lt;void&gt;    remove ();
-};</pre><section><h2>Attributes</h2><dl class="attributes" data-dfn-for="MediaKeySession" data-link-for="MediaKeySession"><dt><dfn><code>sessionId</code></dfn> of type <span class="idlAttrType">{{DOMString}}</span>, readonly       </dt><dd>
-          <p>The <a def-id="session-id"></a> for this object and the associated key(s) or license(s).</p>
-        </dd><dt><dfn><code>expiration</code></dfn> of type <span class="idlAttrType">{{unrestricted double}}</span>, readonly       </dt><dd>
-          <p>The <a def-id="expiration-time"></a> for all key(s) in the session, or <code>NaN</code> if no such time exists or if the license explicitly never expires, as determined by the CDM.</p>
-          <p class="note">This value MAY change during the session lifetime, such as when an action triggers the start of a window.</p>
-        </dd><dt><dfn><code>closed</code></dfn> of type <span class="idlAttrType">Promise&lt;{{void}}&gt;</span>, readonly       </dt><dd>
-          <p>Signals when the object becomes <a def-id="media-key-session-closed"></a> as a result of the <a def-id="session-closed-algorithm"></a> algorithm being run.
-          This promise can only be fulfilled and is never rejected.</p>
-        </dd><dt><dfn><code>keyStatuses</code></dfn> of type <span class="idlAttrType"><a>MediaKeyStatusMap</a></span>, readonly       </dt><dd>
-          <p>A reference to a read-only map of <a def-id="key-id">key IDs</a> <a href="#known-key">known</a> to the session to the current status of the associated key.
-           Each entry MUST have a unique key ID.
-         </p>
-          <p class="note">The map entries and their values may be updated whenever the event loop spins.
-            The map MUST NOT ever be inconsistent or partially updated, but it may change between accesses if the event loop spins in between the accesses.
-            Key IDs may be added as the result of a <a def-id="load"></a> or <a def-id="update"></a> call.
-            Key IDs may be removed as the result of a <a def-id="update"></a> call that removes knowledge of existing keys (or replaces the existing set of keys with a new set).
-            Key IDs MUST NOT be removed because they became unusable, such as due to expiration. Instead, such keys MUST be given an appropriate status, such as <a def-id="status-expired"></a>.
-          </p>
-          <p class="note">
-            Some older platforms may contain Key System implementations that do not expose key IDs, making it impossible to provide a compliant user agent implementation. 
-            To maximize interoperability, user agent implementations exposing such CDMs SHOULD implement this member as follows:
-            Whenever a non-empty list is appropriate, such as when the <a href="#key-session">key session</a> represented by this object may contain <a href="#decryption-key">key(s)</a>, populate the map with a single pair containing
-            the one-byte key ID <code>0</code> and the <a>MediaKeyStatus</a> most appropriate for the aggregated status of this object.
-          </p>
-        </dd><dt><dfn><code>onkeystatuseschange</code></dfn> of type <span class="idlAttrType">{{EventHandler}}</span></dt><dd>
-          <p>Event handler for the <a def-id="keystatuseschange"></a> event.</p>
-        </dd><dt><dfn><code>onmessage</code></dfn> of type <span class="idlAttrType">{{EventHandler}}</span></dt><dd>
-          <p>Event handler for the <a def-id="message"></a> event.</p>
-        </dd></dl></section><section><h2>Methods</h2><dl class="methods" data-dfn-for="MediaKeySession" data-link-for="MediaKeySession"><dt><dfn><code>generateRequest</code></dfn></dt><dd>
-          <p>Generates a license request based on the <var>initData</var>.
-            A <a def-id="message"></a> of type <a def-id="message-type-license-request"></a> or <a def-id="message-type-individualization-request"></a> will always be queued if the algorithm succeeds and the promise is resolved.
-          </p>
-
-          
-
-          <ol class="method-algorithm">
-            <li><p>If this object's <var>closing or closed</var> value is true, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
-            <li><p>If this object's <var>uninitialized</var> value is false, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
-            <li><p>Let this object's <var>uninitialized</var> value be false.</p></li><!-- For simplicity and consistency, this object cannot be reused after any failure. -->
-            <li><p>If <var>initDataType</var> is the empty string, return a promise rejected with a newly created <a def-id="TypeError"></a>.</p></li>
-            <li><p>If <var>initData</var> is an empty array, return a promise rejected with a newly created <a def-id="TypeError"></a>.</p></li>
-            <li><p>If the <a def-id="keysystem"></a> implementation represented by this object's <var>cdm implementation</var> value does not support <var>initDataType</var> as an <a def-id="initialization-data-type"></a>, return a promise rejected with a <a def-id="NotSupportedError"></a>. String comparison is case-sensitive.</p></li>
-            <li><p>Let <var>init data</var> be a copy of the contents of the <var>initData</var> parameter.</p></li>
-            <li><p>Let <var>session type</var> be this object's <var>session type</var>.</p></li>
-            <li><p>Let <var>promise</var> be a new promise.</p></li>
-            <li><p>Run the following steps in parallel:</p>
-              <ol>
-                <li><p>If the <var>init data</var> is not valid for <var>initDataType</var>, reject <var>promise</var> with a newly created <a def-id="TypeError"></a>.</p></li>
-                <li><p>Let <var>sanitized init data</var> be a validated and sanitized version of <var>init data</var>.</p>
-                  <p>The user agent MUST thoroughly validate the <a def-id="initialization-data"></a> before passing it to the CDM.
-                    This includes verifying that the length and values of fields are reasonable, verifying that values are within reasonable limits, and stripping irrelevant, unsupported, or unknown data or fields.
-                    It is RECOMMENDED that user agents pre-parse, sanitize, and/or generate a fully sanitized version of the <a def-id="initialization-data"></a>.
-                    If the <a def-id="initialization-data"></a> format specified by <var>initDataType</var> supports multiple entries, the user agent SHOULD remove entries that are not needed by the CDM. The user agent MUST NOT re-order entries within the <a def-id="initialization-data"></a>.
-                  </p>
-                </li>
-                <li><p>If the preceding step failed, reject <var>promise</var> with a newly created <a def-id="TypeError"></a>.</p></li>
-                <li><p>If <var>sanitized init data</var> is empty, reject <var>promise</var> with a <a def-id="NotSupportedError"></a>.</p></li>
-                <li><p>Let <var>session id</var> be the empty string.</p></li>
-                <li><p>Let <var>message</var> be null.</p></li>
-                <li><p>Let <var>message type</var> be null.</p></li>
-                <li><p>Let <var>cdm</var> be the CDM instance represented by this object's <var>cdm instance</var> value.</p></li>
-                <li><p>Use the <var>cdm</var> to execute the following steps:</p>
-                  <ol>
-                    <li><p>If the <var>sanitized init data</var> is not supported by the <var>cdm</var>, reject <var>promise</var> with a <a def-id="NotSupportedError"></a>.</p></li>
-                    <li><p>Follow the steps for the value of <var>session type</var> from the following list:</p>
-                      <dl class="switch">
-                        <dt><a def-id="temporary-session"></a></dt>
-                        <dd>
-                          <p>Let <var>requested license type</var> be a temporary non-persistable license.</p>
-                          <p class="note">The returned license must not be persistable or require persisting information related to it.</p>
-                        </dd>
-                        <dt><a def-id="persistent-license-session"></a></dt>
-                        <dd>
-                          <p>Let <var>requested license type</var> be a persistable license.</p>
-                        </dd>
-                        <dt><a def-id="persistent-usage-record-session"></a></dt>
-                        <dd>
-                          <ol>
-                            <li>
-                              <p>Initialize this object's <var>record of key usage</var> as follows.</p>
-                              <ul>
-                                <li>
-                                  <p>
-                                    Set the list of <a def-id="key-id">key IDs</a> <a href="#known-key">known</a> to the session to an empty list.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Set the <var>first decrypt time</var> to <code>null</code>.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Set the <var>latest decrypt time</var> to <code>null</code>.
-                                  </p>
-                                </li>
-                              </ul>
-                            </li>
-                            <li>
-                              <p>Let <var>requested license type</var> be a non-persistable license that will persist a <a def-id="record-of-key-usage"></a>.</p>
-                            </li>
-                          </ol>
-                        </dd>
-                      </dl>
-                    </li>
-
-                    <li><p>Let <var>session id</var> be a unique <a def-id="session-id"></a> string.</p>
-                      <p>If the result of running the <a def-id="is-persistent-session-type-algorithm"></a> algorithm on <var>session type</var> is <code>true</code>, the ID MUST be unique within the <a def-id="origin"></a> of this object's <a def-id="document-concept"></a> over time, including across Documents and browsing sessions.</p>
-                    </li>
-                    <li>
-                      <dl class="switch">
-                        <dt>If a license request for the <var>requested license type</var> can be generated based on the <var>sanitized init data</var>:</dt>
-                        <dd>
-                          <ol>
-                            <li>
-                              <p>
-                                Let <var>message</var> be a license request for the <var>requested license type</var> generated based on the <var>sanitized init data</var>
-                                interpreted per <var>initDataType</var>.
-                              </p>
-                              <p>
-                                The <var>cdm</var> MUST NOT use any stream-specific data, including <a def-id="media-data"></a>, not provided via the
-                                <var>sanitized init data</var>.
-                              </p>
-                              <p>The <var>cdm</var> SHOULD NOT store session data, including the session ID, at this point. See <a def-id="session-storage"></a>.</p>
-                            </li>
-                            <li>
-                              <p>
-                                Let <var>message type</var> be <a def-id="message-type-license-request"></a>.
-                              </p>
-                            </li>
-                          </ol>
-                        </dd>
-                        <dt>Otherwise:</dt>
-                        <dd>
-                          <ol>
-                            <li>
-                              <p>
-                                Let <var>message</var> be the request that needs to be processed before a license request request
-                                for the <var>requested license type</var> can be generated based on the <var>sanitized init data</var>.
-                              </p>
-                              <p>
-                                In a subsequent call to <a def-id="update"></a> the CDM MUST generate a license request for the <var>requested license type</var>
-                                based on the <var>sanitized init data</var>, which is interpreted per <var>initDataType</var>.
-                              </p>
-                            </li>
-                            <li>
-                              <p>
-                                Let <var>message type</var> reflect the type of <var>message</var>, either <a def-id="message-type-license-request"></a> or <a def-id="message-type-individualization-request"></a>.
-                              </p>
-                            </li>
-                          </ol>
-                        </dd>
-                      </dl>
-                    </li>
-                  </ol>
-                </li>
-                <li>
-                  <p><a def-id="Queue-a-task"></a> to run the following steps:</p>
-                  <ol>
-                    <li><p>If any of the preceding steps failed, reject <var>promise</var> with <a def-id="new-domexception-named"></a> <a def-id="appropriate-error-name"></a>.</p></li>
-                    <li><p>Set the <a def-id="sessionId"></a> attribute to <var>session id</var>.</p></li>
-                    <li><p>Set this object's <var>callable</var> value to true.</p></li>
-                    <li><p>Run the <a def-id="queue-message-algorithm"></a> algorithm on the <var>session</var>, providing <var>message type</var> and <var>message</var>.</p>
-                    <li>
-                      <p>Resolve <var>promise</var>.</p>
-                      <p class="note">Since promise handlers are queued as microtasks, these will be executed ahead of any events queued by the preceding steps.</p>
-                    </li>
-                  </ol>
-                </li>
-              </ol>
-            </li>
-            <li><p>Return <var>promise</var>.</p></li>
-          </ol>
-        <table class="parameters"><tbody><tr><th>Parameter</th><th>Type</th><th>Nullable</th><th>Optional</th><th>Description</th></tr><tr><td class="prmName">initDataType</td><td class="prmType"><code>DOMString</code></td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td><td class="prmDesc">
-              The <a def-id="initialization-data-type"></a> of the <var>initData</var>.
-            </td></tr><tr><td class="prmName">initData</td><td class="prmType"><code>BufferSource</code></td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td><td class="prmDesc">
-              <a def-id="initialization-data"></a>
-            </td></tr></tbody></table><div><em>Return type: </em><code>Promise&lt;void&gt;</code></div></dd><dt><dfn><code>load</code></dfn></dt><dd>
-          <p>Loads the data stored for the specified session into this object.</p>
-
-          
-
-          <ol class="method-algorithm">
-            <li><p>If this object's <var>closing or closed</var> value is true, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
-            <li><p>If this object's <var>uninitialized</var> value is false, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
-            <li><p>Let this object's <var>uninitialized</var> value be false.</p></li><!-- For simplicity and consistency, this object cannot be reused after any failure. -->
-            <li><p>If <var>sessionId</var> is the empty string, return a promise rejected with a newly created <a def-id="TypeError"></a>.</p></li>
-            <li><p>If the result of running the <a def-id="is-persistent-session-type-algorithm"></a> algorithm on this object's <var>session type</var> is <code>false</code>, return a promise rejected with a newly created <a def-id="TypeError"></a>.</p></li>
-            <li><p>Let <var>origin</var> be the <a def-id="origin"></a> of this object's <a def-id="document-concept"></a>.</p></li>
-            <li><p>Let <var>promise</var> be a new promise.</p></li>
-            <li><p>Run the following steps in parallel:</p>
-              <ol>
-                <li><p>Let <var>sanitized session ID</var> be a validated and/or sanitized version of <var>sessionId</var>.</p>
-                  <p class="note">The user agent should thoroughly validate the sessionId value before passing it to the CDM.
-                    At a minimum, this should include checking that the length and value are reasonable (e.g., not longer than tens of characters and alphanumeric).
-                  </p>
-                </li>
-                <li><p>If the preceding step failed, or if <var>sanitized session ID</var> is empty, reject <var>promise</var> with a newly created <a def-id="TypeError"></a>.</p></li>
-                <li><p>If there is a <a>MediaKeySession</a> object that is not <a def-id="media-key-session-closed"></a> in this object's <a def-id="document-concept"></a> whose <a def-id="sessionId"></a> attribute is <var>sanitized session ID</var>, reject <var>promise</var> with a <a def-id="QuotaExceededError"></a>.</p>
-                  <p class="note">In other words, do not create a session if a non-closed session, regardless of type, already exists for this <var>sanitized session ID</var> in this browsing context.</p>
-                </li>
-                <li><p>Let <var>expiration time</var> be <code>NaN</code>.</p></li>
-                <li><p>Let <var>message</var> be null.</p></li>
-                <li><p>Let <var>message type</var> be null.</p></li>
-                <li><p>Let <var>cdm</var> be the CDM instance represented by this object's <var>cdm instance</var> value.</p></li>
-                <li><p>Use the <var>cdm</var> to execute the following steps:</p>
-                  <ol>
-                    <li><p>If there is no data stored for the <var>sanitized session ID</var> in the <var>origin</var>, resolve <var>promise</var> with <code>false</code> and abort these steps.<!-- Per https://github.com/w3ctag/promises-guide#rejections-should-be-used-for-exceptional-situations. --></p></li>
-                    <li><p>If the stored session's <var>session type</var> is not the same as the current <a>MediaKeySession</a> <var>session type</var>, reject <var>promise</var> with a newly created <a def-id="TypeError"></a>.</p></li>
-                    <li><p>Let <var>session data</var> be the data stored for the <var>sanitized session ID</var> in the <var>origin</var>.
-                    This MUST NOT include data from other origin(s) or that is not associated with an origin.</p></li>
-                    <li><p>If there is a <a>MediaKeySession</a> object that is not <a def-id="media-key-session-closed"></a> in any <a def-id="document-concept"></a> and that
-                    represents the <var>session data</var>, reject <var>promise</var> with a <a def-id="QuotaExceededError"></a>.</p>
-                      <p class="note">In other words, do not create a session if a non-closed persistent session already exists for this <var>sanitized session ID</var> in any browsing context.</p>
-                    </li>
-                    <li><p>Load the <var>session data</var>.</p></li>
-                    <li><p>If the <var>session data</var> indicates an <a def-id="expiration-time"></a> for the session, let <var>expiration time</var> be that expiration time.</p></li>
-                    <li><p>If a message needs to be sent, execute the following steps:</p>
-                      <ol>
-                        <li><p>Let <var>message</var> be a message generated based on the <var>session data</var>.</p></li>
-                        <li><p>Let <var>message type</var> be the appropriate <a>MediaKeyMessageType</a> for the message.</p></li>
-                      </ol>
-                    </li>
-                  </ol>
-                </li>
-                <li>
-                  <p><a def-id="Queue-a-task"></a> to run the following steps:</p>
-                  <ol>
-                    <li><p>If any of the preceding steps failed, reject <var>promise</var> with a <a def-id="appropriate-error-name"></a>.</p></li>
-                    <li><p>Set the <a def-id="sessionId"></a> attribute to <var>sanitized session ID</var>.</p></li>
-                    <li><p>Set this object's <var>callable</var> value to true.</p></li>
-                    <li>
-                      <p>
-                        If the loaded session contains information about any keys (there are <a href="#known-key">known keys</a>), run the <a def-id="update-key-statuses-algorithm"></a> algorithm on the <var>session</var>, providing each key's <a def-id="key-id"></a> along with the appropriate <a>MediaKeyStatus</a>.
-                      </p>
-                      <p>Should additional processing be necessary to determine with certainty the status of a key, use <a def-id="status-status-pending"></a>.
-                        Once the additional processing for one or more keys has completed, run the <a def-id="update-key-statuses-algorithm"></a> algorithm again with the actual status(es).
-                      </p>
-                    </li>
-                    <li><p>Run the <a def-id="update-expiration-algorithm"></a> algorithm on the <var>session</var>, providing <var>expiration time</var>.</p></li>
-                    <li><p>If <var>message</var> is not null, run the <a def-id="queue-message-algorithm"></a> algorithm on the <var>session</var>, providing <var>message type</var> and <var>message</var>.</p></li>
-
-                    <li>
-                      <p>Resolve <var>promise</var> with <code>true</code>.</p>
-                      <p class="note">Since promise handlers are queued as microtasks, these will be executed ahead of any events queued by the preceding steps.</p>
-                    </li>
-                  </ol>
-                </li>
-              </ol>
-            </li>
-            <li><p>Return <var>promise</var>.</p></li>
-          </ol>
-        <table class="parameters"><tbody><tr><th>Parameter</th><th>Type</th><th>Nullable</th><th>Optional</th><th>Description</th></tr><tr><td class="prmName">sessionId</td><td class="prmType"><code>DOMString</code></td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td><td class="prmDesc">
-              The <a def-id="session-id"></a> of the session to load.
-            </td></tr></tbody></table><div><em>Return type: </em><code>Promise&lt;boolean&gt;</code></div></dd><dt><dfn><code>update</code></dfn></dt><dd>
-          <p>Provides messages, including licenses, to the CDM.</p>
-
-          
-
-          <ol class="method-algorithm">
-            <li><p>If this object's <var>closing or closed</var> value is true, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
-            <li><p>If this object's <var>callable</var> value is false, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
-            <li><p>If <var>response</var> is an empty array, return a promise rejected with a newly created <a def-id="TypeError"></a>.</p></li>
-            <li><p>Let <var>response copy</var> be a copy of the contents of the <var>response</var> parameter.</p></li>
-            <li><p>Let <var>promise</var> be a new promise.</p></li>
-            <li><p>Run the following steps in parallel:</p>
-              <ol>
-                <li><p>Let <var>sanitized response</var> be a validated and/or sanitized version of <var>response copy</var>.</p>
-                  <p class="note">The user agent should thoroughly validate the response before passing it to the CDM.
-                    This may include verifying values are within reasonable limits, stripping irrelevant data or fields, pre-parsing it, sanitizing it, and/or generating a fully sanitized version.
-                    The user agent should check that the length and values of fields are reasonable.
-                    Unknown fields should be rejected or removed.
-                  </p>
-                </li>
-                <li><p>If the preceding step failed, or if <var>sanitized response</var> is empty, reject <var>promise</var> with a newly created <a def-id="TypeError"></a>.</p></li>
-                <li><p>Let <var>message</var> be null.</p></li>
-                <li><p>Let <var>message type</var> be null.</p></li>
-                <li><p>Let <var>session closed</var> be false.</p></li>
-                <li><p>Let <var>cdm</var> be the CDM instance represented by this object's <var>cdm instance</var> value.</p></li>
-                <li><p>Use the <var>cdm</var> to execute the following steps:</p>
-                  <ol>
-                    <li><p>If the format of <var>sanitized response</var> is invalid in any way, reject <var>promise</var> with a newly created <a def-id="TypeError"></a>.</p></li>
-                    <li><p>Process <var>sanitized response</var>, following the stipulation for the first matching condition from the following list:</p>
-                      <dl class="switch">
-                        <dt>If <var>sanitized response</var> contains a license or key(s)</dt>
-                        <dd>
-                          <p class="note">This includes an initial license, an updated license, and a license renewal message.</p>
-                          <p>Process <var>sanitized response</var>, following the stipulation for the first matching condition from the following list:</p>
-                          <dl class="switch">
-                            <dt>If <var>sessionType</var> is <a def-id="temporary-session"></a> and <var>sanitized response</var> does not specify that session data, including any license, key(s), or similar session data it contains, should be stored</dt>
-                            <dd>Process <var>sanitized response</var>, not storing any session data.</dd>
-                            <dt>If <var>sessionType</var> is <a def-id="persistent-license-session"></a> and <var>sanitized response</var> contains a persistable license</dt>
-                            <dd>Process <var>sanitized response</var>, storing the license/key(s) and related session data contained in <var>sanitized response</var>.
-                              Such data MUST be stored such that only the <a def-id="origin"></a> of this object's <a def-id="document-concept"></a> can access it.
-                            </dd>
-                            <dt>If <var>sessionType</var> is <a def-id="persistent-usage-record-session"></a> and <var>sanitized response</var> contains a non-persistable license</dt>
-                            <dd>
-                              <p>Run the following steps:</p>
-                              <ol>
-                                <li>
-                                  <p>
-                                    Process <var>sanitized response</var>, not storing any session data.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If processing <var>sanitized response</var> results in the addition of keys to the set of <a href="#known-key">known keys</a>, add the <a def-id="key-id">key IDs</a> of these keys to this object's <var>record of key usage</var>.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                            <dt>Otherwise</dt>
-                            <dd><p>Reject <var>promise</var> with a newly created <a def-id="TypeError"></a>.</p></dd>
-                          </dl>
-                          <p>See also <a def-id="session-storage"></a>.</p>
-                          <p>State information, including keys, for each session MUST be stored in such a way that closing one session does not affect the observable state in other session(s), even if they contain overlapping key IDs.</p>
-                          <p class="note">When <var>sanitized response</var> contains key(s) and/or related data, <var>cdm</var> will likely store (in memory) the key and related data indexed by key ID.</p>
-                          <p class="note">The replacement algorithm within a session is <a def-id="keysystem"></a>-dependent.</p>
-                          <p class="note">It is RECOMMENDED that CDM implementations support a standard and reasonably high minimum number of keys per <a>MediaKeySession</a> object, including a standard replacement algorithm, and a standard and reasonably high minimum number of <a>MediaKeySession</a> objects.
-                            This enables a reasonable number of key rotation algorithms to be implemented across user agents and may reduce the likelihood of playback interruptions in use cases that involve various streams in the same element (e.g., adaptive streams, various audio and video tracks) using different keys.
-                          </p>
-                        </dd>
-                        <dt>If <var>sanitized response</var> contains a <a def-id="record-of-license-destruction"></a> acknowledgement and <var>sessionType</var> is <a def-id="persistent-license-session"></a></dt>
-                        <dd>
-                          <p>Run the following steps:</p>
-                          <ol>
-                            <li>
-                              <p>
-                                Close the <a href="#key-session">key session</a> and clear <em>all</em> stored session data associated with this object,
-                                including the <a def-id="sessionId"></a> and <a def-id="record-of-license-destruction"></a>.
-                              </p>
-                              <p class="note">A subsequent call to <a def-id="load"></a> with the value of this object's <a def-id="sessionId"></a> would fail because there is no data stored for that session ID.</p>
-                            </li>
-                            <li><p>Set <var>session closed</var> to true.</p></li>
-                          </ol>
-                        </dd>
-                        <dt>If <var>sanitized response</var> contains a <a def-id="record-of-key-usage"></a> acknowledgement and <var>sessionType</var> is <a def-id="persistent-usage-record-session"></a></dt>
-                        <dd>
-                          <p>Run the following steps:</p>
-                          <ol>
-                            <li>
-                              <p>
-                                Close the <a href="#key-session">session</a> and clear <em>all</em> stored session data associated with this object,
-                                including the <a def-id="sessionId"></a> and <a def-id="record-of-key-usage"></a>.
-                              </p>
-                              <p class="note">A subsequent call to <a def-id="load"></a> with the value of this object's <a def-id="sessionId"></a> would fail because there is no data stored for that session ID.</p>
-                            </li>
-                            <li><p>Set <var>session closed</var> to true.</p></li>
-                          </ol>
-                        </dd>
-                        <dt>Otherwise</dt>
-                        <dd>Process <var>sanitized response</var>, not storing any session data.
-                          <p class="note">For example, <var>sanitized response</var> may contain information that will be used to generate another <a def-id="message"></a> event.
-                            In this case, there is no need to verify the contents against the <var>sessionType</var>.
-                          </p>
-                        </dd>
-                      </dl>
-                    </li>
-                    <li><p>If a message needs to be sent, execute the following steps:</p>
-                      <ol>
-                        <li><p>Let <var>message</var> be that message.</p></li>
-                        <li><p>Let <var>message type</var> be the appropriate <a>MediaKeyMessageType</a> for the message.</p></li>
-                      </ol>
-                    </li>
-                  </ol>
-                </li>
-                <li>
-                  <p><a def-id="Queue-a-task"></a> to run the following steps:</p>
-                  <ol>
-                    <li>
-                      <dl class="switch">
-                        <dt>If <var>session closed</var> is true:</dt>
-                        <dd>
-                          <p>Run the <a def-id="session-closed-algorithm"></a> algorithm on this object.</p>
-                        </dd>
-                        <dt>Otherwise:</dt>
-                        <dd>
-                          <p>Run the following steps:</p>
-                          <ol>
-                            <li>
-                              <p>
-                                If the set of keys <a href="#known-key">known</a> to the CDM for this object changed or the status of any key(s) changed, run the <a def-id="update-key-statuses-algorithm"></a> algorithm on the <var>session</var>, providing each known key's <a def-id="key-id"></a> along with the appropriate <a>MediaKeyStatus</a>.
-                              </p>
-                              <p>
-                                Should additional processing be necessary to determine with certainty the status of a key, use <a def-id="status-status-pending"></a>.
-                                Once the additional processing for one or more keys has completed, run the <a def-id="update-key-statuses-algorithm"></a> algorithm again with the actual status(es).
-                              </p>
-                            </li>
-                            <li>
-                              <p>If the <a def-id="expiration-time"></a> for the session changed, run the <a def-id="update-expiration-algorithm"></a> algorithm on the <var>session</var>, providing the new expiration time.</p>
-                            </li>
-                            <li>
-                              <p>If any of the preceding steps failed, reject <var>promise</var> with <a def-id="new-domexception-named"></a> <a def-id="appropriate-error-name"></a>.</p>
-                            </li>
-                            <li>
-                              <p>If <var>message</var> is not null, run the <a def-id="queue-message-algorithm"></a> algorithm on the <var>session</var>, providing <var>message type</var> and <var>message</var>.</p>
-                            </li>
-                          </ol>
-                        </dd>
-                      </dl>
-                    </li>
-                    <li>
-                      <p>Resolve <var>promise</var>.</p>
-                      <p class="note">Since promise handlers are queued as microtasks, these will be executed ahead of any events queued by the preceding steps.</p>
-                    </li>
-                  </ol>
-                </li>
-              </ol>
-            </li>
-            <li><p>Return <var>promise</var>.</p></li>
-          </ol>
-        <table class="parameters"><tbody><tr><th>Parameter</th><th>Type</th><th>Nullable</th><th>Optional</th><th>Description</th></tr><tr><td class="prmName">response</td><td class="prmType"><code>BufferSource</code></td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td><td class="prmDesc">
-              A message to be provided to the CDM.
-              The contents are <a def-id="keysystem"></a>-specific.
-              It MUST NOT contain executable code.
-            </td></tr></tbody></table><div><em>Return type: </em><code>Promise&lt;void&gt;</code></div></dd><dt><dfn><code>close</code></dfn></dt><dd>
-          <p>Indicates that the application no longer needs the session and the CDM should release any resources associated with the session and close it. Persisted data should not be released or cleared.</p>
-          <p class="note">The returned promise is resolved when the request has been processed, and the <a def-id="closed"></a> attribute promise is resolved when the session is closed.</p>
-
-          <ol class="method-algorithm">
-            <li><p>If this object's <var>closing or closed</var> value is true, return a resolved promise.</p></li>
-            <li><p>If this object's <var>callable</var> value is false, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
-            <li><p>Let <var>promise</var> be a new promise.</p></li>
-            <li><p>Set this object's <var>closing or closed</var> value to true.</p></li>
-            <li><p>Run the following steps in parallel:</p>
-              <ol>
-                <li><p>Let <var>cdm</var> be the CDM instance represented by this object's <var>cdm instance</var> value.</p></li>
-                <li>
-                  <p>Use <var>cdm</var> to close the <a href="#key-session">key session</a> associated with this object.</p>
-                  <p class="note">Closing the key session results in the destruction of any license(s) and key(s) that have not been explicitly stored.</p>
-                </li>
-                <li>
-                  <p><a def-id="Queue-a-task"></a> to run the following steps:</p>
-                  <ol>
-                    <li><p>Run the <a def-id="session-closed-algorithm"></a> algorithm on this object.</p></li>
-                    <li>
-                      <p>Resolve <var>promise</var>.</p>
-                      <p class="note">Since promise handlers are queued as microtasks, these will be executed ahead of any events queued by the preceding steps.</p>
-                    </li>
-                  </ol>
-                </li>
-              </ol>
-            </li>
-            <li><p>Return <var>promise</var>.</p></li>
-          </ol>
-        <div><em>No parameters.</em></div><div><em>Return type: </em><code>Promise&lt;void&gt;</code></div></dd><dt><dfn><code>remove</code></dfn></dt><dd>
-          <p>
-            Removes all license(s) and key(s) associated with the session.
-            For <a href="#is-persistent-session-type">persistent session types</a>, other session data will be cleared as defined for each session type once a release message acknowledgment is processed by <a def-id="update"></a>.
-          </p>
-
-          <ol class="method-algorithm">
-            <li><p>If this object's <var>closing or closed</var> value is true, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
-            <li><p>If this object's <var>callable</var> value is false, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
-            <li><p>Let <var>promise</var> be a new promise.</p></li>
-            <li><p>Run the following steps in parallel:</p>
-              <ol>
-                <li><p>Let <var>cdm</var> be the CDM instance represented by this object's <var>cdm instance</var> value.</p></li>
-                <li><p>Let <var>message</var> be null.</p></li>
-                <li><p>Let <var>message type</var> be null.</p></li>
-                <li><p>Use the <var>cdm</var> to execute the following steps:</p>
-                  <ol>
-                    <li>
-                      <p>
-                        If any license(s) and/or key(s) are associated with the session:
-                      </p>
-                      <ol>
-                        <li>
-                          <p>
-                            Destroy the license(s) and/or key(s) associated with the session.
-                          </p>
-                          <p class="note">
-                            This implies destruction of the license(s) and/or keys(s) whether they are in memory, persistent store or both.
-                          </p>
-                        </li>
-                        <li><p>Follow the steps for the value of this object's <var>session type</var> from the following list:</p>
-                          <dl class="switch">
-                            <dt><a def-id="temporary-session"></a></dt>
-                            <dd>
-                              <p>Continue with the following steps.</p>
-                            </dd>
-                            <dt><a def-id="persistent-license-session"></a></dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    Let <var>record of license destruction</var> be a <a def-id="record-of-license-destruction"></a> for the license represented by this object.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Store the <var>record of license destruction</var>.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Let <var>message</var> be a message containing or reflecting the <var>record of license destruction</var>.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                            <dt><a def-id="persistent-usage-record-session"></a></dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  Store this object's <var>record of key usage</var>.
-                                </li>
-                                <li>
-                                  <p>
-                                    Let <var>message</var> be a message containing or reflecting this object's <var>record of key usage</var>.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                          </dl>
-                        </li>
-                      </ol>
-                    </li>
-                  </ol>
-                </li>
-                <li>
-                  <p><a def-id="Queue-a-task"></a> to run the following steps:</p>
-                  <ol>
-                    <li>
-                      <p>
-                        Run the <a def-id="update-key-statuses-algorithm"></a> algorithm on the <var>session</var>, providing all <a def-id="key-id">key ID(s)</a> in the session along with the <a def-id="status-released"></a> <a>MediaKeyStatus</a> value for each.
-                      </p>
-                    </li>
-                    <li><p>Run the <a def-id="update-expiration-algorithm"></a> algorithm on the <var>session</var>, providing <code>NaN</code>.</p></li>
-                    <li><p>If any of the preceding steps failed, reject <var>promise</var> with <a def-id="new-domexception-named"></a> <a def-id="appropriate-error-name"></a>.</p></li>
-                    <li><p>Let <var>message type</var> be <a def-id="message-type-license-release"></a>.</p></li>
-                    <li><p>If <var>message</var> is not <code>null</code>, run the <a def-id="queue-message-algorithm"></a> algorithm on the <var>session</var>, providing <var>message type</var> and <var>message</var>.</p></li>
-                    <li>
-                      <p>Resolve <var>promise</var>.</p>
-                      <p class="note">Since promise handlers are queued as microtasks, these will be executed ahead of any events queued by the preceding steps.</p>
-                    </li>
-                  </ol>
-                </li>
-              </ol>
-            </li>
-            <li><p>Return <var>promise</var>.</p></li>
-          </ol>
-        <div><em>No parameters.</em></div><div><em>Return type: </em><code>Promise&lt;void&gt;</code></div></dd></dl></section></div>
-
+};</pre>
       <section>
-        <h2><dfn>MediaKeyStatusMap</dfn> Interface</h2>
-        <p>The MediaKeyStatusMap object is a read-only map of <a def-id="key-id">key IDs</a> to the current status of the associated key.</p>
-        <p>A key's status is independent of whether the key is currently being used and of media data.</p>
-        <p class="note">For example, if a key has output requirements that cannot currently be met, the key's status should be <a def-id="status-output-downscaled"></a> or <a def-id="status-output-restricted"></a>, as appropriate, regardless of whether that key has been or is currently needed to decrypt media data.</p>
-        <div><pre class="idl">[Exposed=Window, SecureContext] interface MediaKeyStatusMap {
+        <h2>Attributes</h2>
+        <dl class="attributes" data-dfn-for="MediaKeySession" data-link-for="MediaKeySession">
+          <dt>
+            <dfn>
+              <code>sessionId</code>
+            </dfn> of type <span class="idlAttrType">{{DOMString}}</span>, readonly
+          </dt>
+          <dd>
+            <p>The <a def-id="session-id"></a> for this object and the associated key(s) or
+              license(s).</p>
+          </dd>
+          <dt>
+            <dfn>
+              <code>expiration</code>
+            </dfn> of type <span class="idlAttrType">{{unrestricted double}}</span>, readonly
+          </dt>
+          <dd>
+            <p>The <a def-id="expiration-time"></a> for all key(s) in the session, or <code>NaN
+              </code> if no such time exists or if the license explicitly never expires, as
+              determined by the CDM.</p>
+            <p class="note">This value MAY change during the session lifetime, such as when an
+              action triggers the start of a window.</p>
+          </dd>
+          <dt>
+            <dfn>
+              <code>closed</code>
+            </dfn> of type <span class="idlAttrType">Promise&lt;{{void}}&gt;</span>, readonly
+          </dt>
+          <dd>
+            <p>Signals when the object becomes <a def-id="media-key-session-closed"></a> as a result
+              of the <a def-id="session-closed-algorithm"></a> algorithm being run. This promise can
+              only be fulfilled and is never rejected.</p>
+          </dd>
+          <dt>
+            <dfn>
+              <code>keyStatuses</code>
+            </dfn> of type <span class="idlAttrType"><a>MediaKeyStatusMap</a></span>, readonly
+          </dt>
+          <dd>
+            <p>A reference to a read-only map of <a def-id="key-id">key IDs</a> <a
+                href="#known-key">known</a> to the session to the current status of the associated
+              key. Each entry MUST have a unique key ID. </p>
+            <p class="note">The map entries and their values may be updated whenever the event loop
+              spins. The map MUST NOT ever be inconsistent or partially updated, but it may change
+              between accesses if the event loop spins in between the accesses. Key IDs may be added
+              as the result of a <a def-id="load"></a> or <a def-id="update"></a> call. Key IDs may
+              be removed as the result of a <a def-id="update"></a> call that removes knowledge of
+              existing keys (or replaces the existing set of keys with a new set). Key IDs MUST NOT
+              be removed because they became unusable, such as due to expiration. Instead, such keys
+              MUST be given an appropriate status, such as <a def-id="status-expired"></a>. </p>
+            <p class="note"> Some older platforms may contain Key System implementations that do not
+              expose key IDs, making it impossible to provide a compliant user agent implementation.
+              To maximize interoperability, user agent implementations exposing such CDMs SHOULD
+              implement this member as follows: Whenever a non-empty list is appropriate, such as
+              when the <a href="#key-session">key session</a> represented by this object may contain
+              <a href="#decryption-key">key(s)</a>, populate the map with a single pair containing
+              the one-byte key ID <code>0</code> and the <a>MediaKeyStatus</a> most appropriate for
+              the aggregated status of this object. </p>
+          </dd>
+          <dt>
+            <dfn>
+              <code>onkeystatuseschange</code>
+            </dfn> of type <span class="idlAttrType">{{EventHandler}}</span>
+          </dt>
+          <dd>
+            <p>Event handler for the <a def-id="keystatuseschange"></a> event.</p>
+          </dd>
+          <dt>
+            <dfn>
+              <code>onmessage</code>
+            </dfn> of type <span class="idlAttrType">{{EventHandler}}</span>
+          </dt>
+          <dd>
+            <p>Event handler for the <a def-id="message"></a> event.</p>
+          </dd>
+        </dl>
+      </section>
+      <section>
+        <h2>Methods</h2>
+        <dl class="methods" data-dfn-for="MediaKeySession" data-link-for="MediaKeySession">
+          <dt>
+            <dfn>
+              <code>generateRequest</code>
+            </dfn>
+          </dt>
+          <dd>
+            <p>Generates a license request based on the <var>initData</var>. A <a
+                def-id="message"></a> of type <a def-id="message-type-license-request"></a> or <a
+                def-id="message-type-individualization-request"></a> will always be queued if the
+              algorithm succeeds and the promise is resolved. </p>
+            <ol class="method-algorithm">
+              <li>
+                <p>If this object's <var>closing or closed</var> value is true, return a promise
+                  rejected with an <a def-id="InvalidStateError"></a>.</p>
+              </li>
+              <li>
+                <p>If this object's <var>uninitialized</var> value is false, return a promise
+                  rejected with an <a def-id="InvalidStateError"></a>.</p>
+              </li>
+              <li>
+                <p>Let this object's <var>uninitialized</var> value be false.</p>
+              </li>
+              <!-- For simplicity and consistency, this object cannot be reused after any
+                   failure. -->
+              <li>
+                <p>If <var>initDataType</var> is the empty string, return a promise rejected with a
+                  newly created <a def-id="TypeError"></a>.</p>
+              </li>
+              <li>
+                <p>If <var>initData</var> is an empty array, return a promise rejected with a newly
+                  created <a def-id="TypeError"></a>.</p>
+              </li>
+              <li>
+                <p>If the <a def-id="keysystem"></a> implementation represented by this object's
+                  <var>cdm implementation</var> value does not support <var>initDataType</var> as an
+                  <a def-id="initialization-data-type"></a>, return a promise rejected with a <a
+                    def-id="NotSupportedError"></a>. String comparison is case-sensitive.</p>
+              </li>
+              <li>
+                <p>Let <var>init data</var> be a copy of the contents of the <var>initData</var>
+                  parameter.</p>
+              </li>
+              <li>
+                <p>Let <var>session type</var> be this object's <var>session type</var>.</p>
+              </li>
+              <li>
+                <p>Let <var>promise</var> be a new promise.</p>
+              </li>
+              <li>
+                <p>Run the following steps in parallel:</p>
+                <ol>
+                  <li>
+                    <p>If the <var>init data</var> is not valid for <var>initDataType</var>, reject
+                      <var>promise</var> with a newly created <a def-id="TypeError"></a>.</p>
+                  </li>
+                  <li>
+                    <p>Let <var>sanitized init data</var> be a validated and sanitized version of
+                      <var>init data</var>.</p>
+                    <p>The user agent MUST thoroughly validate the <a
+                        def-id="initialization-data"></a> before passing it to the CDM. This
+                      includes verifying that the length and values of fields are reasonable,
+                      verifying that values are within reasonable limits, and stripping irrelevant,
+                      unsupported, or unknown data or fields. It is RECOMMENDED that user agents
+                      pre-parse, sanitize, and/or generate a fully sanitized version of the <a
+                        def-id="initialization-data"></a>. If the <a
+                        def-id="initialization-data"></a> format specified by <var>initDataType
+                      </var> supports multiple entries, the user agent SHOULD remove entries that
+                      are not needed by the CDM. The user agent MUST NOT re-order entries within the
+                      <a def-id="initialization-data"></a>. </p>
+                  </li>
+                  <li>
+                    <p>If the preceding step failed, reject <var>promise</var> with a newly created
+                      <a def-id="TypeError"></a>.</p>
+                  </li>
+                  <li>
+                    <p>If <var>sanitized init data</var> is empty, reject <var>promise</var> with a
+                      <a def-id="NotSupportedError"></a>.</p>
+                  </li>
+                  <li>
+                    <p>Let <var>session id</var> be the empty string.</p>
+                  </li>
+                  <li>
+                    <p>Let <var>message</var> be null.</p>
+                  </li>
+                  <li>
+                    <p>Let <var>message type</var> be null.</p>
+                  </li>
+                  <li>
+                    <p>Let <var>cdm</var> be the CDM instance represented by this object's <var>cdm
+                        instance</var> value.</p>
+                  </li>
+                  <li>
+                    <p>Use the <var>cdm</var> to execute the following steps:</p>
+                    <ol>
+                      <li>
+                        <p>If the <var>sanitized init data</var> is not supported by the <var>cdm
+                          </var>, reject <var>promise</var> with a <a
+                            def-id="NotSupportedError"></a>.</p>
+                      </li>
+                      <li>
+                        <p>Follow the steps for the value of <var>session type</var> from the
+                          following list:</p>
+                        <dl class="switch">
+                          <dt><a def-id="temporary-session"></a></dt>
+                          <dd>
+                            <p>Let <var>requested license type</var> be a temporary non-persistable
+                              license.</p>
+                            <p class="note">The returned license must not be persistable or require
+                              persisting information related to it.</p>
+                          </dd>
+                          <dt><a def-id="persistent-license-session"></a></dt>
+                          <dd>
+                            <p>Let <var>requested license type</var> be a persistable license.</p>
+                          </dd>
+                          <dt><a def-id="persistent-usage-record-session"></a></dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>Initialize this object's <var>record of key usage</var> as
+                                  follows.</p>
+                                <ul>
+                                  <li>
+                                    <p> Set the list of <a def-id="key-id">key IDs</a> <a
+                                        href="#known-key">known</a> to the session to an empty list.
+                                    </p>
+                                  </li>
+                                  <li>
+                                    <p> Set the <var>first decrypt time</var> to <code>null</code>.
+                                    </p>
+                                  </li>
+                                  <li>
+                                    <p> Set the <var>latest decrypt time</var> to <code>null</code>.
+                                    </p>
+                                  </li>
+                                </ul>
+                              </li>
+                              <li>
+                                <p>Let <var>requested license type</var> be a non-persistable
+                                  license that will persist a <a def-id="record-of-key-usage"></a>.
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>Let <var>session id</var> be a unique <a def-id="session-id"></a> string.
+                        </p>
+                        <p>If the result of running the <a
+                            def-id="is-persistent-session-type-algorithm"></a> algorithm on <var>
+                            session type</var> is <code>true</code>, the ID MUST be unique within
+                          the <a def-id="origin"></a> of this object's <a
+                            def-id="document-concept"></a> over time, including across Documents and
+                          browsing sessions.</p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>If a license request for the <var>requested license type</var> can be
+                            generated based on the <var>sanitized init data</var>:</dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p> Let <var>message</var> be a license request for the <var>
+                                    requested license type</var> generated based on the <var>
+                                    sanitized init data</var> interpreted per <var>initDataType
+                                  </var>. </p>
+                                <p> The <var>cdm</var> MUST NOT use any stream-specific data,
+                                  including <a def-id="media-data"></a>, not provided via the <var>
+                                    sanitized init data</var>. </p>
+                                <p>The <var>cdm</var> SHOULD NOT store session data, including the
+                                  session ID, at this point. See <a def-id="session-storage"></a>.
+                                </p>
+                              </li>
+                              <li>
+                                <p> Let <var>message type</var> be <a
+                                    def-id="message-type-license-request"></a>. </p>
+                              </li>
+                            </ol>
+                          </dd>
+                          <dt>Otherwise:</dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p> Let <var>message</var> be the request that needs to be processed
+                                  before a license request request for the <var>requested license
+                                    type</var> can be generated based on the <var>sanitized init
+                                    data</var>. </p>
+                                <p> In a subsequent call to <a def-id="update"></a> the CDM MUST
+                                  generate a license request for the <var>requested license type
+                                  </var> based on the <var>sanitized init data</var>, which is
+                                  interpreted per <var>initDataType</var>. </p>
+                              </li>
+                              <li>
+                                <p> Let <var>message type</var> reflect the type of <var>message
+                                  </var>, either <a def-id="message-type-license-request"></a> or <a
+                                    def-id="message-type-individualization-request"></a>. </p>
+                              </li>
+                            </ol>
+                          </dd>
+                        </dl>
+                      </li>
+                    </ol>
+                  </li>
+                  <li>
+                    <p><a def-id="Queue-a-task"></a> to run the following steps:</p>
+                    <ol>
+                      <li>
+                        <p>If any of the preceding steps failed, reject <var>promise</var> with <a
+                            def-id="new-domexception-named"></a> <a
+                            def-id="appropriate-error-name"></a>.</p>
+                      </li>
+                      <li>
+                        <p>Set the <a def-id="sessionId"></a> attribute to <var>session id</var>.
+                        </p>
+                      </li>
+                      <li>
+                        <p>Set this object's <var>callable</var> value to true.</p>
+                      </li>
+                      <li>
+                        <p>Run the <a def-id="queue-message-algorithm"></a> algorithm on the <var>
+                            session</var>, providing <var>message type</var> and <var>message</var>.
+                        </p>
+                      <li>
+                        <p>Resolve <var>promise</var>.</p>
+                        <p class="note">Since promise handlers are queued as microtasks, these will
+                          be executed ahead of any events queued by the preceding steps.</p>
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+              <li>
+                <p>Return <var>promise</var>.</p>
+              </li>
+            </ol>
+            <table class="parameters">
+              <tbody>
+                <tr>
+                  <th>Parameter</th>
+                  <th>Type</th>
+                  <th>Nullable</th>
+                  <th>Optional</th>
+                  <th>Description</th>
+                </tr>
+                <tr>
+                  <td class="prmName">initDataType</td>
+                  <td class="prmType">
+                    <code>DOMString</code>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc"> The <a def-id="initialization-data-type"></a> of the <var>
+                      initData</var>. </td>
+                </tr>
+                <tr>
+                  <td class="prmName">initData</td>
+                  <td class="prmType">
+                    <code>BufferSource</code>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc">
+                    <a def-id="initialization-data"></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <div>
+              <em>Return type: </em>
+              <code>Promise&lt;void&gt;</code>
+            </div>
+          </dd>
+          <dt>
+            <dfn>
+              <code>load</code>
+            </dfn>
+          </dt>
+          <dd>
+            <p>Loads the data stored for the specified session into this object.</p>
+            <ol class="method-algorithm">
+              <li>
+                <p>If this object's <var>closing or closed</var> value is true, return a promise
+                  rejected with an <a def-id="InvalidStateError"></a>.</p>
+              </li>
+              <li>
+                <p>If this object's <var>uninitialized</var> value is false, return a promise
+                  rejected with an <a def-id="InvalidStateError"></a>.</p>
+              </li>
+              <li>
+                <p>Let this object's <var>uninitialized</var> value be false.</p>
+              </li>
+              <!-- For simplicity and consistency, this object cannot be reused after any
+                   failure. -->
+              <li>
+                <p>If <var>sessionId</var> is the empty string, return a promise rejected with a
+                  newly created <a def-id="TypeError"></a>.</p>
+              </li>
+              <li>
+                <p>If the result of running the <a
+                    def-id="is-persistent-session-type-algorithm"></a> algorithm on this object's
+                  <var>session type</var> is <code>false</code>, return a promise rejected with a
+                  newly created <a def-id="TypeError"></a>.</p>
+              </li>
+              <li>
+                <p>Let <var>origin</var> be the <a def-id="origin"></a> of this object's <a
+                    def-id="document-concept"></a>.</p>
+              </li>
+              <li>
+                <p>Let <var>promise</var> be a new promise.</p>
+              </li>
+              <li>
+                <p>Run the following steps in parallel:</p>
+                <ol>
+                  <li>
+                    <p>Let <var>sanitized session ID</var> be a validated and/or sanitized version
+                      of <var>sessionId</var>.</p>
+                    <p class="note">The user agent should thoroughly validate the sessionId value
+                      before passing it to the CDM. At a minimum, this should include checking that
+                      the length and value are reasonable (e.g., not longer than tens of characters
+                      and alphanumeric). </p>
+                  </li>
+                  <li>
+                    <p>If the preceding step failed, or if <var>sanitized session ID</var> is empty,
+                      reject <var>promise</var> with a newly created <a def-id="TypeError"></a>.</p>
+                  </li>
+                  <li>
+                    <p>If there is a <a>MediaKeySession</a> object that is not <a
+                        def-id="media-key-session-closed"></a> in this object's <a
+                        def-id="document-concept"></a> whose <a def-id="sessionId"></a> attribute is
+                      <var>sanitized session ID</var>, reject <var>promise</var> with a <a
+                        def-id="QuotaExceededError"></a>.</p>
+                    <p class="note">In other words, do not create a session if a non-closed session,
+                      regardless of type, already exists for this <var>sanitized session ID</var> in
+                      this browsing context.</p>
+                  </li>
+                  <li>
+                    <p>Let <var>expiration time</var> be <code>NaN</code>.</p>
+                  </li>
+                  <li>
+                    <p>Let <var>message</var> be null.</p>
+                  </li>
+                  <li>
+                    <p>Let <var>message type</var> be null.</p>
+                  </li>
+                  <li>
+                    <p>Let <var>cdm</var> be the CDM instance represented by this object's <var>cdm
+                        instance</var> value.</p>
+                  </li>
+                  <li>
+                    <p>Use the <var>cdm</var> to execute the following steps:</p>
+                    <ol>
+                      <li>
+                        <p>If there is no data stored for the <var>sanitized session ID</var> in the
+                          <var>origin</var>, resolve <var>promise</var> with <code>false</code> and
+                          abort these steps.
+                          <!-- Per https://www.w3.org/2001/tag/doc/promises-guide#rejections-should-be-exceptional -->
+                        </p>
+                      </li>
+                      <li>
+                        <p>If the stored session's <var>session type</var> is not the same as the
+                          current <a>MediaKeySession</a>
+                          <var>session type</var>, reject <var>promise</var> with a newly created <a
+                            def-id="TypeError"></a>.
+                        </p>
+                      </li>
+                      <li>
+                        <p>Let <var>session data</var> be the data stored for the <var>sanitized
+                            session ID</var> in the <var>origin</var>. This MUST NOT include data
+                          from other origin(s) or that is not associated with an origin.</p>
+                      </li>
+                      <li>
+                        <p>If there is a <a>MediaKeySession</a> object that is not <a
+                            def-id="media-key-session-closed"></a> in any <a
+                            def-id="document-concept"></a> and that represents the <var>session data
+                          </var>, reject <var>promise</var> with a <a
+                            def-id="QuotaExceededError"></a>.</p>
+                        <p class="note">In other words, do not create a session if a non-closed
+                          persistent session already exists for this <var>sanitized session ID</var>
+                          in any browsing context.</p>
+                      </li>
+                      <li>
+                        <p>Load the <var>session data</var>.</p>
+                      </li>
+                      <li>
+                        <p>If the <var>session data</var> indicates an <a
+                            def-id="expiration-time"></a> for the session, let <var>expiration time
+                          </var> be that expiration time.</p>
+                      </li>
+                      <li>
+                        <p>If a message needs to be sent, execute the following steps:</p>
+                        <ol>
+                          <li>
+                            <p>Let <var>message</var> be a message generated based on the <var>
+                                session data</var>.</p>
+                          </li>
+                          <li>
+                            <p>Let <var>message type</var> be the appropriate
+                              <a>MediaKeyMessageType</a> for the message.</p>
+                          </li>
+                        </ol>
+                      </li>
+                    </ol>
+                  </li>
+                  <li>
+                    <p><a def-id="Queue-a-task"></a> to run the following steps:</p>
+                    <ol>
+                      <li>
+                        <p>If any of the preceding steps failed, reject <var>promise</var> with a <a
+                            def-id="appropriate-error-name"></a>.</p>
+                      </li>
+                      <li>
+                        <p>Set the <a def-id="sessionId"></a> attribute to <var>sanitized session ID
+                          </var>.</p>
+                      </li>
+                      <li>
+                        <p>Set this object's <var>callable</var> value to true.</p>
+                      </li>
+                      <li>
+                        <p> If the loaded session contains information about any keys (there are <a
+                            href="#known-key">known keys</a>), run the <a
+                            def-id="update-key-statuses-algorithm"></a> algorithm on the <var>
+                            session</var>, providing each key's <a def-id="key-id"></a> along with
+                          the appropriate <a>MediaKeyStatus</a>. </p>
+                        <p>Should additional processing be necessary to determine with certainty the
+                          status of a key, use <a def-id="status-status-pending"></a>. Once the
+                          additional processing for one or more keys has completed, run the <a
+                            def-id="update-key-statuses-algorithm"></a> algorithm again with the
+                          actual status(es). </p>
+                      </li>
+                      <li>
+                        <p>Run the <a def-id="update-expiration-algorithm"></a> algorithm on the
+                          <var>session</var>, providing <var>expiration time</var>.</p>
+                      </li>
+                      <li>
+                        <p>If <var>message</var> is not null, run the <a
+                            def-id="queue-message-algorithm"></a> algorithm on the <var>session
+                          </var>, providing <var>message type</var> and <var>message</var>.</p>
+                      </li>
+                      <li>
+                        <p>Resolve <var>promise</var> with <code>true</code>.</p>
+                        <p class="note">Since promise handlers are queued as microtasks, these will
+                          be executed ahead of any events queued by the preceding steps.</p>
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+              <li>
+                <p>Return <var>promise</var>.</p>
+              </li>
+            </ol>
+            <table class="parameters">
+              <tbody>
+                <tr>
+                  <th>Parameter</th>
+                  <th>Type</th>
+                  <th>Nullable</th>
+                  <th>Optional</th>
+                  <th>Description</th>
+                </tr>
+                <tr>
+                  <td class="prmName">sessionId</td>
+                  <td class="prmType">
+                    <code>DOMString</code>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc"> The <a def-id="session-id"></a> of the session to load. </td>
+                </tr>
+              </tbody>
+            </table>
+            <div>
+              <em>Return type: </em>
+              <code>Promise&lt;boolean&gt;</code>
+            </div>
+          </dd>
+          <dt>
+            <dfn>
+              <code>update</code>
+            </dfn>
+          </dt>
+          <dd>
+            <p>Provides messages, including licenses, to the CDM.</p>
+            <ol class="method-algorithm">
+              <li>
+                <p>If this object's <var>closing or closed</var> value is true, return a promise
+                  rejected with an <a def-id="InvalidStateError"></a>.</p>
+              </li>
+              <li>
+                <p>If this object's <var>callable</var> value is false, return a promise rejected
+                  with an <a def-id="InvalidStateError"></a>.</p>
+              </li>
+              <li>
+                <p>If <var>response</var> is an empty array, return a promise rejected with a newly
+                  created <a def-id="TypeError"></a>.</p>
+              </li>
+              <li>
+                <p>Let <var>response copy</var> be a copy of the contents of the <var>response</var>
+                  parameter.</p>
+              </li>
+              <li>
+                <p>Let <var>promise</var> be a new promise.</p>
+              </li>
+              <li>
+                <p>Run the following steps in parallel:</p>
+                <ol>
+                  <li>
+                    <p>Let <var>sanitized response</var> be a validated and/or sanitized version of
+                      <var>response copy</var>.</p>
+                    <p class="note">The user agent should thoroughly validate the response before
+                      passing it to the CDM. This may include verifying values are within reasonable
+                      limits, stripping irrelevant data or fields, pre-parsing it, sanitizing it,
+                      and/or generating a fully sanitized version. The user agent should check that
+                      the length and values of fields are reasonable. Unknown fields should be
+                      rejected or removed. </p>
+                  </li>
+                  <li>
+                    <p>If the preceding step failed, or if <var>sanitized response</var> is empty,
+                      reject <var>promise</var> with a newly created <a def-id="TypeError"></a>.</p>
+                  </li>
+                  <li>
+                    <p>Let <var>message</var> be null.</p>
+                  </li>
+                  <li>
+                    <p>Let <var>message type</var> be null.</p>
+                  </li>
+                  <li>
+                    <p>Let <var>session closed</var> be false.</p>
+                  </li>
+                  <li>
+                    <p>Let <var>cdm</var> be the CDM instance represented by this object's <var>cdm
+                        instance</var> value.</p>
+                  </li>
+                  <li>
+                    <p>Use the <var>cdm</var> to execute the following steps:</p>
+                    <ol>
+                      <li>
+                        <p>If the format of <var>sanitized response</var> is invalid in any way,
+                          reject <var>promise</var> with a newly created <a def-id="TypeError"></a>.
+                        </p>
+                      </li>
+                      <li>
+                        <p>Process <var>sanitized response</var>, following the stipulation for the
+                          first matching condition from the following list:</p>
+                        <dl class="switch">
+                          <dt>If <var>sanitized response</var> contains a license or key(s)</dt>
+                          <dd>
+                            <p class="note">This includes an initial license, an updated license,
+                              and a license renewal message.</p>
+                            <p>Process <var>sanitized response</var>, following the stipulation for
+                              the first matching condition from the following list:</p>
+                            <dl class="switch">
+                              <dt>If <var>sessionType</var> is <a def-id="temporary-session"></a>
+                                and <var>sanitized response</var> does not specify that session
+                                data, including any license, key(s), or similar session data it
+                                contains, should be stored</dt>
+                              <dd>Process <var>sanitized response</var>, not storing any session
+                                data.</dd>
+                              <dt>If <var>sessionType</var> is <a
+                                  def-id="persistent-license-session"></a> and <var>sanitized
+                                  response</var> contains a persistable license</dt>
+                              <dd>Process <var>sanitized response</var>, storing the license/key(s)
+                                and related session data contained in <var>sanitized response</var>.
+                                Such data MUST be stored such that only the <a def-id="origin"></a>
+                                of this object's <a def-id="document-concept"></a> can access it.
+                              </dd>
+                              <dt>If <var>sessionType</var> is <a
+                                  def-id="persistent-usage-record-session"></a> and <var>sanitized
+                                  response</var> contains a non-persistable license</dt>
+                              <dd>
+                                <p>Run the following steps:</p>
+                                <ol>
+                                  <li>
+                                    <p> Process <var>sanitized response</var>, not storing any
+                                      session data. </p>
+                                  </li>
+                                  <li>
+                                    <p> If processing <var>sanitized response</var> results in the
+                                      addition of keys to the set of <a href="#known-key">known
+                                        keys</a>, add the <a def-id="key-id">key IDs</a> of these
+                                      keys to this object's <var>record of key usage</var>. </p>
+                                  </li>
+                                </ol>
+                              </dd>
+                              <dt>Otherwise</dt>
+                              <dd>
+                                <p>Reject <var>promise</var> with a newly created <a
+                                    def-id="TypeError"></a>.</p>
+                              </dd>
+                            </dl>
+                            <p>See also <a def-id="session-storage"></a>.</p>
+                            <p>State information, including keys, for each session MUST be stored in
+                              such a way that closing one session does not affect the observable
+                              state in other session(s), even if they contain overlapping key IDs.
+                            </p>
+                            <p class="note">When <var>sanitized response</var> contains key(s)
+                              and/or related data, <var>cdm</var> will likely store (in memory) the
+                              key and related data indexed by key ID.</p>
+                            <p class="note">The replacement algorithm within a session is <a
+                                def-id="keysystem"></a>-dependent.</p>
+                            <p class="note">It is RECOMMENDED that CDM implementations support a
+                              standard and reasonably high minimum number of keys per
+                              <a>MediaKeySession</a> object, including a standard replacement
+                              algorithm, and a standard and reasonably high minimum number of
+                              <a>MediaKeySession</a> objects. This enables a reasonable number of
+                              key rotation algorithms to be implemented across user agents and may
+                              reduce the likelihood of playback interruptions in use cases that
+                              involve various streams in the same element (e.g., adaptive streams,
+                              various audio and video tracks) using different keys. </p>
+                          </dd>
+                          <dt>If <var>sanitized response</var> contains a <a
+                              def-id="record-of-license-destruction"></a> acknowledgement and <var>
+                              sessionType</var> is <a def-id="persistent-license-session"></a></dt>
+                          <dd>
+                            <p>Run the following steps:</p>
+                            <ol>
+                              <li>
+                                <p> Close the <a href="#key-session">key session</a> and clear <em>
+                                    all</em> stored session data associated with this object,
+                                  including the <a def-id="sessionId"></a> and <a
+                                    def-id="record-of-license-destruction"></a>. </p>
+                                <p class="note">A subsequent call to <a def-id="load"></a> with the
+                                  value of this object's <a def-id="sessionId"></a> would fail
+                                  because there is no data stored for that session ID.</p>
+                              </li>
+                              <li>
+                                <p>Set <var>session closed</var> to true.</p>
+                              </li>
+                            </ol>
+                          </dd>
+                          <dt>If <var>sanitized response</var> contains a <a
+                              def-id="record-of-key-usage"></a> acknowledgement and <var>sessionType
+                            </var> is <a def-id="persistent-usage-record-session"></a></dt>
+                          <dd>
+                            <p>Run the following steps:</p>
+                            <ol>
+                              <li>
+                                <p> Close the <a href="#key-session">session</a> and clear <em>all
+                                  </em> stored session data associated with this object, including
+                                  the <a def-id="sessionId"></a> and <a
+                                    def-id="record-of-key-usage"></a>. </p>
+                                <p class="note">A subsequent call to <a def-id="load"></a> with the
+                                  value of this object's <a def-id="sessionId"></a> would fail
+                                  because there is no data stored for that session ID.</p>
+                              </li>
+                              <li>
+                                <p>Set <var>session closed</var> to true.</p>
+                              </li>
+                            </ol>
+                          </dd>
+                          <dt>Otherwise</dt>
+                          <dd>Process <var>sanitized response</var>, not storing any session data.
+                            <p class="note">For example, <var>sanitized response</var> may contain
+                              information that will be used to generate another <a
+                                def-id="message"></a> event. In this case, there is no need to
+                              verify the contents against the <var>sessionType</var>. </p>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>If a message needs to be sent, execute the following steps:</p>
+                        <ol>
+                          <li>
+                            <p>Let <var>message</var> be that message.</p>
+                          </li>
+                          <li>
+                            <p>Let <var>message type</var> be the appropriate
+                              <a>MediaKeyMessageType</a> for the message.</p>
+                          </li>
+                        </ol>
+                      </li>
+                    </ol>
+                  </li>
+                  <li>
+                    <p><a def-id="Queue-a-task"></a> to run the following steps:</p>
+                    <ol>
+                      <li>
+                        <dl class="switch">
+                          <dt>If <var>session closed</var> is true:</dt>
+                          <dd>
+                            <p>Run the <a def-id="session-closed-algorithm"></a> algorithm on this
+                              object.</p>
+                          </dd>
+                          <dt>Otherwise:</dt>
+                          <dd>
+                            <p>Run the following steps:</p>
+                            <ol>
+                              <li>
+                                <p> If the set of keys <a href="#known-key">known</a> to the CDM for
+                                  this object changed or the status of any key(s) changed, run the
+                                  <a def-id="update-key-statuses-algorithm"></a> algorithm on the
+                                  <var>session</var>, providing each known key's <a
+                                    def-id="key-id"></a> along with the appropriate
+                                  <a>MediaKeyStatus</a>. </p>
+                                <p> Should additional processing be necessary to determine with
+                                  certainty the status of a key, use <a
+                                    def-id="status-status-pending"></a>. Once the additional
+                                  processing for one or more keys has completed, run the <a
+                                    def-id="update-key-statuses-algorithm"></a> algorithm again with
+                                  the actual status(es). </p>
+                              </li>
+                              <li>
+                                <p>If the <a def-id="expiration-time"></a> for the session changed,
+                                  run the <a def-id="update-expiration-algorithm"></a> algorithm on
+                                  the <var>session</var>, providing the new expiration time.</p>
+                              </li>
+                              <li>
+                                <p>If any of the preceding steps failed, reject <var>promise</var>
+                                  with <a def-id="new-domexception-named"></a> <a
+                                    def-id="appropriate-error-name"></a>.</p>
+                              </li>
+                              <li>
+                                <p>If <var>message</var> is not null, run the <a
+                                    def-id="queue-message-algorithm"></a> algorithm on the <var>
+                                    session</var>, providing <var>message type</var> and <var>
+                                    message</var>.</p>
+                              </li>
+                            </ol>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>Resolve <var>promise</var>.</p>
+                        <p class="note">Since promise handlers are queued as microtasks, these will
+                          be executed ahead of any events queued by the preceding steps.</p>
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+              <li>
+                <p>Return <var>promise</var>.</p>
+              </li>
+            </ol>
+            <table class="parameters">
+              <tbody>
+                <tr>
+                  <th>Parameter</th>
+                  <th>Type</th>
+                  <th>Nullable</th>
+                  <th>Optional</th>
+                  <th>Description</th>
+                </tr>
+                <tr>
+                  <td class="prmName">response</td>
+                  <td class="prmType">
+                    <code>BufferSource</code>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc"> A message to be provided to the CDM. The contents are <a
+                      def-id="keysystem"></a>-specific. It MUST NOT contain executable code. </td>
+                </tr>
+              </tbody>
+            </table>
+            <div>
+              <em>Return type: </em>
+              <code>Promise&lt;void&gt;</code>
+            </div>
+          </dd>
+          <dt>
+            <dfn>
+              <code>close</code>
+            </dfn>
+          </dt>
+          <dd>
+            <p>Indicates that the application no longer needs the session and the CDM should release
+              any resources associated with the session and close it. Persisted data should not be
+              released or cleared.</p>
+            <p class="note">The returned promise is resolved when the request has been processed,
+              and the <a def-id="closed"></a> attribute promise is resolved when the session is
+              closed.</p>
+            <ol class="method-algorithm">
+              <li>
+                <p>If this object's <var>closing or closed</var> value is true, return a resolved
+                  promise.</p>
+              </li>
+              <li>
+                <p>If this object's <var>callable</var> value is false, return a promise rejected
+                  with an <a def-id="InvalidStateError"></a>.</p>
+              </li>
+              <li>
+                <p>Let <var>promise</var> be a new promise.</p>
+              </li>
+              <li>
+                <p>Set this object's <var>closing or closed</var> value to true.</p>
+              </li>
+              <li>
+                <p>Run the following steps in parallel:</p>
+                <ol>
+                  <li>
+                    <p>Let <var>cdm</var> be the CDM instance represented by this object's <var>cdm
+                        instance</var> value.</p>
+                  </li>
+                  <li>
+                    <p>Use <var>cdm</var> to close the <a href="#key-session">key session</a>
+                      associated with this object.</p>
+                    <p class="note">Closing the key session results in the destruction of any
+                      license(s) and key(s) that have not been explicitly stored.</p>
+                  </li>
+                  <li>
+                    <p><a def-id="Queue-a-task"></a> to run the following steps:</p>
+                    <ol>
+                      <li>
+                        <p>Run the <a def-id="session-closed-algorithm"></a> algorithm on this
+                          object.</p>
+                      </li>
+                      <li>
+                        <p>Resolve <var>promise</var>.</p>
+                        <p class="note">Since promise handlers are queued as microtasks, these will
+                          be executed ahead of any events queued by the preceding steps.</p>
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+              <li>
+                <p>Return <var>promise</var>.</p>
+              </li>
+            </ol>
+            <div>
+              <em>No parameters.</em>
+            </div>
+            <div>
+              <em>Return type: </em>
+              <code>Promise&lt;void&gt;</code>
+            </div>
+          </dd>
+          <dt>
+            <dfn>
+              <code>remove</code>
+            </dfn>
+          </dt>
+          <dd>
+            <p> Removes all license(s) and key(s) associated with the session. For <a
+                href="#is-persistent-session-type">persistent session types</a>, other session data
+              will be cleared as defined for each session type once a release message acknowledgment
+              is processed by <a def-id="update"></a>. </p>
+            <ol class="method-algorithm">
+              <li>
+                <p>If this object's <var>closing or closed</var> value is true, return a promise
+                  rejected with an <a def-id="InvalidStateError"></a>.</p>
+              </li>
+              <li>
+                <p>If this object's <var>callable</var> value is false, return a promise rejected
+                  with an <a def-id="InvalidStateError"></a>.</p>
+              </li>
+              <li>
+                <p>Let <var>promise</var> be a new promise.</p>
+              </li>
+              <li>
+                <p>Run the following steps in parallel:</p>
+                <ol>
+                  <li>
+                    <p>Let <var>cdm</var> be the CDM instance represented by this object's <var>cdm
+                        instance</var> value.</p>
+                  </li>
+                  <li>
+                    <p>Let <var>message</var> be null.</p>
+                  </li>
+                  <li>
+                    <p>Let <var>message type</var> be null.</p>
+                  </li>
+                  <li>
+                    <p>Use the <var>cdm</var> to execute the following steps:</p>
+                    <ol>
+                      <li>
+                        <p> If any license(s) and/or key(s) are associated with the session: </p>
+                        <ol>
+                          <li>
+                            <p> Destroy the license(s) and/or key(s) associated with the session.
+                            </p>
+                            <p class="note"> This implies destruction of the license(s) and/or
+                              keys(s) whether they are in memory, persistent store or both. </p>
+                          </li>
+                          <li>
+                            <p>Follow the steps for the value of this object's <var>session type
+                              </var> from the following list:</p>
+                            <dl class="switch">
+                              <dt><a def-id="temporary-session"></a></dt>
+                              <dd>
+                                <p>Continue with the following steps.</p>
+                              </dd>
+                              <dt><a def-id="persistent-license-session"></a></dt>
+                              <dd>
+                                <ol>
+                                  <li>
+                                    <p> Let <var>record of license destruction</var> be a <a
+                                        def-id="record-of-license-destruction"></a> for the license
+                                      represented by this object. </p>
+                                  </li>
+                                  <li>
+                                    <p> Store the <var>record of license destruction</var>. </p>
+                                  </li>
+                                  <li>
+                                    <p> Let <var>message</var> be a message containing or reflecting
+                                      the <var>record of license destruction</var>. </p>
+                                  </li>
+                                </ol>
+                              </dd>
+                              <dt><a def-id="persistent-usage-record-session"></a></dt>
+                              <dd>
+                                <ol>
+                                  <li> Store this object's <var>record of key usage</var>. </li>
+                                  <li>
+                                    <p> Let <var>message</var> be a message containing or reflecting
+                                      this object's <var>record of key usage</var>. </p>
+                                  </li>
+                                </ol>
+                              </dd>
+                            </dl>
+                          </li>
+                        </ol>
+                      </li>
+                    </ol>
+                  </li>
+                  <li>
+                    <p><a def-id="Queue-a-task"></a> to run the following steps:</p>
+                    <ol>
+                      <li>
+                        <p> Run the <a def-id="update-key-statuses-algorithm"></a> algorithm on the
+                          <var>session</var>, providing all <a def-id="key-id">key ID(s)</a> in the
+                          session along with the <a def-id="status-released"></a>
+                          <a>MediaKeyStatus</a> value for each. </p>
+                      </li>
+                      <li>
+                        <p>Run the <a def-id="update-expiration-algorithm"></a> algorithm on the
+                          <var>session</var>, providing <code>NaN</code>.</p>
+                      </li>
+                      <li>
+                        <p>If any of the preceding steps failed, reject <var>promise</var> with <a
+                            def-id="new-domexception-named"></a> <a
+                            def-id="appropriate-error-name"></a>.</p>
+                      </li>
+                      <li>
+                        <p>Let <var>message type</var> be <a
+                            def-id="message-type-license-release"></a>.</p>
+                      </li>
+                      <li>
+                        <p>If <var>message</var> is not <code>null</code>, run the <a
+                            def-id="queue-message-algorithm"></a> algorithm on the <var>session
+                          </var>, providing <var>message type</var> and <var>message</var>.</p>
+                      </li>
+                      <li>
+                        <p>Resolve <var>promise</var>.</p>
+                        <p class="note">Since promise handlers are queued as microtasks, these will
+                          be executed ahead of any events queued by the preceding steps.</p>
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+              <li>
+                <p>Return <var>promise</var>.</p>
+              </li>
+            </ol>
+            <div>
+              <em>No parameters.</em>
+            </div>
+            <div>
+              <em>Return type: </em>
+              <code>Promise&lt;void&gt;</code>
+            </div>
+          </dd>
+        </dl>
+      </section>
+    </div>
+    <section>
+      <h2>
+        <dfn>MediaKeyStatusMap</dfn> Interface
+      </h2>
+      <p>The MediaKeyStatusMap object is a read-only map of <a def-id="key-id">key IDs</a> to the
+        current status of the associated key.</p>
+      <p>A key's status is independent of whether the key is currently being used and of media data.
+      </p>
+      <p class="note">For example, if a key has output requirements that cannot currently be met,
+        the key's status should be <a def-id="status-output-downscaled"></a> or <a
+          def-id="status-output-restricted"></a>, as appropriate, regardless of whether that key has
+        been or is currently needed to decrypt media data.</p>
+      <div>
+        <pre class="idl">[Exposed=Window, SecureContext] interface MediaKeyStatusMap {
     iterable&lt;BufferSource,MediaKeyStatus&gt;;
     readonly        attribute unsigned long size;
     boolean has (BufferSource keyId);
     any     get (BufferSource keyId);
 };</pre>
-          <section>
-            <h2>Attributes</h2>
-            <dl class="attributes" data-dfn-for="MediaKeyStatusMap" data-link-for="MediaKeyStatusMap"><dt><dfn><code>size</code></dfn> of type <span class="idlAttrType">{{unsigned long}}</span>, readonly       </dt><dd>
-            <p>The number of <a href="#known-key">known keys.</a></p>
-              </dd>
-            </dl>
-          </section>
-
-          <section>
-            <h2>Methods</h2>
-            <dl class="methods" data-dfn-for="MediaKeyStatusMap" data-link-for="MediaKeyStatusMap">
-              <dt><dfn><code>has</code></dfn></dt>
-              <dd>
-                <p>Returns <code>true</code> if the status of the key identified by <var>keyId</var> is known.</p>
-            
-                <table class="parameters"><tbody><tr><th>Parameter</th><th>Type</th><th>Nullable</th><th>Optional</th><th>Description</th></tr><tr><td class="prmName">keyId</td><td class="prmType"><code>BufferSource</code></td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td><td class="prmDesc">The <a def-id="key-id"></a> of the key.</td></tr></tbody></table>
-                <div><em>Return type: </em><code>boolean</code></div>
-              </dd>
-              <dt><dfn><code>get</code></dfn></dt>
-              <dd>
-                <p>Returns the <a>MediaKeyStatus</a> of the key identified by <var>keyId</var> or <code>undefined</code> if the status of the key identified by <var>keyId</var> is not known.</p>
-            
-                <table class="parameters"><tbody><tr><th>Parameter</th><th>Type</th><th>Nullable</th><th>Optional</th><th>Description</th></tr><tr><td class="prmName">keyId</td><td class="prmType"><code>BufferSource</code></td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td><td class="prmDesc">The <a def-id="key-id"></a> of the key.</td></tr></tbody></table>
-                <div><em>Return type: </em><code>any</code></div>
-              </dd>
-            </dl>
-            <p>
-              This interface has <code>entries</code>, <code>keys</code>, <code>values</code>, <code>forEach</code> and <code>@@iterator</code> methods
-              brought by <dfn data-dfn-for="MediaKeyStatusMap" data-link-for="MediaKeyStatusMap">iterable</dfn> (see WebIDL, <a href='https://www.w3.org/TR/WebIDL-1/#idl-iterable'>3.2.7 Iterable declarations</a>).
-            </p>
-            <p>
-              The value pairs to iterate over are a snapshot of the set of pairs formed from the <a def-id="key-id"></a> and
-              associated <a>MediaKeyStatus</a> value for all <a href="#known-key">known keys</a>, sorted by <a def-id="key-id"></a>.
-              Key IDs are compared as follows:
-              For key IDs <var>A</var> of length <var>m</var> and <var>B</var> of length <var>n</var>, assigned such that <var>m</var> &lt;= <var>n</var>,
-              let <var>A</var> &lt; <var>B</var> if and only if the <var>m</var> octets of <var>A</var> are less in lexicographical
-              order than the first <var>m</var> octets of <var>B</var> or those octets are equal and <var>m</var> &lt; <var>n</var>.
-            </p>
-          </section>
-        </div>
-
-        <div><pre class="idl">enum MediaKeyStatus {
+        <section>
+          <h2>Attributes</h2>
+          <dl class="attributes" data-dfn-for="MediaKeyStatusMap" data-link-for="MediaKeyStatusMap">
+            <dt>
+              <dfn>
+                <code>size</code>
+              </dfn> of type <span class="idlAttrType">{{unsigned long}}</span>, readonly
+            </dt>
+            <dd>
+              <p>The number of <a href="#known-key">known keys.</a></p>
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h2>Methods</h2>
+          <dl class="methods" data-dfn-for="MediaKeyStatusMap" data-link-for="MediaKeyStatusMap">
+            <dt>
+              <dfn>
+                <code>has</code>
+              </dfn>
+            </dt>
+            <dd>
+              <p>Returns <code>true</code> if the status of the key identified by <var>keyId</var>
+                is known.</p>
+              <table class="parameters">
+                <tbody>
+                  <tr>
+                    <th>Parameter</th>
+                    <th>Type</th>
+                    <th>Nullable</th>
+                    <th>Optional</th>
+                    <th>Description</th>
+                  </tr>
+                  <tr>
+                    <td class="prmName">keyId</td>
+                    <td class="prmType">
+                      <code>BufferSource</code>
+                    </td>
+                    <td class="prmNullFalse">
+                      <span role="img" aria-label="False">✘</span>
+                    </td>
+                    <td class="prmOptFalse">
+                      <span role="img" aria-label="False">✘</span>
+                    </td>
+                    <td class="prmDesc">The <a def-id="key-id"></a> of the key.</td>
+                  </tr>
+                </tbody>
+              </table>
+              <div>
+                <em>Return type: </em>
+                <code>boolean</code>
+              </div>
+            </dd>
+            <dt>
+              <dfn>
+                <code>get</code>
+              </dfn>
+            </dt>
+            <dd>
+              <p>Returns the <a>MediaKeyStatus</a> of the key identified by <var>keyId</var> or
+                <code>undefined</code> if the status of the key identified by <var>keyId</var> is
+                not known.</p>
+              <table class="parameters">
+                <tbody>
+                  <tr>
+                    <th>Parameter</th>
+                    <th>Type</th>
+                    <th>Nullable</th>
+                    <th>Optional</th>
+                    <th>Description</th>
+                  </tr>
+                  <tr>
+                    <td class="prmName">keyId</td>
+                    <td class="prmType">
+                      <code>BufferSource</code>
+                    </td>
+                    <td class="prmNullFalse">
+                      <span role="img" aria-label="False">✘</span>
+                    </td>
+                    <td class="prmOptFalse">
+                      <span role="img" aria-label="False">✘</span>
+                    </td>
+                    <td class="prmDesc">The <a def-id="key-id"></a> of the key.</td>
+                  </tr>
+                </tbody>
+              </table>
+              <div>
+                <em>Return type: </em>
+                <code>any</code>
+              </div>
+            </dd>
+          </dl>
+          <p> This interface has <code>entries</code>, <code>keys</code>, <code>values</code>,
+            <code>forEach</code> and <code>@@iterator</code> methods brought by <dfn
+              data-dfn-for="MediaKeyStatusMap" data-link-for="MediaKeyStatusMap">iterable</dfn> (see
+            WebIDL, <a href='https://www.w3.org/TR/WebIDL-1/#idl-iterable'>3.2.7 Iterable
+              declarations</a>). </p>
+          <p> The value pairs to iterate over are a snapshot of the set of pairs formed from the <a
+              def-id="key-id"></a> and associated <a>MediaKeyStatus</a> value for all <a
+              href="#known-key">known keys</a>, sorted by <a def-id="key-id"></a>. Key IDs are
+            compared as follows: For key IDs <var>A</var> of length <var>m</var> and <var>B</var> of
+            length <var>n</var>, assigned such that <var>m</var> &lt;= <var>n</var>, let <var>A
+            </var> &lt; <var>B</var> if and only if the <var>m</var> octets of <var>A</var> are less
+            in lexicographical order than the first <var>m</var> octets of <var>B</var> or those
+            octets are equal and <var>m</var> &lt; <var>n</var>. </p>
+        </section>
+      </div>
+      <div>
+        <pre class="idl">enum MediaKeyStatus {
     "usable",
     "expired",
     "released",
@@ -2401,1498 +3800,2314 @@ The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows:
     "status-pending",
     "internal-error"
 };</pre>
-<p>The <dfn>MediaKeyStatus</dfn> enumeration is defined as follows:
-</p>
-  <table class="simple" data-dfn-for="MediaKeyStatus" data-link-for="MediaKeyStatus"><tbody><tr><th colspan="2">Enumeration description</th></tr><tr><td><dfn><code id="idl-def-MediaKeyStatus.usable">usable</code></dfn></td><td>
-            The CDM is certain the key is currently <a def-id="usable-for-decryption"></a>.<br>
-            Keys that <em>may not</em> currently be <a def-id="usable-for-decryption"></a> MUST NOT have this status.
-          </td></tr><tr><td><dfn><code id="idl-def-MediaKeyStatus.expired">expired</code></dfn></td><td>
-            The key is no longer <a def-id="usable-for-decryption"></a> because its <a def-id="expiration-time"></a> has passed.<br>
-            The time represented by the <a def-id="expiration"></a> attribute MUST be earlier than the current time.
-            All other keys in the session MUST have this status.
-          </td></tr><tr><td><dfn><code id="idl-def-MediaKeyStatus.released">released</code></dfn></td><td>
-            The key itself is no longer available to the CDM, but information about the key, such as a <a def-id="record-of-license-destruction"></a> or <a def-id="record-of-key-usage"></a>, is available.
-          </td></tr><tr><td><dfn><code id="idl-def-MediaKeyStatus.output-restricted">output-restricted</code></dfn></td><td>
-            There are output restrictions associated with the key that cannot currently be met.
-            Media data decrypted with this key may be blocked from presentation, if necessary according to
-            the output restrictions.
-            The application should avoid using streams that will trigger the output restrictions associated
-            with the key.
-          </td></tr><tr><td><dfn><code id="idl-def-MediaKeyStatus.output-downscaled">output-downscaled</code></dfn></td><td>
-            There are output restrictions associated with the key that cannot currently be met.
-            Media data decrypted with this key may be presented at a lower quality (e.g., resolution),
-            if necessary according to the output restrictions.
-            The application should avoid using streams that will trigger the output restrictions associated
-            with the key.<br>
-            Support for downscaling is OPTIONAL.
-            Applications SHOULD NOT rely on downscaling to ensure uninterrupted playback when output requirements cannot be met.
-          </td></tr><tr><td><dfn><code id="idl-def-MediaKeyStatus.status-pending">status-pending</code></dfn></td><td>
-            The status of the key is not yet known and is being determined.
-            The status will be updated with the actual status when it has been determined.
-          </td></tr><tr><td><dfn><code id="idl-def-MediaKeyStatus.internal-error">internal-error</code></dfn></td><td>
-            The key is not currently <a def-id="usable-for-decryption"></a> because of an error in the CDM unrelated to the other values.
-            This value is not actionable by the application.
-          </td></tr></tbody></table></div>
-      </section>
-
-      <section>
-        <h3><a>MediaKeyMessageEvent</a></h3>
-        <p>The MediaKeyMessageEvent object is used for the <a def-id="message"></a> event.</p>
-        <p>Events are constructed as defined in <a def-id="constructing-events"></a> [[DOM]].</p>
-
-        <div><pre class="idl">enum MediaKeyMessageType {
+        <p>The <dfn>MediaKeyStatus</dfn> enumeration is defined as follows: </p>
+        <table class="simple" data-dfn-for="MediaKeyStatus" data-link-for="MediaKeyStatus">
+          <tbody>
+            <tr>
+              <th colspan="2">Enumeration description</th>
+            </tr>
+            <tr>
+              <td>
+                <dfn>
+                  <code id="idl-def-MediaKeyStatus.usable">usable</code>
+                </dfn>
+              </td>
+              <td> The CDM is certain the key is currently <a def-id="usable-for-decryption"></a>.
+                <br> Keys that <em>may not</em> currently be <a def-id="usable-for-decryption"></a>
+                MUST NOT have this status. </td>
+            </tr>
+            <tr>
+              <td>
+                <dfn>
+                  <code id="idl-def-MediaKeyStatus.expired">expired</code>
+                </dfn>
+              </td>
+              <td> The key is no longer <a def-id="usable-for-decryption"></a> because its <a
+                  def-id="expiration-time"></a> has passed.
+                <br> The time represented by the <a def-id="expiration"></a> attribute MUST be
+                earlier than the current time. All other keys in the session MUST have this status.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <dfn>
+                  <code id="idl-def-MediaKeyStatus.released">released</code>
+                </dfn>
+              </td>
+              <td> The key itself is no longer available to the CDM, but information about the key,
+                such as a <a def-id="record-of-license-destruction"></a> or <a
+                  def-id="record-of-key-usage"></a>, is available. </td>
+            </tr>
+            <tr>
+              <td>
+                <dfn>
+                  <code id="idl-def-MediaKeyStatus.output-restricted">output-restricted</code>
+                </dfn>
+              </td>
+              <td> There are output restrictions associated with the key that cannot currently be
+                met. Media data decrypted with this key may be blocked from presentation, if
+                necessary according to the output restrictions. The application should avoid using
+                streams that will trigger the output restrictions associated with the key. </td>
+            </tr>
+            <tr>
+              <td>
+                <dfn>
+                  <code id="idl-def-MediaKeyStatus.output-downscaled">output-downscaled</code>
+                </dfn>
+              </td>
+              <td> There are output restrictions associated with the key that cannot currently be
+                met. Media data decrypted with this key may be presented at a lower quality (e.g.,
+                resolution), if necessary according to the output restrictions. The application
+                should avoid using streams that will trigger the output restrictions associated with
+                the key.
+                <br> Support for downscaling is OPTIONAL. Applications SHOULD NOT rely on
+                downscaling to ensure uninterrupted playback when output requirements cannot be met.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <dfn>
+                  <code id="idl-def-MediaKeyStatus.status-pending">status-pending</code>
+                </dfn>
+              </td>
+              <td> The status of the key is not yet known and is being determined. The status will
+                be updated with the actual status when it has been determined. </td>
+            </tr>
+            <tr>
+              <td>
+                <dfn>
+                  <code id="idl-def-MediaKeyStatus.internal-error">internal-error</code>
+                </dfn>
+              </td>
+              <td> The key is not currently <a def-id="usable-for-decryption"></a> because of an
+                error in the CDM unrelated to the other values. This value is not actionable by the
+                application. </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+    <section>
+      <h3><a>MediaKeyMessageEvent</a></h3>
+      <p>The MediaKeyMessageEvent object is used for the <a def-id="message"></a> event.</p>
+      <p>Events are constructed as defined in <a def-id="constructing-events"></a> [[DOM]].</p>
+      <div>
+        <pre class="idl">enum MediaKeyMessageType {
     "license-request",
     "license-renewal",
     "license-release",
     "individualization-request"
 };</pre>
-<p>The <dfn>MediaKeyMessageType</dfn> is defined as follows:</p>
-  <table class="simple" data-dfn-for="MediaKeyMessageType" data-link-for="MediaKeyMessageType"><tbody><tr><th colspan="2">Enumeration description</th></tr><tr><td><dfn><code id="idl-def-MediaKeyMessageType.license-request">license-request</code></dfn></td><td>The message contains a request for a new license.</td></tr><tr><td><dfn><code id="idl-def-MediaKeyMessageType.license-renewal">license-renewal</code></dfn></td><td>The message contains a request to renew an existing license.</td></tr><tr><td><dfn><code id="idl-def-MediaKeyMessageType.license-release">license-release</code></dfn></td><td>The message contains a <a def-id="record-of-license-destruction"></a> or <a def-id="record-of-key-usage"></a>.</td></tr><tr><td><dfn><code id="idl-def-MediaKeyMessageType.individualization-request">individualization-request</code></dfn></td><td>
-            The message contains a request for <a href="#app-assisted-individualization">App-Assisted Individualization</a> (or re-individualization).<br>
-            As with all other messages, any identifiers in the message MUST be <a href="#per-origin-per-profile-identifiers">distinctive per origin and profile</a> and MUST NOT be <a def-id="distinctive-permanent-identifier-maybe-plural"></a>.
-          </td></tr></tbody></table></div>
-
-        <div><pre class="idl">[Exposed=Window, SecureContext]
+        <p>The <dfn>MediaKeyMessageType</dfn> is defined as follows:</p>
+        <table class="simple" data-dfn-for="MediaKeyMessageType"
+          data-link-for="MediaKeyMessageType">
+          <tbody>
+            <tr>
+              <th colspan="2">Enumeration description</th>
+            </tr>
+            <tr>
+              <td>
+                <dfn>
+                  <code id="idl-def-MediaKeyMessageType.license-request">license-request</code>
+                </dfn>
+              </td>
+              <td>The message contains a request for a new license.</td>
+            </tr>
+            <tr>
+              <td>
+                <dfn>
+                  <code id="idl-def-MediaKeyMessageType.license-renewal">license-renewal</code>
+                </dfn>
+              </td>
+              <td>The message contains a request to renew an existing license.</td>
+            </tr>
+            <tr>
+              <td>
+                <dfn>
+                  <code id="idl-def-MediaKeyMessageType.license-release">license-release</code>
+                </dfn>
+              </td>
+              <td>The message contains a <a def-id="record-of-license-destruction"></a> or <a
+                  def-id="record-of-key-usage"></a>.</td>
+            </tr>
+            <tr>
+              <td>
+                <dfn>
+                  <code id="idl-def-MediaKeyMessageType.individualization-request">
+                    individualization-request</code>
+                </dfn>
+              </td>
+              <td> The message contains a request for <a
+                  href="#app-assisted-individualization">App-Assisted Individualization</a> (or
+                re-individualization).
+                <br> As with all other messages, any identifiers in the message MUST be <a
+                  href="#per-origin-per-profile-identifiers">distinctive per origin and profile</a>
+                and MUST NOT be <a def-id="distinctive-permanent-identifier-maybe-plural"></a>.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div>
+        <pre class="idl">[Exposed=Window, SecureContext]
 interface MediaKeyMessageEvent : Event {
     constructor(DOMString type, MediaKeyMessageEventInit eventInitDict);
     readonly        attribute MediaKeyMessageType messageType;
     readonly        attribute ArrayBuffer         message;
-};</pre><section><h2>Constructors</h2><dl class="constructors" data-dfn-for="MediaKeyMessageEvent" data-link-for="MediaKeyMessageEvent"><dt><dfn><code>MediaKeyMessageEvent</code></dfn></dt><dd>
-
-          <table class="parameters"><tbody><tr><th>Parameter</th><th>Type</th><th>Nullable</th><th>Optional</th><th>Description</th></tr><tr><td class="prmName">type</td><td class="prmType"><code>DOMString</code></td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td><td class="prmDesc"></td></tr><tr><td class="prmName">eventInitDict</td><td class="prmType"><code>MediaKeyMessageEventInit</code></td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptTrue"><span role="img" aria-label="True">✔</span></td><td class="prmDesc"></td></tr></tbody></table></dd></dl></section><section><h2>Attributes</h2><dl class="attributes" data-dfn-for="MediaKeyMessageEvent" data-link-for="MediaKeyMessageEvent"><dt><dfn><code>messageType</code></dfn> of type <span class="idlAttrType"><a>MediaKeyMessageType</a></span>, readonly       </dt><dd>
-            The type of the message.
-            <p>Implementations MUST NOT require applications to handle message types.
-              Implementations MUST support applications that do not differentiate messages and MUST NOT require that applications handle message types.
-              Specifically, Key Systems MUST support passing all types of messages to a single URL.
-            </p>
-            <p class="note">This attribute allows an application to differentiate messages without parsing the message.
-              It is intended to enable optional application and/or server optimizations, but applications are not required to use it.
-            </p>
-          </dd><dt><dfn><code>message</code></dfn> of type <span class="idlAttrType">{{ArrayBuffer}}</span>, readonly       </dt><dd>
-            The message from the CDM. Messages are Key System-specific.
-          </dd></dl></section></div>
-
+};</pre>
         <section>
-          <h4><dfn>MediaKeyMessageEventInit</dfn></h4>
-          <div><pre class="idl" data-cite="DOM">dictionary MediaKeyMessageEventInit : EventInit {
+          <h2>Constructors</h2>
+          <dl class="constructors" data-dfn-for="MediaKeyMessageEvent"
+            data-link-for="MediaKeyMessageEvent">
+            <dt>
+              <dfn>
+                <code>MediaKeyMessageEvent</code>
+              </dfn>
+            </dt>
+            <dd>
+              <table class="parameters">
+                <tbody>
+                  <tr>
+                    <th>Parameter</th>
+                    <th>Type</th>
+                    <th>Nullable</th>
+                    <th>Optional</th>
+                    <th>Description</th>
+                  </tr>
+                  <tr>
+                    <td class="prmName">type</td>
+                    <td class="prmType">
+                      <code>DOMString</code>
+                    </td>
+                    <td class="prmNullFalse">
+                      <span role="img" aria-label="False">✘</span>
+                    </td>
+                    <td class="prmOptFalse">
+                      <span role="img" aria-label="False">✘</span>
+                    </td>
+                    <td class="prmDesc"></td>
+                  </tr>
+                  <tr>
+                    <td class="prmName">eventInitDict</td>
+                    <td class="prmType">
+                      <code>MediaKeyMessageEventInit</code>
+                    </td>
+                    <td class="prmNullFalse">
+                      <span role="img" aria-label="False">✘</span>
+                    </td>
+                    <td class="prmOptTrue">
+                      <span role="img" aria-label="True">✔</span>
+                    </td>
+                    <td class="prmDesc"></td>
+                  </tr>
+                </tbody>
+              </table>
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h2>Attributes</h2>
+          <dl class="attributes" data-dfn-for="MediaKeyMessageEvent"
+            data-link-for="MediaKeyMessageEvent">
+            <dt>
+              <dfn>
+                <code>messageType</code>
+              </dfn> of type <span class="idlAttrType"><a>MediaKeyMessageType</a></span>, readonly
+            </dt>
+            <dd> The type of the message. <p>Implementations MUST NOT require applications to handle
+                message types. Implementations MUST support applications that do not differentiate
+                messages and MUST NOT require that applications handle message types. Specifically,
+                Key Systems MUST support passing all types of messages to a single URL. </p>
+              <p class="note">This attribute allows an application to differentiate messages without
+                parsing the message. It is intended to enable optional application and/or server
+                optimizations, but applications are not required to use it. </p>
+            </dd>
+            <dt>
+              <dfn>
+                <code>message</code>
+              </dfn> of type <span class="idlAttrType">{{ArrayBuffer}}</span>, readonly
+            </dt>
+            <dd> The message from the CDM. Messages are Key System-specific. </dd>
+          </dl>
+        </section>
+      </div>
+      <section>
+        <h4>
+          <dfn>MediaKeyMessageEventInit</dfn>
+        </h4>
+        <div>
+          <pre class="idl" data-cite="DOM">dictionary MediaKeyMessageEventInit : EventInit {
              required MediaKeyMessageType messageType;
              required ArrayBuffer         message;
-};</pre><section><h2>Dictionary <a class="idlType">MediaKeyMessageEventInit</a> Members</h2><dl class="dictionary-members" data-dfn-for="MediaKeyMessageEventInit" data-link-for="MediaKeyMessageEventInit"><dt><dfn><code>messageType</code></dfn> of type <span class="idlMemberType"><a>MediaKeyMessageType</a></span></dt><dd>
-              The type of the message.
-            </dd><dt><dfn><code>message</code></dfn> of type <span class="idlMemberType">{{ArrayBuffer}}</span></dt><dd>
-              The message.
-            </dd></dl></section></div>
-        </section>
-      </section>
-
-      <section id="mediakeysession-events" class="informative">
-        <h3>Event Summary</h3>
-
-        <table class="old-table">
-          <thead>
-            <tr>
-              <th>Event name</th>
-              <th>Interface</th>
-              <th>Dispatched when...</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td><a def-id="eventdfn">keystatuseschange</a></td>
-              <td><a def-id="event"></a></td>
-              <td>There has been a change in the keys in the session or their status.</td>
-            </tr>
-            <tr>
-              <td><a def-id="eventdfn">message</a></td>
-              <td><a>MediaKeyMessageEvent</a></td>
-              <td>The CDM has generated a message for the session.</td>
-            </tr>
-          </tbody>
-        </table>
-      </section>
-
-      <section id="mediakeysession-algorithms">
-        <h3>Algorithms</h3>
-
-        <section id="queue-message">
-          <h4>Queue a "message" Event</h4>
-          <p>The Queue a "message" Event algorithm queues a message event to a <a>MediaKeySession</a> object.
-          Requests to run this algorithm include a target <a>MediaKeySession</a> object, a <var>message type</var>, and a <var>message</var>.
-          </p>
-          <p>
-            <var>message</var> MUST NOT contain <a def-id="distinctive-permanent-identifier-maybe-plural"></a>, even in an encrypted form.
-            <var>message</var> MUST NOT contain <a def-id="distinctive-identifier-maybe-plural"></a>, even in an encrypted form, if the <a>MediaKeySession</a> object's <var>use distinctive identifier</var> value is false.
-          </p>
-          <p>The following steps are run:</p>
-          <ol>
-            <li><p>Let the <var>session</var> be the specified <a>MediaKeySession</a> object.</p></li>
-            <li>
-              <p><a def-id="Queue-a-task"></a> to create an event named <a def-id="message"></a> that does not bubble and is not cancellable using the <a>MediaKeyMessageEvent</a> interface with its <var>type</var> attribute set to <code>message</code> and its <var>isTrusted</var> attribute initialized to <code>true</code>, and dispatch it at the <var>session</var>.</p>
-              <p>The event interface <a>MediaKeyMessageEvent</a> has:</p>
-              <ul style="list-style-type:none"><li>
-                <a def-id="message-event-messagetype-attribute"></a> = the specified <var>message type</var><br><br>
-                <a def-id="message-event-message-attribute"></a> = the specified <var>message</var>
-              </li></ul>
-            </li>
-         </ol>
-        </section>
-
-        <section id="update-key-statuses">
-          <h4>Update Key Statuses</h4>
-          <p>The Update Key Statuses algorithm updates the set of <a href="#known-key">known</a> keys for a <a>MediaKeySession</a> or the status of one or more of the keys.
-          Requests to run this algorithm include a target <a>MediaKeySession</a> object and a sequence of <a def-id="key-id"></a> and associated <a>MediaKeyStatus</a> pairs.
-          </p>
-          <p class="note">The algorithm is always run in a task.</p>
-          <p>The following steps are run:</p>
-          <ol>
-            <li><p>Let the <var>session</var> be the associated <a>MediaKeySession</a> object.</p></li>
-            <li><p>Let the <var>input statuses</var> be the sequence of pairs key ID and associated <a>MediaKeyStatus</a> pairs.</p></li>
-            <li><p>Let the <var>statuses</var> be <var>session</var>'s <a def-id="keyStatuses"></a> attribute.</p></li>
-            <li><p>Run the following steps to replace the contents of <var>statuses</var>:</p>
-              <ol>
-                <li><p>Empty <var>statuses</var>.</p></li>
-                <li><p>For each pair in <var>input statuses</var>.</p>
-                  <ol>
-                    <li><p>Let <var>pair</var> be the pair.</p></li>
-                    <li><p>Insert an entry for <var>pair</var>'s key ID into <var>statuses</var> with the value of <var>pair</var>'s <a>MediaKeyStatus</a> value.</p></li>
-                  </ol>
-                </li>
-              </ol>
-              <p class="note">The effect of this steps is that the contents of <var>session</var>'s <a def-id="keyStatuses"></a> attribute are replaced without invalidating existing references to the attribute.
-                This replacement is atomic from a script perspective. That is, script MUST NOT ever see a partially populated sequence.
-              </p>
-            </li>
-            <li><p><a def-id="Queue-a-task-to-fire-an-event-named"></a> <a def-id="keystatuseschange"></a> at the <var>session</var>.</p></li>
-            <li><p><a def-id="Queue-a-task-to-run-algorithm"></a> <a def-id="resume-playback-algorithm"></a> algorithm on each of the media element(s) whose <a def-id="mediaKeys-attribute"></a> attribute is the MediaKeys object that created the <var>session</var>.</p>
-            </li>
-          </ol>
-        </section>
-
-        <section id="update-expiration">
-          <h4>Update Expiration</h4>
-          <p>The Update Expiration algorithm updates the <a def-id="expiration-time"></a> of a <a>MediaKeySession</a>.
-          Requests to run this algorithm include a target <a>MediaKeySession</a> object and the new expiration time, which may be <code>NaN</code>.
-          </p>
-          <p class="note">The algorithm is always run in a task.</p>
-          <p>The following steps are run:</p>
-          <ol>
-            <li><p>Let the <var>session</var> be the associated <a>MediaKeySession</a> object.</p></li>
-            <li><p>Let <var>expiration time</var> be <code>NaN</code>.</p></li>
-            <li><p>If the new expiration time is not <code>NaN</code>, let <var>expiration time</var> be that expiration time.</p></li>
-            <li><p>Set the <var>session</var>'s <a def-id="expiration"></a> attribute to <var>expiration time</var> expressed as <a href="#time">time</a>.</p></li>
-          </ol>
-        </section>
-      
-        <section id="session-closed">
-          <h4>Session Closed</h4>
-          <p>The Session Closed algorithm updates the <a>MediaKeySession</a> state after a <a href="#key-session">key session</a> has been closed by the <a def-id="cdm"></a>.</p>
-          <p class="note">The algorithm is always run in a task.</p>
-          <p>
-            When a session is closed, the license(s) and key(s) associated with it are no longer available to
-            decrypt <a def-id="media-data"></a>. All <a>MediaKeySession</a> methods will fail and no further events will be queued for this object
-            after this algorithm is run.
-          </p>
-          <div class="note">
-            <p>
-              The CDM may close a session at any point, such as when the session is no longer needed or when system resources are lost.
-              In that case, the <a def-id="monitor-cdm-algorithm"></a> algorithm detects the change and runs this algorithm.
-            </p>
-            <p>Keys in other sessions MUST be unaffected, even if they have overlapping key IDs.</p>
-            <p>
-              After this algorithm has run, event handlers for the events queued by this algorithm will be executed, but no further events
-              can be queued. As a result, no messages can be sent by the CDM as a result of closing the session.
-            </p>
-          </div>
-          <p>The following steps are run:</p>
-          <ol>
-            <li><p>Let <var>session</var> be the associated <a>MediaKeySession</a> object.</p></li>
-            <li><p>Let <var>promise</var> be the <var>session</var>'s <a def-id="closed"></a> attribute.</p></li>
-            <!-- Avoid a race condition that could cause the algorithms below to be run multiple times. -->
-            <li><p>If <var>promise</var> is resolved, abort these steps.</p></li>
-            <!-- Handle the case that this algorithm is reached by a path other than close(). In all cases, the value is set before the algorithms below are run. -->
-            <li><p>Set the <var>session</var>'s <var>closing or closed</var> value to true.</p></li>
-            <li>
-              <p>
-                If <var>session</var>'s <var>session type</var> is <a def-id="persistent-usage-record-session"></a>, execute the following steps:
-              </p>
-              <ol>
-                <li><p>Let <var>cdm</var> be the CDM instance represented by <var>session</var>'s <var>cdm instance</var> value.</p></li>
-                <li>
-                  <p>Use <var>cdm</var> to store <var>session</var>'s <var>record of key usage</var>, if it exists.</p>
-                  <div class="note">
-                    <p>
-                      The <var>record of key usage</var> may not exist if no keys have been used in the session or if it has been deleted as
-                      a result of the <a def-id="update"></a> method processing an acknowledgement of the <a def-id="record-of-key-usage"></a>.
-                    </p>
-                    <p>
-                      Since it has no effects observable to the document, this step may be run asynchronously, including after the document has unloaded.
-                    </p>
-                  </div>
-                </li>
-              </ol>
-
-            </li>
-            <li><p>Run the <a def-id="update-key-statuses-algorithm"></a> algorithm on the <var>session</var>, providing an empty sequence.</p></li>
-            <li><p>Run the <a def-id="update-expiration-algorithm"></a> algorithm on the <var>session</var>, providing <code>NaN</code>.</p></li>
-            <li><p>Resolve <var>promise</var>.</p></li>
-          </ol>
-        </section>
-        <section id="media-key-session-destroyed">
-          <h4>MediaKeySession Destroyed</h4>
-          <p>
-            The MediaKeySession Destroyed algorithm performs steps that are necessary when a <a>MediaKeySession</a> that is not <a def-id="media-key-session-closed"></a> is destroyed.
-          </p>
-          <p>The following steps are run in parallel to the main event loop:</p>
-          <ol>
-            <li><p>Let <var>session</var> be the associated <a>MediaKeySession</a> object.</p></li>
-            <li><p>Let <var>cdm</var> be the CDM instance represented by <var>session</var>'s <var>cdm instance</var> value.</p></li>
-            <li>
-              <p>Use <var>cdm</var> to execute the following steps:</p>
-              <ol>
-                <li><p>Close the <a href="#key-session">session</a> associated with <var>session</var>.</p></li>
-                <li>
-                  <p>
-                    If <var>session</var>'s <var>session type</var> is <a def-id="persistent-usage-record-session"></a>,
-                    store <var>session</var>'s <var>record of key usage</var>, if it exists.
-                  </p>
-                  <p class="note">
-                    Since it has no effects observable to the document, this step may be run asynchronously, including after the document has unloaded.
-                  </p>
-                </li>
-              </ol>
-            </li>
-          </ol>
-        </section>
-        <section id="monitor-cdm">
-          <h4>Monitor for CDM State Changes</h4>
-          <p>
-            The Monitor for CDM State Changes algorithm executes steps required when various aspects of CDM state change.
-          </p>
-          <p class="note">This algorithm only applies to CDM state changes that are not covered by other algorithms.  For example, <a def-id="update"></a> may result in messages, key status changes and/or expiration changes, but those are all handled within that algorithm.</p>
-          <p class="note">The algorithm is always run in parallel to the main event loop.</p>
-          <p>
-            The following steps are run:
-          </p>
-
-          <ol>
-            <li>
-              <p>
-                Let <var>session</var> be the <a>MediaKeySession</a> object.
-              </p>
-            </li>
-            <li><p>Let <var>cdm</var> be the CDM instance represented by <var>session</var>'s <var>cdm instance</var> value.</p></li>
-            <li>
-              <p>
-                If <var>cdm</var> has an outgoing message that has not yet been sent, <a def-id="queue-a-task"></a> to execute the following steps:
-              </p>
-              <ol>
-                <li>
-                  <p>
-                    Let <var>message type</var> and <var>message</var> be the message type and message, respectively.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Run the <a def-id="queue-message-algorithm"></a> algorithm, passing <var>session</var>, <var>message type</var> and <var>message</var>.
-                  </p>
-                </li>
-              </ol>
-            </li>
-            <li>
-              <p>
-                If <var>cdm</var> has changed the set of keys <a href="#known-key">known</a> to <var>session</var> or the status of one or more of the keys,
-                <a def-id="queue-a-task"></a> to execute the following steps:
-              </p>
-              <ol>
-                <li>
-                  <p>
-                    Let <var>statuses</var> be a list of key ID and <a>MediaKeyStatus</a> value pairs containing one pair for each key
-                    <a href="#known-key">known</a> to <var>session</var>.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Run the <a def-id="update-key-statuses-algorithm"></a> algorithm, passing <var>session</var> and <var>statuses</var>.
-                  </p>
-                </li>
-              </ol>
-            </li>
-            <li>
-              <p>
-                If <var>cdm</var> has changed the <a def-id="expiration-time"></a> of <var>session</var>, <a def-id="queue-a-task"></a> to execute the following steps:
-              </p>
-              <ol>
-                <li>
-                  <p>
-                    Let <var>expiration time</var> be the new expiration time of <var>session</var>.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Run the <a def-id="update-expiration-algorithm"></a> algorithm, passing <var>session</var> and <var>expiration time</var>.
-                  </p>
-                </li>
-              </ol>
-            </li>
-            <li>
-              <p>
-                If <var>cdm</var> has closed <var>session</var>, <a def-id="queue-a-task"></a> to run the <a def-id="session-closed-algorithm"></a> algorithm on <var>session</var>.
-              </p>
-            </li>
-            <li>
-              <p>
-                If <var>cdm</var> had become unavailable, <a def-id="queue-a-task"></a> to run the <a def-id="session-closed-algorithm"></a> algorithm on <var>session</var>.
-              </p>
-            </li>
-          </ol>
-        </section>
-      </section>
-      <section id="exceptions">
-        <h3>Exceptions</h3>
-        <p id="error-names">The methods report errors by rejecting the returned promise with a <a def-id="simple-exception">simple exception</a> [[WEBIDL]] or a <a def-id="domexception"></a>.
-        The following <a def-id="simple-exception">simple exceptions</a> and <a def-id="domexception-names">DOMException names</a> from [[WEBIDL]] are used in the algorithms.
-        Causes specified specified in the algorithms are listed alongside each name, though these names MAY be used for other reasons as well.
-        </p>
-
-        <table class="old-table">
-          <tbody>
-            <tr>
-              <th>Name</th>
-              <th>Possible Causes (non-exhaustive)</th>
-            </tr>
-            <tr>
-              <td><dfn id="dfn-TypeError"><code>TypeError</code></dfn></td>
-              <td>
-                The parameter is empty.<br>
-                Invalid initialization data.<br>
-                Invalid response format.<br>
-                A persistent license was provided for a <a def-id="temporary-session"></a> session.
-              </td>
-            </tr>
-            <tr>
-              <td><dfn id="dfn-NotSupportedError"><code>NotSupportedError</code></dfn></td>
-              <td>
-                The existing MediaKeys object cannot be removed.<br>
-                The key system is not supported.<br>
-                The initialization data type is not supported by the key system.<br>
-                The session type is not supported by the key system.<br>
-                The initialization data is not supported by the key system.<br>
-                The operation is not supported by the key system.
-              </td>
-            </tr>
-            <tr>
-              <td><dfn id="dfn-InvalidStateError"><code>InvalidStateError</code></dfn></td>
-              <td>The existing MediaKeys object cannot be removed at this time.<br>
-                The session has already been used.<br>
-                The session is not yet initialized.<br>
-                The session is closed.
-              </td>
-            </tr>
-            <tr>
-              <td><dfn id="dfn-QuotaExceededError"><code>QuotaExceededError</code></dfn></td>
-              <td>The MediaKeys object cannot be used with additional HTMLMediaElements.<br>
-                A non-closed session already exists for this sessionId.
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </section>
-
-      <section id="session-storage">
-        <h3>Session Storage and Persistence</h3>
-        <p>This section provides an overview of session storage and persistence that complements the algorithms.</p>
-        <p>The following requirements apply in addition to those in <a def-id="media-keys-storage"></a>.</p>
-        <p>If the result of running the <a def-id="is-persistent-session-type-algorithm"></a> algorithm on this object's <var>session type</var> is <code>false</code>, the user agent and CDM MUST NOT persist a record of or data related to the session at any point.
-          This includes license(s), key(s), <a def-id="record-of-license-destruction-maybe-plural"></a>, <a def-id="record-of-key-usage-maybe-plural"></a>, and the <a def-id="session-id"></a>.
-        </p>
-        <p>The remainder of this section applies to session types for which the <a def-id="is-persistent-session-type-algorithm"></a> algorithm returns <code>true</code>.</p>
-        <p>The CDM SHOULD NOT store session data, including the Session ID, until <a def-id="update"></a> is called the first time.
-          Specifically, the CDM SHOULD NOT store session data during the <a def-id="generateRequest"></a> algorithm.
-          This ensures that the application is aware of the session and knows it needs to eventually remove it.
-        </p>
-        <p><em>All</em> data associated with a session MUST be cleared when the session is cleared, such as in <a def-id="update"></a> when processing a <a def-id="record-of-license-destruction"></a> acknowledgement or <a def-id="record-of-key-usage"></a> acknowledgement.
-          See <a href="#persistent-state-requirements">Persistent Data</a>.
-        </p>
-        <p>The CDM MUST ensure that data for a given session is only present in one <a>MediaKeySession</a> object that is not
-        <a def-id="media-key-session-closed"></a> in any <a def-id="document-concept"></a>.
-          In other words, <a def-id="load"></a> MUST fail when there is already a <a>MediaKeySession</a> representing the session specified by the <var>sessionId</var> parameter, either because the object that created it via <a def-id="generateRequest"></a> is still active or it has been loaded into another object via <a def-id="load"></a>.
-          A session MAY only be loaded again if all objects that have ever represented it are <a def-id="media-key-session-closed"></a>.
-        </p>
-        <p>An application that creates a session using a type for which the <a def-id="is-persistent-session-type-algorithm"></a> algorithm returns <code>true</code> SHOULD 
-          later remove the stored data by first initiating the removal process using <a def-id="remove"></a> and then ensuring that the removal process, which may involve 
-          message exchange(s), successfully completes. The CDM MAY also remove sessions as appropriate, but applications SHOULD NOT rely on this.
-        </p>
-        <p>See <a href="#security"></a> and <a href="#privacy"></a> for additional considerations when supporting persistent storage.</p>
+};</pre>
+          <section>
+            <h2>Dictionary <a class="idlType">MediaKeyMessageEventInit</a> Members</h2>
+            <dl class="dictionary-members" data-dfn-for="MediaKeyMessageEventInit"
+              data-link-for="MediaKeyMessageEventInit">
+              <dt>
+                <dfn>
+                  <code>messageType</code>
+                </dfn> of type <span class="idlMemberType"><a>MediaKeyMessageType</a></span>
+              </dt>
+              <dd> The type of the message. </dd>
+              <dt>
+                <dfn>
+                  <code>message</code>
+                </dfn> of type <span class="idlMemberType">{{ArrayBuffer}}</span>
+              </dt>
+              <dd> The message. </dd>
+            </dl>
+          </section>
+        </div>
       </section>
     </section>
-
-    <section>
-      <h2><dfn>HTMLMediaElement</dfn> Extensions</h2>
-      
-      <!-- Put all the monkey-patching here -->
-      
-      <p>This section specifies additions to and modifications of the <a def-id="htmlmediaelement"></a> [[HTML]] when the Encrypted Media Extensions are supported.</p>
-      <p>The following internal values are added to the <a def-id="htmlmediaelement"></a>:</p>
-      <ul>
-        <li>
-          <p><var>attaching media keys</var>, which SHALL have a boolean value, and</p>
-        </li>
-        <li>
-          <p><var>encrypted block queue</var>, which SHALL be a queue of encrypted blocks awaiting decryption, and</p>
-        </li>
-        <li>
-          <p><var>decryption blocked waiting for key</var>, which SHALL have a boolean value.</p>
-        </li>
-        <li>
-          <p><var>playback blocked waiting for key</var>, which SHALL have a boolean value.</p>
-        </li>
-      </ul>
-      <p>The following modifications are made to the behaviour of the <a def-id="htmlmediaelement"></a>:</p>
-      <ul>
-        <li>
-          <p>When a <a def-id="htmlmediaelement"></a> is created, its <var>attaching media keys</var> value SHALL be initialized to <code>false</code>, its <var>encrypted block queue</var> value SHALL be empty, its <var>decryption blocked waiting for key</var> value SHALL be initialized to <code>false</code>, and its <var>playback blocked waiting for key</var> value SHALL be initialized to <code>false</code>.</p>
-        </li>
-        <li>
-          <p>When the <a def-id="current-playback-position"></a> is changed other than advancing in the <a def-id="direction-of-playback"></a> as part of normal playback, the <var>encrypted block queue</var> value SHALL be empty, the <var>decryption blocked waiting for key</var> value SHALL be initialized to <code>false</code>, and the <var>playback blocked waiting for key</var> value SHALL be set to <code>false</code>.</p>
-          <p class="note">
-            In other words, these values should be reset when, for example, <a def-id="loading-the-media-resource"></a> or <a def-id="seeking"></a>.
-          </p>
-        </li>
-        <li>
-          <p>In addition to the criteria specified in [[HTML]], an <a def-id="htmlmediaelement"></a> SHALL be considered a <a def-id="blocked-media-element"></a> if its <var>playback blocked waiting for key</var> value is <code>true</code>.</p>
-        </li>
-        <li>
-          <p>When the user agent is ready to begin playback and has encountered an indication that the <a def-id="media-data"></a> may contain encrypted blocks during the <a def-id="resource-fetch-algorithm"></a>, the user agent SHALL run the <a href="#media-may-contain-encrypted-blocks">Media Data May Contain Encrypted Blocks</a> algorithm.</p>
-          <p class="note">
-            For some container formats, such indication is separate from <a def-id="initialization-data"></a>.
-          </p>
-          <p class="note">
-            The algorithm is to be run after parsing the relevant container data, including running the <a def-id="initdata-encountered-algorithm"></a> algorithm, but before decoding starts.
-          </p>
-        </li>
-        <li>
-          <p>When the user agent encounters <a def-id="initialization-data"></a> in the <a def-id="media-data"></a> during the <a def-id="resource-fetch-algorithm"></a>, the user agent SHALL run the <a def-id="initdata-encountered-algorithm"></a> algorithm.</p>
-          <p class="note">
-            Some container formats may support encrypted media data that does not contain <a def-id="initialization-data"></a> and thus support media data that does not trigger this algorithm.
-          </p>
-        </li>
-        <li>
-          <p>For each block of encrypted <a def-id="media-data"></a> encountered during the <a def-id="resource-fetch-algorithm"></a>, the user agent SHALL run the <a def-id="encrypted-block-encountered-algorithm"></a> algorithm in the order the encrypted blocks were encountered.</p>
-          <p class="note">The above step provides flexibility for user agent implementations to perform decryption at any time after an encrypted block is encountered before it is needed for playback.</p>
-        </li>
-        <li>
-          <p>When one of the following occurs while the <var>decryption blocked waiting for key</var> value is <code>true</code>, the user agent SHALL run the <a def-id="wait-for-key-algorithm"></a> algorithm.</p>
-          <ul>
-            <li><p>The user agent cannot advance the <a def-id="current-playback-position"></a> in the <a def-id="direction-of-playback"></a>.</p></li>
-            <li>
-              <p>The user agent cannot provide data for the <a def-id="current-playback-position"></a>.</p>
-              <p class="note">For example, at the beginning of playback or after <a def-id="seeking"></a>.</p>
-            </li>
-          </ul>
-        </li>
-        <li>
-          <p>Additional attributes and a method are added, as specified below.</p>
-        </li>
-      </ul>
-
-      <p>For methods that return a promise, all errors are reported asynchronously by rejecting the returned Promise. This includes [[WEBIDL]] type mapping errors.</p>
-      <p>The steps of an algorithm are always aborted when rejecting a promise.</p>
-
-      <div><pre class="idl">[Exposed=Window] partial interface HTMLMediaElement {
+    <section id="mediakeysession-events" class="informative">
+      <h3>Event Summary</h3>
+      <table class="old-table">
+        <thead>
+          <tr>
+            <th>Event name</th>
+            <th>Interface</th>
+            <th>Dispatched when...</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><a def-id="eventdfn">keystatuseschange</a></td>
+            <td><a def-id="event"></a></td>
+            <td>There has been a change in the keys in the session or their status.</td>
+          </tr>
+          <tr>
+            <td><a def-id="eventdfn">message</a></td>
+            <td><a>MediaKeyMessageEvent</a></td>
+            <td>The CDM has generated a message for the session.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+    <section id="mediakeysession-algorithms">
+      <h3>Algorithms</h3>
+      <section id="queue-message">
+        <h4>Queue a "message" Event</h4>
+        <p>The Queue a "message" Event algorithm queues a message event to a <a>MediaKeySession</a>
+          object. Requests to run this algorithm include a target <a>MediaKeySession</a> object, a
+          <var>message type</var>, and a <var>message</var>. </p>
+        <p>
+          <var>message</var> MUST NOT contain <a
+            def-id="distinctive-permanent-identifier-maybe-plural"></a>, even in an encrypted form.
+          <var>message</var> MUST NOT contain <a def-id="distinctive-identifier-maybe-plural"></a>,
+          even in an encrypted form, if the <a>MediaKeySession</a> object's <var>use distinctive
+            identifier</var> value is false.
+        </p>
+        <p>The following steps are run:</p>
+        <ol>
+          <li>
+            <p>Let the <var>session</var> be the specified <a>MediaKeySession</a> object.</p>
+          </li>
+          <li>
+            <p><a def-id="Queue-a-task"></a> to create an event named <a def-id="message"></a> that
+              does not bubble and is not cancellable using the <a>MediaKeyMessageEvent</a> interface
+              with its <var>type</var> attribute set to <code>message</code> and its <var>isTrusted
+              </var> attribute initialized to <code>true</code>, and dispatch it at the <var>session
+              </var>.</p>
+            <p>The event interface <a>MediaKeyMessageEvent</a> has:</p>
+            <ul style="list-style-type:none">
+              <li>
+                <a def-id="message-event-messagetype-attribute"></a> = the specified <var>message
+                  type</var>
+                <br>
+                <br>
+                <a def-id="message-event-message-attribute"></a> = the specified <var>message</var>
+              </li>
+            </ul>
+          </li>
+        </ol>
+      </section>
+      <section id="update-key-statuses">
+        <h4>Update Key Statuses</h4>
+        <p>The Update Key Statuses algorithm updates the set of <a href="#known-key">known</a> keys
+          for a <a>MediaKeySession</a> or the status of one or more of the keys. Requests to run
+          this algorithm include a target <a>MediaKeySession</a> object and a sequence of <a
+            def-id="key-id"></a> and associated <a>MediaKeyStatus</a> pairs. </p>
+        <p class="note">The algorithm is always run in a task.</p>
+        <p>The following steps are run:</p>
+        <ol>
+          <li>
+            <p>Let the <var>session</var> be the associated <a>MediaKeySession</a> object.</p>
+          </li>
+          <li>
+            <p>Let the <var>input statuses</var> be the sequence of pairs key ID and associated
+              <a>MediaKeyStatus</a> pairs.</p>
+          </li>
+          <li>
+            <p>Let the <var>statuses</var> be <var>session</var>'s <a def-id="keyStatuses"></a>
+              attribute.</p>
+          </li>
+          <li>
+            <p>Run the following steps to replace the contents of <var>statuses</var>:</p>
+            <ol>
+              <li>
+                <p>Empty <var>statuses</var>.</p>
+              </li>
+              <li>
+                <p>For each pair in <var>input statuses</var>.</p>
+                <ol>
+                  <li>
+                    <p>Let <var>pair</var> be the pair.</p>
+                  </li>
+                  <li>
+                    <p>Insert an entry for <var>pair</var>'s key ID into <var>statuses</var> with
+                      the value of <var>pair</var>'s <a>MediaKeyStatus</a> value.</p>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+            <p class="note">The effect of this steps is that the contents of <var>session</var>'s <a
+                def-id="keyStatuses"></a> attribute are replaced without invalidating existing
+              references to the attribute. This replacement is atomic from a script perspective.
+              That is, script MUST NOT ever see a partially populated sequence. </p>
+          </li>
+          <li>
+            <p><a def-id="Queue-a-task-to-fire-an-event-named"></a> <a
+                def-id="keystatuseschange"></a> at the <var>session</var>.</p>
+          </li>
+          <li>
+            <p><a def-id="Queue-a-task-to-run-algorithm"></a> <a
+                def-id="resume-playback-algorithm"></a> algorithm on each of the media element(s)
+              whose <a def-id="mediaKeys-attribute"></a> attribute is the MediaKeys object that
+              created the <var>session</var>.</p>
+          </li>
+        </ol>
+      </section>
+      <section id="update-expiration">
+        <h4>Update Expiration</h4>
+        <p>The Update Expiration algorithm updates the <a def-id="expiration-time"></a> of a
+          <a>MediaKeySession</a>. Requests to run this algorithm include a target
+          <a>MediaKeySession</a> object and the new expiration time, which may be <code>NaN</code>.
+        </p>
+        <p class="note">The algorithm is always run in a task.</p>
+        <p>The following steps are run:</p>
+        <ol>
+          <li>
+            <p>Let the <var>session</var> be the associated <a>MediaKeySession</a> object.</p>
+          </li>
+          <li>
+            <p>Let <var>expiration time</var> be <code>NaN</code>.</p>
+          </li>
+          <li>
+            <p>If the new expiration time is not <code>NaN</code>, let <var>expiration time</var> be
+              that expiration time.</p>
+          </li>
+          <li>
+            <p>Set the <var>session</var>'s <a def-id="expiration"></a> attribute to <var>expiration
+                time</var> expressed as <a href="#time">time</a>.</p>
+          </li>
+        </ol>
+      </section>
+      <section id="session-closed">
+        <h4>Session Closed</h4>
+        <p>The Session Closed algorithm updates the <a>MediaKeySession</a> state after a <a
+            href="#key-session">key session</a> has been closed by the <a def-id="cdm"></a>.</p>
+        <p class="note">The algorithm is always run in a task.</p>
+        <p> When a session is closed, the license(s) and key(s) associated with it are no longer
+          available to decrypt <a def-id="media-data"></a>. All <a>MediaKeySession</a> methods will
+          fail and no further events will be queued for this object after this algorithm is run.
+        </p>
+        <div class="note">
+          <p> The CDM may close a session at any point, such as when the session is no longer needed
+            or when system resources are lost. In that case, the <a
+              def-id="monitor-cdm-algorithm"></a> algorithm detects the change and runs this
+            algorithm. </p>
+          <p>Keys in other sessions MUST be unaffected, even if they have overlapping key IDs.</p>
+          <p> After this algorithm has run, event handlers for the events queued by this algorithm
+            will be executed, but no further events can be queued. As a result, no messages can be
+            sent by the CDM as a result of closing the session. </p>
+        </div>
+        <p>The following steps are run:</p>
+        <ol>
+          <li>
+            <p>Let <var>session</var> be the associated <a>MediaKeySession</a> object.</p>
+          </li>
+          <li>
+            <p>Let <var>promise</var> be the <var>session</var>'s <a def-id="closed"></a> attribute.
+            </p>
+          </li>
+          <!-- Avoid a race condition that could cause the algorithms below to be run multiple
+               times. -->
+          <li>
+            <p>If <var>promise</var> is resolved, abort these steps.</p>
+          </li>
+          <!-- Handle the case that this algorithm is reached by a path other than close(). In all
+               cases, the value is set before the algorithms below are run. -->
+          <li>
+            <p>Set the <var>session</var>'s <var>closing or closed</var> value to true.</p>
+          </li>
+          <li>
+            <p> If <var>session</var>'s <var>session type</var> is <a
+                def-id="persistent-usage-record-session"></a>, execute the following steps: </p>
+            <ol>
+              <li>
+                <p>Let <var>cdm</var> be the CDM instance represented by <var>session</var>'s <var>
+                    cdm instance</var> value.</p>
+              </li>
+              <li>
+                <p>Use <var>cdm</var> to store <var>session</var>'s <var>record of key usage</var>,
+                  if it exists.</p>
+                <div class="note">
+                  <p> The <var>record of key usage</var> may not exist if no keys have been used in
+                    the session or if it has been deleted as a result of the <a def-id="update"></a>
+                    method processing an acknowledgement of the <a
+                      def-id="record-of-key-usage"></a>. </p>
+                  <p> Since it has no effects observable to the document, this step may be run
+                    asynchronously, including after the document has unloaded. </p>
+                </div>
+              </li>
+            </ol>
+          </li>
+          <li>
+            <p>Run the <a def-id="update-key-statuses-algorithm"></a> algorithm on the <var>session
+              </var>, providing an empty sequence.</p>
+          </li>
+          <li>
+            <p>Run the <a def-id="update-expiration-algorithm"></a> algorithm on the <var>session
+              </var>, providing <code>NaN</code>.</p>
+          </li>
+          <li>
+            <p>Resolve <var>promise</var>.</p>
+          </li>
+        </ol>
+      </section>
+      <section id="media-key-session-destroyed">
+        <h4>MediaKeySession Destroyed</h4>
+        <p> The MediaKeySession Destroyed algorithm performs steps that are necessary when a
+          <a>MediaKeySession</a> that is not <a def-id="media-key-session-closed"></a> is destroyed.
+        </p>
+        <p>The following steps are run in parallel to the main event loop:</p>
+        <ol>
+          <li>
+            <p>Let <var>session</var> be the associated <a>MediaKeySession</a> object.</p>
+          </li>
+          <li>
+            <p>Let <var>cdm</var> be the CDM instance represented by <var>session</var>'s <var>cdm
+                instance</var> value.</p>
+          </li>
+          <li>
+            <p>Use <var>cdm</var> to execute the following steps:</p>
+            <ol>
+              <li>
+                <p>Close the <a href="#key-session">session</a> associated with <var>session</var>.
+                </p>
+              </li>
+              <li>
+                <p> If <var>session</var>'s <var>session type</var> is <a
+                    def-id="persistent-usage-record-session"></a>, store <var>session</var>'s <var>
+                    record of key usage</var>, if it exists. </p>
+                <p class="note"> Since it has no effects observable to the document, this step may
+                  be run asynchronously, including after the document has unloaded. </p>
+              </li>
+            </ol>
+          </li>
+        </ol>
+      </section>
+      <section id="monitor-cdm">
+        <h4>Monitor for CDM State Changes</h4>
+        <p> The Monitor for CDM State Changes algorithm executes steps required when various aspects
+          of CDM state change. </p>
+        <p class="note">This algorithm only applies to CDM state changes that are not covered by
+          other algorithms. For example, <a def-id="update"></a> may result in messages, key status
+          changes and/or expiration changes, but those are all handled within that algorithm.</p>
+        <p class="note">The algorithm is always run in parallel to the main event loop.</p>
+        <p> The following steps are run: </p>
+        <ol>
+          <li>
+            <p> Let <var>session</var> be the <a>MediaKeySession</a> object. </p>
+          </li>
+          <li>
+            <p>Let <var>cdm</var> be the CDM instance represented by <var>session</var>'s <var>cdm
+                instance</var> value.</p>
+          </li>
+          <li>
+            <p> If <var>cdm</var> has an outgoing message that has not yet been sent, <a
+                def-id="queue-a-task"></a> to execute the following steps: </p>
+            <ol>
+              <li>
+                <p> Let <var>message type</var> and <var>message</var> be the message type and
+                  message, respectively. </p>
+              </li>
+              <li>
+                <p> Run the <a def-id="queue-message-algorithm"></a> algorithm, passing <var>session
+                  </var>, <var>message type</var> and <var>message</var>. </p>
+              </li>
+            </ol>
+          </li>
+          <li>
+            <p> If <var>cdm</var> has changed the set of keys <a href="#known-key">known</a> to
+              <var>session</var> or the status of one or more of the keys, <a
+                def-id="queue-a-task"></a> to execute the following steps: </p>
+            <ol>
+              <li>
+                <p> Let <var>statuses</var> be a list of key ID and <a>MediaKeyStatus</a> value
+                  pairs containing one pair for each key <a href="#known-key">known</a> to <var>
+                    session</var>. </p>
+              </li>
+              <li>
+                <p> Run the <a def-id="update-key-statuses-algorithm"></a> algorithm, passing <var>
+                    session</var> and <var>statuses</var>. </p>
+              </li>
+            </ol>
+          </li>
+          <li>
+            <p> If <var>cdm</var> has changed the <a def-id="expiration-time"></a> of <var>session
+              </var>, <a def-id="queue-a-task"></a> to execute the following steps: </p>
+            <ol>
+              <li>
+                <p> Let <var>expiration time</var> be the new expiration time of <var>session</var>.
+                </p>
+              </li>
+              <li>
+                <p> Run the <a def-id="update-expiration-algorithm"></a> algorithm, passing <var>
+                    session</var> and <var>expiration time</var>. </p>
+              </li>
+            </ol>
+          </li>
+          <li>
+            <p> If <var>cdm</var> has closed <var>session</var>, <a def-id="queue-a-task"></a> to
+              run the <a def-id="session-closed-algorithm"></a> algorithm on <var>session</var>.
+            </p>
+          </li>
+          <li>
+            <p> If <var>cdm</var> had become unavailable, <a def-id="queue-a-task"></a> to run the
+              <a def-id="session-closed-algorithm"></a> algorithm on <var>session</var>. </p>
+          </li>
+        </ol>
+      </section>
+    </section>
+    <section id="exceptions">
+      <h3>Exceptions</h3>
+      <p id="error-names">The methods report errors by rejecting the returned promise with a <a
+          def-id="simple-exception">simple exception</a> [[WEBIDL]] or a <a
+          def-id="domexception"></a>. The following <a def-id="simple-exception">simple
+          exceptions</a> and <a def-id="domexception-names">DOMException names</a> from [[WEBIDL]]
+        are used in the algorithms. Causes specified specified in the algorithms are listed
+        alongside each name, though these names MAY be used for other reasons as well. </p>
+      <table class="old-table">
+        <tbody>
+          <tr>
+            <th>Name</th>
+            <th>Possible Causes (non-exhaustive)</th>
+          </tr>
+          <tr>
+            <td>
+              <dfn id="dfn-TypeError">
+                <code>TypeError</code>
+              </dfn>
+            </td>
+            <td> The parameter is empty.
+              <br> Invalid initialization data.
+              <br> Invalid response format.
+              <br> A persistent license was provided for a <a def-id="temporary-session"></a>
+              session. </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn id="dfn-NotSupportedError">
+                <code>NotSupportedError</code>
+              </dfn>
+            </td>
+            <td> The existing MediaKeys object cannot be removed.
+              <br> The key system is not supported.
+              <br> The initialization data type is not supported by the key system.
+              <br> The session type is not supported by the key system.
+              <br> The initialization data is not supported by the key system.
+              <br> The operation is not supported by the key system. </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn id="dfn-InvalidStateError">
+                <code>InvalidStateError</code>
+              </dfn>
+            </td>
+            <td>The existing MediaKeys object cannot be removed at this time.
+              <br> The session has already been used.
+              <br> The session is not yet initialized.
+              <br> The session is closed. </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn id="dfn-QuotaExceededError">
+                <code>QuotaExceededError</code>
+              </dfn>
+            </td>
+            <td>The MediaKeys object cannot be used with additional HTMLMediaElements.
+              <br> A non-closed session already exists for this sessionId. </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+    <section id="session-storage">
+      <h3>Session Storage and Persistence</h3>
+      <p>This section provides an overview of session storage and persistence that complements the
+        algorithms.</p>
+      <p>The following requirements apply in addition to those in <a
+          def-id="media-keys-storage"></a>.</p>
+      <p>If the result of running the <a def-id="is-persistent-session-type-algorithm"></a>
+        algorithm on this object's <var>session type</var> is <code>false</code>, the user agent and
+        CDM MUST NOT persist a record of or data related to the session at any point. This includes
+        license(s), key(s), <a def-id="record-of-license-destruction-maybe-plural"></a>, <a
+          def-id="record-of-key-usage-maybe-plural"></a>, and the <a def-id="session-id"></a>. </p>
+      <p>The remainder of this section applies to session types for which the <a
+          def-id="is-persistent-session-type-algorithm"></a> algorithm returns <code>true</code>.
+      </p>
+      <p>The CDM SHOULD NOT store session data, including the Session ID, until <a
+          def-id="update"></a> is called the first time. Specifically, the CDM SHOULD NOT store
+        session data during the <a def-id="generateRequest"></a> algorithm. This ensures that the
+        application is aware of the session and knows it needs to eventually remove it. </p>
+      <p>
+        <em>All</em> data associated with a session MUST be cleared when the session is cleared,
+        such as in <a def-id="update"></a> when processing a <a
+          def-id="record-of-license-destruction"></a> acknowledgement or <a
+          def-id="record-of-key-usage"></a> acknowledgement. See <a
+          href="#persistent-state-requirements">Persistent Data</a>.
+      </p>
+      <p>The CDM MUST ensure that data for a given session is only present in one
+        <a>MediaKeySession</a> object that is not <a def-id="media-key-session-closed"></a> in any
+        <a def-id="document-concept"></a>. In other words, <a def-id="load"></a> MUST fail when
+        there is already a <a>MediaKeySession</a> representing the session specified by the <var>
+          sessionId</var> parameter, either because the object that created it via <a
+          def-id="generateRequest"></a> is still active or it has been loaded into another object
+        via <a def-id="load"></a>. A session MAY only be loaded again if all objects that have ever
+        represented it are <a def-id="media-key-session-closed"></a>. </p>
+      <p>An application that creates a session using a type for which the <a
+          def-id="is-persistent-session-type-algorithm"></a> algorithm returns <code>true</code>
+        SHOULD later remove the stored data by first initiating the removal process using <a
+          def-id="remove"></a> and then ensuring that the removal process, which may involve message
+        exchange(s), successfully completes. The CDM MAY also remove sessions as appropriate, but
+        applications SHOULD NOT rely on this. </p>
+      <p>See <a href="#security"></a> and <a href="#privacy"></a> for additional considerations when
+        supporting persistent storage.</p>
+    </section>
+  </section>
+  <section>
+    <h2>
+      <dfn>HTMLMediaElement</dfn> Extensions
+    </h2>
+    <!-- Put all the monkey-patching here -->
+    <p>This section specifies additions to and modifications of the <a
+        def-id="htmlmediaelement"></a> [[HTML]] when the Encrypted Media Extensions are supported.
+    </p>
+    <p>The following internal values are added to the <a def-id="htmlmediaelement"></a>:</p>
+    <ul>
+      <li>
+        <p>
+          <var>attaching media keys</var>, which SHALL have a boolean value, and
+        </p>
+      </li>
+      <li>
+        <p>
+          <var>encrypted block queue</var>, which SHALL be a queue of encrypted blocks awaiting
+          decryption, and
+        </p>
+      </li>
+      <li>
+        <p>
+          <var>decryption blocked waiting for key</var>, which SHALL have a boolean value.
+        </p>
+      </li>
+      <li>
+        <p>
+          <var>playback blocked waiting for key</var>, which SHALL have a boolean value.
+        </p>
+      </li>
+    </ul>
+    <p>The following modifications are made to the behaviour of the <a
+        def-id="htmlmediaelement"></a>:</p>
+    <ul>
+      <li>
+        <p>When a <a def-id="htmlmediaelement"></a> is created, its <var>attaching media keys</var>
+          value SHALL be initialized to <code>false</code>, its <var>encrypted block queue</var>
+          value SHALL be empty, its <var>decryption blocked waiting for key</var> value SHALL be
+          initialized to <code>false</code>, and its <var>playback blocked waiting for key</var>
+          value SHALL be initialized to <code>false</code>.</p>
+      </li>
+      <li>
+        <p>When the <a def-id="current-playback-position"></a> is changed other than advancing in
+          the <a def-id="direction-of-playback"></a> as part of normal playback, the <var>encrypted
+            block queue</var> value SHALL be empty, the <var>decryption blocked waiting for key
+          </var> value SHALL be initialized to <code>false</code>, and the <var>playback blocked
+            waiting for key</var> value SHALL be set to <code>false</code>.</p>
+        <p class="note"> In other words, these values should be reset when, for example, <a
+            def-id="loading-the-media-resource"></a> or <a def-id="seeking"></a>. </p>
+      </li>
+      <li>
+        <p>In addition to the criteria specified in [[HTML]], an <a def-id="htmlmediaelement"></a>
+          SHALL be considered a <a def-id="blocked-media-element"></a> if its <var>playback blocked
+            waiting for key</var> value is <code>true</code>.</p>
+      </li>
+      <li>
+        <p>When the user agent is ready to begin playback and has encountered an indication that the
+          <a def-id="media-data"></a> may contain encrypted blocks during the <a
+            def-id="resource-fetch-algorithm"></a>, the user agent SHALL run the <a
+            href="#media-may-contain-encrypted-blocks">Media Data May Contain Encrypted Blocks</a>
+          algorithm.</p>
+        <p class="note"> For some container formats, such indication is separate from <a
+            def-id="initialization-data"></a>. </p>
+        <p class="note"> The algorithm is to be run after parsing the relevant container data,
+          including running the <a def-id="initdata-encountered-algorithm"></a> algorithm, but
+          before decoding starts. </p>
+      </li>
+      <li>
+        <p>When the user agent encounters <a def-id="initialization-data"></a> in the <a
+            def-id="media-data"></a> during the <a def-id="resource-fetch-algorithm"></a>, the user
+          agent SHALL run the <a def-id="initdata-encountered-algorithm"></a> algorithm.</p>
+        <p class="note"> Some container formats may support encrypted media data that does not
+          contain <a def-id="initialization-data"></a> and thus support media data that does not
+          trigger this algorithm. </p>
+      </li>
+      <li>
+        <p>For each block of encrypted <a def-id="media-data"></a> encountered during the <a
+            def-id="resource-fetch-algorithm"></a>, the user agent SHALL run the <a
+            def-id="encrypted-block-encountered-algorithm"></a> algorithm in the order the encrypted
+          blocks were encountered.</p>
+        <p class="note">The above step provides flexibility for user agent implementations to
+          perform decryption at any time after an encrypted block is encountered before it is needed
+          for playback.</p>
+      </li>
+      <li>
+        <p>When one of the following occurs while the <var>decryption blocked waiting for key</var>
+          value is <code>true</code>, the user agent SHALL run the <a
+            def-id="wait-for-key-algorithm"></a> algorithm.</p>
+        <ul>
+          <li>
+            <p>The user agent cannot advance the <a def-id="current-playback-position"></a> in the
+              <a def-id="direction-of-playback"></a>.</p>
+          </li>
+          <li>
+            <p>The user agent cannot provide data for the <a
+                def-id="current-playback-position"></a>.</p>
+            <p class="note">For example, at the beginning of playback or after <a
+                def-id="seeking"></a>.</p>
+          </li>
+        </ul>
+      </li>
+      <li>
+        <p>Additional attributes and a method are added, as specified below.</p>
+      </li>
+    </ul>
+    <p>For methods that return a promise, all errors are reported asynchronously by rejecting the
+      returned Promise. This includes [[WEBIDL]] type mapping errors.</p>
+    <p>The steps of an algorithm are always aborted when rejecting a promise.</p>
+    <div>
+      <pre class="idl">[Exposed=Window] partial interface HTMLMediaElement {
     [SecureContext] readonly        attribute MediaKeys?   mediaKeys;
                                     attribute EventHandler onencrypted;
                                     attribute EventHandler onwaitingforkey;
     [SecureContext] Promise&lt;void&gt; setMediaKeys (MediaKeys? mediaKeys);
-};</pre><section><h2>Attributes</h2><dl class="attributes" data-dfn-for="HTMLMediaElement" data-link-for="HTMLMediaElement"><dt><dfn><code>mediaKeys</code></dfn> of type <span class="idlAttrType"><!-- Restore when https://github.com/w3c/respec/issues/893 is fixed. <a> -->MediaKeys<!-- </a> --></span>, readonly       , nullable</dt><dd>
-          <p>The <!-- Restore when https://github.com/w3c/respec/issues/893 is fixed. <a> -->MediaKeys<!-- </a> --> being used when decrypting encrypted <a def-id="media-data"></a> for this media element.</p>
-        </dd><dt><dfn><code>onencrypted</code></dfn> of type <span class="idlAttrType">{{EventHandler}}</span></dt><dd>
-          <p>Event handler for the <a def-id="encrypted"></a> event. It MUST be supported by all HTMLMediaElements as both a content attribute and an IDL attribute.</p>
-        </dd><dt><dfn><code>onwaitingforkey</code></dfn> of type <span class="idlAttrType">{{EventHandler}}</span></dt><dd>
-          <p>Event handler for the <a def-id="waitingforkey"></a> event. It MUST be supported by all HTMLMediaElements as both a content attribute and an IDL attribute.</p>
-        </dd></dl></section><section><h2>Methods</h2><dl class="methods" data-dfn-for="HTMLMediaElement" data-link-for="HTMLMediaElement"><dt><dfn><code>setMediaKeys</code></dfn></dt><dd>
-          <p>Provides the <!-- Restore when https://github.com/w3c/respec/issues/893 is fixed. <a> -->MediaKeys<!-- </a> --> to use when decrypting media data during playback.</p>
-
-          <p class="note">Support for clearing or replacing the associated <!-- Restore when https://github.com/w3c/respec/issues/893 is fixed. <a> -->MediaKeys<!-- </a> --> object during playback is a quality of implementation issue. In many cases it will result in a bad user experience or rejected promise.</p>
-
-          <ol class="method-algorithm">
-            <!-- For simplicity and consistency, do not allow multiple pending calls. -->
-            <li><p>If this object's <var>attaching media keys</var> value is true, return a promise rejected with an <a def-id="InvalidStateError"></a>.</p></li>
-            <li><p>If <var>mediaKeys</var> and the <a def-id="mediaKeys-attribute"></a> attribute are the same object, return a resolved promise.</p></li>
-            <li><p>Let this object's <var>attaching media keys</var> value be true.</p></li>
-            <li><p>Let <var>promise</var> be a new promise.</p></li>
-            <li><p>Run the following steps in parallel:</p>
-              <ol>
-                <li>
-                  <p>If all the following conditions hold:</p>
-                  <ul>
-                    <li><p><var>mediaKeys</var> is not null,</p></li>
-                    <li>
-                      <p>the CDM instance represented by <var>mediaKeys</var> is already in use by another media element</p>
-                    </li>
-                    <li><p>the user agent is unable to use it with this element</p></li>
-                  </ul>
-                  <p>
-                    then let this object's <var>attaching media keys</var> value be false and reject <var>promise</var> with a <a def-id="QuotaExceededError"></a>.
-                  </p>
-                </li>
-                <li><p>If the <a def-id="mediaKeys-attribute"></a> attribute is not null, run the following steps:</p>
-                  <ol>
-                    <li><p>If the user agent or CDM do not support removing the association, let this object's <var>attaching media keys</var> value be false and reject <var>promise</var> with a <a def-id="NotSupportedError"></a>.</p></li>
-                    <li><p>If the association cannot currently be removed, let this object's <var>attaching media keys</var> value be false and reject <var>promise</var> with an <a def-id="InvalidStateError"></a>.</p>
-                      <p class="note">For example, some implementations may not allow removal during playback.</p>
-                    </li>
-                    <li><p>Stop using the CDM instance represented by the <a def-id="mediaKeys-attribute"></a> attribute to decrypt <a def-id="media-data"></a> and remove the association with the media element.</p></li>
-                    <li><p>If the preceding step failed, let this object's <var>attaching media keys</var> value be false and reject <var>promise</var> with <a def-id="appropriate-error-name"></a>.</p></li>
-                  </ol>
-                </li>
-                <li><p>If <var>mediaKeys</var> is not null, run the following steps:</p>
-                  <ol>
-                    <li><p>Associate the CDM instance represented by <var>mediaKeys</var> with the media element for decrypting <a def-id="media-data"></a>.</p></li>
-                    <li><p>If the preceding step failed, run the following steps:</p>
-                      <ol>
-                        <li><p>Set the <a def-id="mediaKeys-attribute"></a> attribute to null.</p></li><!-- In case it was previously not null since the previous association has been removed. -->
-                        <li><p>Let this object's <var>attaching media keys</var> value be false.</p></li>
-                        <li><p>Reject <var>promise</var> with <a def-id="new-domexception-named"></a> <a def-id="appropriate-error-name"></a>.</p></li>
-                      </ol>
-                    </li>
-                    <li><p><a def-id="Queue-a-task-to-run-algorithm"></a> <a def-id="resume-playback-algorithm"></a> algorithm on the media element.</p>
-                    </li>
-                  </ol>
-                </li>
-                <li><p>Set the <a def-id="mediaKeys-attribute"></a> attribute to <var>mediaKeys</var>.</p></li>
-                <li><p>Let this object's <var>attaching media keys</var> value be false.</p></li>
-                <li><p>Resolve <var>promise</var>.</p></li>
-              </ol>
-            </li>
-            <li><p>Return <var>promise</var>.</p></li>
-          </ol>
-        <table class="parameters"><tbody><tr><th>Parameter</th><th>Type</th><th>Nullable</th><th>Optional</th><th>Description</th></tr><tr><td class="prmName">mediaKeys</td><td class="prmType"><code>MediaKeys</code></td><td class="prmNullTrue"><span role="img" aria-label="True">✔</span></td><td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td><td class="prmDesc">
-              A <!-- Restore when https://github.com/w3c/respec/issues/893 is fixed. <a> -->MediaKeys<!-- </a> --> object.
-            </td></tr></tbody></table><div><em>Return type: </em><code>Promise&lt;void&gt;</code></div></dd></dl></secion></div>
-
+};</pre>
       <section>
-        <h3><a>MediaEncryptedEvent</a></h3>
-        <p>The MediaEncryptedEvent object is used for the <a def-id="encrypted"></a> event.</p>
-        <p>Events are constructed as defined in <a def-id="constructing-events"></a> [[DOM]].</p>
-
-        <div><pre class="idl">[Exposed=Window]
+        <h2>Attributes</h2>
+        <dl class="attributes" data-dfn-for="HTMLMediaElement" data-link-for="HTMLMediaElement">
+          <dt>
+            <dfn>
+              <code>mediaKeys</code>
+            </dfn> of type <span class="idlAttrType">
+              <!-- Restore when https://github.com/w3c/respec/issues/893 is fixed. <a> -->MediaKeys
+              <!-- </a> -->
+            </span>, readonly , nullable
+          </dt>
+          <dd>
+            <p>The
+              <!-- Restore when https://github.com/w3c/respec/issues/893 is fixed. <a> -->MediaKeys
+              <!-- </a> --> being used when decrypting encrypted <a def-id="media-data"></a> for
+              this media element.</p>
+          </dd>
+          <dt>
+            <dfn>
+              <code>onencrypted</code>
+            </dfn> of type <span class="idlAttrType">{{EventHandler}}</span>
+          </dt>
+          <dd>
+            <p>Event handler for the <a def-id="encrypted"></a> event. It MUST be supported by all
+              HTMLMediaElements as both a content attribute and an IDL attribute.</p>
+          </dd>
+          <dt>
+            <dfn>
+              <code>onwaitingforkey</code>
+            </dfn> of type <span class="idlAttrType">{{EventHandler}}</span>
+          </dt>
+          <dd>
+            <p>Event handler for the <a def-id="waitingforkey"></a> event. It MUST be supported by
+              all HTMLMediaElements as both a content attribute and an IDL attribute.</p>
+          </dd>
+        </dl>
+      </section>
+      <section>
+        <h2>Methods</h2>
+        <dl class="methods" data-dfn-for="HTMLMediaElement" data-link-for="HTMLMediaElement">
+          <dt>
+            <dfn>
+              <code>setMediaKeys</code>
+            </dfn>
+          </dt>
+          <dd>
+            <p>Provides the
+              <!-- Restore when https://github.com/w3c/respec/issues/893 is fixed. <a> -->MediaKeys
+              <!-- </a> --> to use when decrypting media data during playback.</p>
+            <p class="note">Support for clearing or replacing the associated
+              <!-- Restore when https://github.com/w3c/respec/issues/893 is fixed. <a> -->MediaKeys
+              <!-- </a> --> object during playback is a quality of implementation issue. In many
+              cases it will result in a bad user experience or rejected promise.</p>
+            <ol class="method-algorithm">
+              <!-- For simplicity and consistency, do not allow multiple pending calls. -->
+              <li>
+                <p>If this object's <var>attaching media keys</var> value is true, return a promise
+                  rejected with an <a def-id="InvalidStateError"></a>.</p>
+              </li>
+              <li>
+                <p>If <var>mediaKeys</var> and the <a def-id="mediaKeys-attribute"></a> attribute
+                  are the same object, return a resolved promise.</p>
+              </li>
+              <li>
+                <p>Let this object's <var>attaching media keys</var> value be true.</p>
+              </li>
+              <li>
+                <p>Let <var>promise</var> be a new promise.</p>
+              </li>
+              <li>
+                <p>Run the following steps in parallel:</p>
+                <ol>
+                  <li>
+                    <p>If all the following conditions hold:</p>
+                    <ul>
+                      <li>
+                        <p>
+                          <var>mediaKeys</var> is not null,
+                        </p>
+                      </li>
+                      <li>
+                        <p>the CDM instance represented by <var>mediaKeys</var> is already in use by
+                          another media element</p>
+                      </li>
+                      <li>
+                        <p>the user agent is unable to use it with this element</p>
+                      </li>
+                    </ul>
+                    <p> then let this object's <var>attaching media keys</var> value be false and
+                      reject <var>promise</var> with a <a def-id="QuotaExceededError"></a>. </p>
+                  </li>
+                  <li>
+                    <p>If the <a def-id="mediaKeys-attribute"></a> attribute is not null, run the
+                      following steps:</p>
+                    <ol>
+                      <li>
+                        <p>If the user agent or CDM do not support removing the association, let
+                          this object's <var>attaching media keys</var> value be false and reject
+                          <var>promise</var> with a <a def-id="NotSupportedError"></a>.</p>
+                      </li>
+                      <li>
+                        <p>If the association cannot currently be removed, let this object's <var>
+                            attaching media keys</var> value be false and reject <var>promise</var>
+                          with an <a def-id="InvalidStateError"></a>.</p>
+                        <p class="note">For example, some implementations may not allow removal
+                          during playback.</p>
+                      </li>
+                      <li>
+                        <p>Stop using the CDM instance represented by the <a
+                            def-id="mediaKeys-attribute"></a> attribute to decrypt <a
+                            def-id="media-data"></a> and remove the association with the media
+                          element.</p>
+                      </li>
+                      <li>
+                        <p>If the preceding step failed, let this object's <var>attaching media keys
+                          </var> value be false and reject <var>promise</var> with <a
+                            def-id="appropriate-error-name"></a>.</p>
+                      </li>
+                    </ol>
+                  </li>
+                  <li>
+                    <p>If <var>mediaKeys</var> is not null, run the following steps:</p>
+                    <ol>
+                      <li>
+                        <p>Associate the CDM instance represented by <var>mediaKeys</var> with the
+                          media element for decrypting <a def-id="media-data"></a>.</p>
+                      </li>
+                      <li>
+                        <p>If the preceding step failed, run the following steps:</p>
+                        <ol>
+                          <li>
+                            <p>Set the <a def-id="mediaKeys-attribute"></a> attribute to null.</p>
+                          </li>
+                          <!-- In case it was previously not null since the previous association has
+                               been removed. -->
+                          <li>
+                            <p>Let this object's <var>attaching media keys</var> value be false.</p>
+                          </li>
+                          <li>
+                            <p>Reject <var>promise</var> with <a
+                                def-id="new-domexception-named"></a> <a
+                                def-id="appropriate-error-name"></a>.</p>
+                          </li>
+                        </ol>
+                      </li>
+                      <li>
+                        <p><a def-id="Queue-a-task-to-run-algorithm"></a> <a
+                            def-id="resume-playback-algorithm"></a> algorithm on the media element.
+                        </p>
+                      </li>
+                    </ol>
+                  </li>
+                  <li>
+                    <p>Set the <a def-id="mediaKeys-attribute"></a> attribute to <var>mediaKeys
+                      </var>.</p>
+                  </li>
+                  <li>
+                    <p>Let this object's <var>attaching media keys</var> value be false.</p>
+                  </li>
+                  <li>
+                    <p>Resolve <var>promise</var>.</p>
+                  </li>
+                </ol>
+              </li>
+              <li>
+                <p>Return <var>promise</var>.</p>
+              </li>
+            </ol>
+            <table class="parameters">
+              <tbody>
+                <tr>
+                  <th>Parameter</th>
+                  <th>Type</th>
+                  <th>Nullable</th>
+                  <th>Optional</th>
+                  <th>Description</th>
+                </tr>
+                <tr>
+                  <td class="prmName">mediaKeys</td>
+                  <td class="prmType">
+                    <code>MediaKeys</code>
+                  </td>
+                  <td class="prmNullTrue">
+                    <span role="img" aria-label="True">✔</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc"> A
+                    <!-- Restore when https://github.com/w3c/respec/issues/893 is fixed. <a> -->
+                    MediaKeys
+                    <!-- </a> --> object. </td>
+                </tr>
+              </tbody>
+            </table>
+            <div>
+              <em>Return type: </em>
+              <code>Promise&lt;void&gt;</code>
+            </div>
+          </dd>
+        </dl>
+        </secion>
+    </div>
+    <section>
+      <h3><a>MediaEncryptedEvent</a></h3>
+      <p>The MediaEncryptedEvent object is used for the <a def-id="encrypted"></a> event.</p>
+      <p>Events are constructed as defined in <a def-id="constructing-events"></a> [[DOM]].</p>
+      <div>
+        <pre class="idl">[Exposed=Window]
 interface MediaEncryptedEvent : Event {
     constructor(DOMString type, optional MediaEncryptedEventInit eventInitDict = {});
     readonly        attribute DOMString    initDataType;
     readonly        attribute ArrayBuffer? initData;
-};</pre><section><h2>Constructors</h2><dl class="constructors" data-dfn-for="MediaEncryptedEvent" data-link-for="MediaEncryptedEvent"><dt><dfn><code>MediaEncryptedEvent</code></dfn></dt><dd>
-
-          <table class="parameters"><tbody><tr><th>Parameter</th><th>Type</th><th>Nullable</th><th>Optional</th><th>Description</th></tr><tr><td class="prmName">type</td><td class="prmType"><code>DOMString</code></td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td><td class="prmDesc"></td></tr><tr><td class="prmName">eventInitDict</td><td class="prmType"><code>MediaEncryptedEventInit</code></td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptTrue"><span role="img" aria-label="True">✔</span></td><td class="prmDesc"></td></tr></tbody></table></dd></dl></section><section><h2>Attributes</h2><dl class="attributes" data-dfn-for="MediaEncryptedEvent" data-link-for="MediaEncryptedEvent"><dt><dfn><code>initDataType</code></dfn> of type <span class="idlAttrType">{{DOMString}}</span>, readonly       </dt><dd>
-            Indicates the <a def-id="initialization-data-type"></a> of the <a def-id="initialization-data"></a> contained in the <a def-id="encrypted-event-initdata-attribute"></a> attribute.
-          </dd><dt><dfn><code>initData</code></dfn> of type <span class="idlAttrType">{{ArrayBuffer}}</span>, readonly       , nullable</dt><dd>
-            The <a def-id="initialization-data"></a> for the event.
-          </dd></dl></section></div>
-
+};</pre>
         <section>
-          <h4><dfn>MediaEncryptedEventInit</dfn></h4>
-          <div><pre class="idl" data-cite="DOM">dictionary MediaEncryptedEventInit : EventInit {
+          <h2>Constructors</h2>
+          <dl class="constructors" data-dfn-for="MediaEncryptedEvent"
+            data-link-for="MediaEncryptedEvent">
+            <dt>
+              <dfn>
+                <code>MediaEncryptedEvent</code>
+              </dfn>
+            </dt>
+            <dd>
+              <table class="parameters">
+                <tbody>
+                  <tr>
+                    <th>Parameter</th>
+                    <th>Type</th>
+                    <th>Nullable</th>
+                    <th>Optional</th>
+                    <th>Description</th>
+                  </tr>
+                  <tr>
+                    <td class="prmName">type</td>
+                    <td class="prmType">
+                      <code>DOMString</code>
+                    </td>
+                    <td class="prmNullFalse">
+                      <span role="img" aria-label="False">✘</span>
+                    </td>
+                    <td class="prmOptFalse">
+                      <span role="img" aria-label="False">✘</span>
+                    </td>
+                    <td class="prmDesc"></td>
+                  </tr>
+                  <tr>
+                    <td class="prmName">eventInitDict</td>
+                    <td class="prmType">
+                      <code>MediaEncryptedEventInit</code>
+                    </td>
+                    <td class="prmNullFalse">
+                      <span role="img" aria-label="False">✘</span>
+                    </td>
+                    <td class="prmOptTrue">
+                      <span role="img" aria-label="True">✔</span>
+                    </td>
+                    <td class="prmDesc"></td>
+                  </tr>
+                </tbody>
+              </table>
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h2>Attributes</h2>
+          <dl class="attributes" data-dfn-for="MediaEncryptedEvent"
+            data-link-for="MediaEncryptedEvent">
+            <dt>
+              <dfn>
+                <code>initDataType</code>
+              </dfn> of type <span class="idlAttrType">{{DOMString}}</span>, readonly
+            </dt>
+            <dd> Indicates the <a def-id="initialization-data-type"></a> of the <a
+                def-id="initialization-data"></a> contained in the <a
+                def-id="encrypted-event-initdata-attribute"></a> attribute. </dd>
+            <dt>
+              <dfn>
+                <code>initData</code>
+              </dfn> of type <span class="idlAttrType">{{ArrayBuffer}}</span>, readonly , nullable
+            </dt>
+            <dd> The <a def-id="initialization-data"></a> for the event. </dd>
+          </dl>
+        </section>
+      </div>
+      <section>
+        <h4>
+          <dfn>MediaEncryptedEventInit</dfn>
+        </h4>
+        <div>
+          <pre class="idl" data-cite="DOM">dictionary MediaEncryptedEventInit : EventInit {
              DOMString    initDataType = "";
              ArrayBuffer? initData = null;
-};</pre><section><h2>Dictionary <a class="idlType">MediaEncryptedEventInit</a> Members</h2><dl class="dictionary-members" data-dfn-for="MediaEncryptedEventInit" data-link-for="MediaEncryptedEventInit"><dt><dfn><code>initDataType</code></dfn> of type <span class="idlMemberType">{{DOMString}}</span>, defaulting to <code>""</code></dt><dd>
-              The <a def-id="initialization-data-type"></a>.
-            </dd><dt><dfn><code>initData</code></dfn> of type <span class="idlMemberType">{{ArrayBuffer}}</span>, nullable, defaulting to <code>null</code></dt><dd>
-              The <a def-id="initialization-data"></a>.
-            </dd></dl></section></div>
-        </section>
-      </section>
-
-      <section id="htmlmediaelement-events" class="informative">
-        <h3>Event Summary</h3>
-
-        <table class="old-table">
-          <thead>
-            <tr>
-              <th>Event name</th>
-              <th>Interface</th>
-              <th>Dispatched when...</th>
-              <th>Preconditions</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td><a def-id="eventdfn">encrypted</a></td>
-              <td><a>MediaEncryptedEvent</a></td>
-              <td>The user agent encounters <a def-id="initialization-data"></a> in the <a def-id="media-data"></a>.</td>
-              <td>The element's <a def-id="readystate"></a> is equal to or greater than  <a def-id="have-metadata"></a>.
-              <p class="note">It is possible that the element is playing or has played.</p>
-              </td>
-            </tr>
-            <tr>
-              <td><a def-id="eventdfn">waitingforkey</a></td>
-              <td><a def-id="event"></a></td>
-              <td>Playback is blocked waiting for a key.</td>
-              <td>
-                The <a def-id="readystate"></a> is equal to or less than <a def-id="have-current-data"></a>.
-                The element's <var>playback blocked waiting for key</var> value is newly <code>true</code>.
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </section>
-
-      <section id="htmlmediaelement-algorithms">
-        <h3>Algorithms</h3>
-
-        <section id="media-may-contain-encrypted-blocks">
-          <h4>Media Data May Contain Encrypted Blocks</h4>
-          <p>
-            The Media Data May Contain Encrypted Blocks algorithm pauses playback if the user agent requires specification of a <a>MediaKeys</a> object before playing the media data.
-            Requests to run this algorithm include a target <a def-id="htmlmediaelement"></a> object.
-          </p>
-          <p>The following steps are run:</p>
-          <ol>
-            <li><p>Let the <var>media element</var> be the specified <a def-id="htmlmediaelement"></a> object.</p></li>
-            <li>
-              <p>If the <var>media element</var>'s <a def-id="mediaKeys-attribute"></a> attribute is null and the implementation requires specification of a <a>MediaKeys</a> object before decoding potentially-encrypted <a def-id="media-data"></a>, run the following steps:</p>
-              <p class="note">These steps may be reached when the application provides <a def-id="media-data"></a> before calling <a def-id="setMediaKeys"></a> to provide a <a>MediaKeys</a> object.
-                Selecting a <a def-id="cdm"></a> may affect the pipeline and/or decoders used, so some implementations may delay playback of media data that may contain encrypted blocks until a CDM is specified by passing a <a>MediaKeys</a> object to <a def-id="setMediaKeys"></a>.
-              </p>
-              <ol>
-                <li><p>Run the <a def-id="wait-for-key-algorithm"></a> algorithm on the <var>media element</var>.</p></li>
-                <li><p>Wait for a signal to resume playback.</p></li>
-              </ol>
-            </li>
-          </ol>
-        </section>
-
-        <section id="initdata-encountered">
-          <h4>Initialization Data Encountered</h4>
-          <p>
-            The Initialization Data Encountered algorithm queues an <a def-id="encrypted"></a> event for <a def-id="initialization-data"></a> encounterd in the <a def-id="media-data"></a>.
-            Requests to run this algorithm include a target <a def-id="htmlmediaelement"></a> object.
-          </p>
-          <p>The following steps are run:</p>
-          <ol>
-            <li><p>Let the <var>media element</var> be the specified <a def-id="htmlmediaelement"></a> object.</p></li>
-            <li><p>Let <var>initDataType</var> be the empty string.</p></li>
-            <li><p>Let <var>initData</var> be null.</p></li>
-            <li>
-              <p>If the <a def-id="media-data"></a> is <a def-id="cors-same-origin"></a> and <em>not</em> <a href="#mixed-content">mixed content</a>, run the following steps:</p>
-              <ol>
-                <li><p>Let <var>initDataType</var> be the string representing the <a def-id="initialization-data-type"></a> of the Initialization Data.</p></li>
-                <li><p>Let <var>initData</var> be the Initialization Data.</p></li>
-              </ol>
-              <p class="note">While the media element may allow loading of "Optionally-blockable Content" [[MIXED-CONTENT]], the user agent MUST NOT expose Initialization Data from such media data to the application.</p>
-            </li>
-            <li>
-              <p><a def-id="Queue-a-task"></a> to create an event named <a def-id="encrypted"></a> that does not bubble and is not cancellable using the <a>MediaEncryptedEvent</a> interface with its <var>type</var> attribute set to <code>encrypted</code> and its <var>isTrusted</var> attribute initialized to <code>true</code>, and dispatch it at the <var>media element</var>.</p>
-              <p>The event interface <a>MediaEncryptedEvent</a> has:</p>
-              <ul style="list-style-type:none"><li>
-                <a def-id="encrypted-event-initdatatype-attribute"></a> = <var>initDataType</var><br><br>
-                <a def-id="encrypted-event-initdata-attribute"></a> = <var>initData</var>
-              </li></ul>
-              <p class="note"><a def-id="readystate"></a> is <em>not</em> changed and no algorithms are aborted. This event merely provides information.</p>
-              <p class="note">The <a def-id="encrypted-event-initdata-attribute"></a> attribute will be null if the media data is <em>not</em> <a def-id="cors-same-origin"></a> or is <a href="#mixed-content">mixed content</a>.
-                Applications may retrieve the Initialization Data from an alternate source.
-              </p>
-            </li>
-          </ol>
-        </section>
-
-        <section id="encrypted-block-encountered">
-          <h4>Encrypted Block Encountered</h4>
-          <p>
-            The Encrypted Block Encountered algorithm queues a block of encrypted media data for decryption and attempts to decrypt if possible.
-            Requests to run this algorithm include a target <a def-id="htmlmediaelement"></a> object.
-          </p>
-          <p>The following steps are run:</p>
-          <ol>
-            <li><p>Let the <var>media element</var> be the specified <a def-id="htmlmediaelement"></a> object.</p></li>
-            <li>
-              <p>Let <var>block</var> be the block of encrypted media data.</p>
-            </li>
-            <li>
-              <p>Add <var>block</var> to the end of the <var>media element</var>'s <var>encrypted block queue</var>.</p>
-            </li>
-            <li>
-              <p>If the <var>media element</var>'s <var>decryption blocked waiting for key</var> value is <code>false</code>, run the <a def-id="attempt-to-decrypt-algorithm"></a> algorithm.</p>
-              <!-- While media-may-contain-encrypted-blocks may also result in waiting for a key without setting this variable, it should not be possible to reach this algorithm in that case. -->
-            </li>
-          </ol>
-        </section>
-        <section id="attempt-to-decrypt">
-          <h4>Attempt to Decrypt</h4>
-          <p>
-            The Attempt to Decrypt algorithm attempts to decrypt media data that is queued for decryption.
-            Requests to run this algorithm include a target <a def-id="htmlmediaelement"></a> object.
-          </p>
-          <p>The following steps are run:</p>
-          <ol>
-            <li><p>Let the <var>media element</var> be the specified <a def-id="htmlmediaelement"></a> object.</p></li>
-            <li><p>If the <var>media element</var>'s <var>encrypted block queue</var> is empty, abort these steps.</p></li>
-            <li><p>If the <var>media element</var>'s <a def-id="mediaKeys-attribute"></a> attribute is not null, run the following steps:</p>
-              <ol>
-                <li><p>Let <var>media keys</var> be the <a>MediaKeys</a> object referenced by that attribute.</p></li>
-                <li><p>Let <var>cdm</var> be the CDM instance represented by <var>media keys</var>'s <var>cdm instance</var> value.</p></li>
-                <li>
-                  <p>If <var>cdm</var> is no longer usable for any reason, run the following steps:</p>
-                  <p class="note">These steps are intended to be run on unrecoverable failures of the CDM.</p>
-                  <ol>
-                    <li>
-                      <p>Run the <a def-id="media-data-is-corrupted"></a> steps of the <a def-id="resource-fetch-algorithm"></a>.</p>
-                    </li>
-                    <li>
-                      <p>Run the <a def-id="cdm-unavailable-algorithm"></a> algorithm on <var>media keys</var>.</p>
-                    </li>
-                    <li>
-                      <p>Abort these steps.</p>
-                    </li>
-                  </ol>
-                </li>
-                <li><p>If there is at least one <a>MediaKeySession</a> created by the <var>media keys</var> that is not <a def-id="media-key-session-closed"></a>, run the following steps:</p>
-                  <p class="note">This check ensures the <var>cdm</var> has finished loading and is a prerequisite for a matching key being available.</p>
-                  <ol>
-                    <li><p>Let <var>block</var> be the first entry in the <var>media element</var>'s <var>encrypted block queue</var>.</p></li>
-                    <li><p>Let the <var>block key ID</var> be the key ID of <var>block</var>.</p>
-                      <p class="note">The key ID is generally specified by the container.</p>
-                    </li>
-                    <li><p>Use the <var>cdm</var> to execute the following steps:</p>
-                      <ol>
-                        <li><p>Let <var>available keys</var> be the union of keys in sessions that were created by the <var>media keys</var>.</p></li>
-                        <li><p>Let <var>block key</var> be null.</p></li>
-                        <li><p>If any of the <var>available keys</var> corresponds to the <var>block key ID</var> and is <a def-id="usable-for-decryption"></a>, let <var>session</var> be a
-                        <a>MediaKeySession</a> object containing that key and let <var>block key</var> be that key.</p>
-                          <p class="note">If multiple sessions contain a key that is <a def-id="usable-for-decryption"></a> for the <var>block key ID</var>, which session and key to use is <a def-id="keysystem"></a>-dependent.</p>
-                        </li>
-                        <li><p>If the status of any of the <var>available keys</var> changed as the result of running the preceding step, <a def-id="queue-a-task"></a> to run the <a def-id="update-key-statuses-algorithm"></a> algorithm on each affected <var>session</var>, providing all <a def-id="key-id">key ID(s)</a> in the session along with the appropriate <a>MediaKeyStatus</a> value(s) for each.</p></li>
-                        <li><p>If <var>block key</var> is not null, run the following steps:</p>
-                          <ol>
-                            <li>
-                              <p>If <var>session</var>'s <var>session type</var> is <a def-id="persistent-usage-record-session"></a>, run the following steps:</p>
-                              <ol>
-                                <li>
-                                  <p>Let <var>usage</var> be <var>session</var>'s <var>record of key usage</var>.</p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If the <var>first decrypt time</var> of <var>usage</var> is <code>null</code>, set the <var>first decrypt time</var> of <var>usage</var> to the current time, accurate to within <a def-id="key-usage-accuracy"></a>.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Set the <var>latest decrypt time</var> of <var>usage</var> to the current time, accurate to within <a def-id="key-usage-accuracy"></a>.
-                                  </p>
-                                </li>
-                              </ol>
-                              <p class="note">
-                                Implementations MAY optimize the times at which this step is executed, provided the recorded key usage times remain
-                                accurate to within <var>key usage accuracy</var>.
-                              </p>
-                            </li>
-                            <li><p>Use the <var>cdm</var> to decrypt <var>block</var> using <var>block key</var>.</p></li>
-                            <li><p>Follow the steps for the first matching condition from the following list:</p>
-                              <dl class="switch">
-                                <dt>If decryption fails</dt>
-                                <dd>
-                                  <ol>
-                                    <li>
-                                      <p>Run the <a def-id="media-data-is-corrupted"></a> steps of the <a def-id="resource-fetch-algorithm"></a>.</p>
-                                    </li>
-                                    <li>
-                                      <p>If <var>cdm</var> is no longer usable for any reason then run the <a def-id="cdm-unavailable-algorithm"></a> algorithm on <var>media keys</var>.</p>
-                                    </li>
-                                    <li>
-                                      <p>Abort these steps.</p>
-                                    </li>
-                                  </ol>
-                                </dd>
-                                <dt>Otherwise</dt>
-                                <dd>
-                                  <ol>
-                                    <li><p>Remove <var>block</var> from the front of the <var>media element</var>'s <var>encrypted block queue</var>.</p></li>
-                                    <li><p>Process the decrypted block as normal.</p>
-                                        <p class="note">In other words, decode the block.</p>
-                                    </li>
-                                    <li><p>Return to the beginning of this algorithm.</p></li>
-                                  </ol>
-                                  
-                                </dd>
-                              </dl>
-                              <p class="note">Not all decryption problems (e.g., using the wrong key) will result in a decryption failure. In such cases, no error is fired here but one may be fired during decode.</p>
-                            </li>
-                          </ol>
-                          <p class="note">Otherwise, there is no key for the <var>block key ID</var> in any session so continue.</p>
-                        </li>
-                      </ol>
-                    </li>
-                  </ol>
-                </li>
-              </ol>
-            </li>
-            <li>
-              <p>Set the <var>media element</var>'s <var>decryption blocked waiting for key</var> value to <code>true</code>.</p>
-              <p class="note">This step is reached when there is no key that is <a def-id="usable-for-decryption"></a> for <var>block</var>.</p>
-              <div class="note">
-                <p>Once the user agent has rendered the blocks preceding the block that cannot be decrypted (as much as it can, such as, all complete video frames), it will run the <a def-id="wait-for-key-algorithm"></a> algorithm.</p>
-                <p>That algorithm is not run directly here in order to allow implementations to decrypt and decode media data ahead of the ahead of the current playback position without affecting the visible behavior.</p>
-            </li>
-          </ol>
-
-          <div class="note">
-            <p>For frame-based encryption, this may be implemented as follows when the media element attempts to decode a frame as part of the <a def-id="resource-fetch-algorithm"></a>:</p>
-            <ol>
-              <li><p>Let <var>encrypted</var> be false.</p></li>
-              <li><p>Detect whether the frame is encrypted.</p>
-                <dl class="switch">
-                  <dt>If the frame is encrypted</dt>
-                  <dd>Run the steps above.</dd>
-                  <dt>Otherwise</dt>
-                  <dd>Continue.</dd>
-                </dl>
-              </li>
-              <li><p>Decode the frame.</p></li>
-              <li><p>Provide the frame for rendering.</p></li>
-            </ol>
-          </div>
-        </section>
-
-        <section id="wait-for-key">
-          <h4>Wait for Key</h4>
-          <p>
-            The Wait for Key algorithm queues a <a def-id="waitingforkey"></a> event and updates <a def-id="readystate"></a>.
-            It should only be called when the <a def-id="htmlmediaelement"></a> object is <a def-id="potentially-playing"></a> and its <a def-id="readystate"></a> is equal to <a def-id="have-future-data"></a> or greater.
-            Requests to run this algorithm include a target <a def-id="htmlmediaelement"></a> object.
-          </p>
-          <p>The following steps are run:</p>
-          <ol>
-            <li><p>Let the <var>media element</var> be the specified <a def-id="htmlmediaelement"></a> object.</p></li>
-            <li><p>If the <var>media element</var>'s <var>playback blocked waiting for key</var> value is <code>true</code>, abort these steps.</p></li>
-            <li>
-              <p>Set the <var>media element</var>'s <var>playback blocked waiting for key</var> value to <code>true</code>.</p>
-              <p class="note">As a result of the above step, the media element will become a <a def-id="blocked-media-element"></a> if it wasn't already. In that case, the media element will stop playback.</p>
-            </li>
-            <li>
-              <p>Follow the steps for the first matching condition from the following list:</p>
-              <dl class="switch">
-                <dt>If data for the immediate <a def-id="current-playback-position"></a> is available</dt>
-                <dd>
-                  <p>Set the <a def-id="readystate"></a> of <var>media element</var> to <a def-id="have-current-data"></a>.</p>
-                </dd>
-                <dt>Otherwise</dt>
-                <dd>
-                  <p>Set the <a def-id="readystate"></a> of <var>media element</var> to <a def-id="have-metadata"></a>.</p>
-                </dd>
-              </dl>                  
-              <p class="note">
-                In other words, if the video frame and audio data for the <a def-id="current-playback-position"></a> have been decoded because they were unencrypted and/or successfully decrypted, set <a def-id="readystate"></a> to <a def-id="have-current-data"></a>.
-                Otherwise, including if this was previously the case but the data is no longer available, set <a def-id="readystate"></a> to <a def-id="have-metadata"></a>.
-              </p>
-            </li>
-            <li><p><a def-id="Queue-a-task-to-fire-an-event-named"></a> <a def-id="waitingforkey"></a> at the <var>media element</var>.</p></li>
-            <li><p>Suspend playback.</p></li>
-          </ol>
-        </section>
-
-        <section id="resume-playback">
-          <h4>Attempt to Resume Playback If Necessary</h4>
-          <p>
-            The Attempt to Resume Playback If Necessary algorithm resumes playback if the media element is blocked waiting for a key and necessary key is currently <a def-id="usable-for-decryption"></a>
-            Requests to run this algorithm include a target <a def-id="htmlmediaelement"></a> object.
-          </p>
-          <p>The following steps are run:</p>
-          <ol>
-            <li><p>Let the <var>media element</var> be the specified <a def-id="htmlmediaelement"></a> object.</p></li>
-            <li><p>If the <var>media element</var>'s <var>playback blocked waiting for key</var> is <code>false</code>, abort these steps.</p></li>
-            <li><p>Run the <a def-id="attempt-to-decrypt-algorithm"></a> algorithm on the <var>media element</var>.</p></li>
-            <li><p>If the user agent can advance the <a def-id="current-playback-position"></a> in the <a def-id="direction-of-playback"></a>:</p>
-              <ol>
-                <li>
-                  <p>Set the <var>media element</var>'s <var>decryption blocked waiting for key</var> value to <code>false</code>.</p>
-                </li>
-                <li>
-                  <p>Set the <var>media element</var>'s <var>playback blocked waiting for key</var> value to <code>false</code>.</p>
-                  <p class="note">As a result of the above step, the media element may no longer be a <a def-id="blocked-media-element"></a> and thus playback may resume.</p>
-                </li>
-                <li>
-                  <p>
-                    Set the <var>media element</var>'s <a def-id="readystate"></a> value to <a def-id="have-current-data"></a>, <a def-id="have-future-data"></a> or
-                    <a def-id="have-enough-data"></a> as <a def-id="ready-states">appropriate</a>.
-                  </p>
-                  <div class="note">
-                    <p>
-                      States beyond <a def-id="have-current-data"></a> and the <a def-id="canplaythrough"></a> event do not
-                      (or are unlikely to) consider key availability beyond the current key.
-                    </p>
-                    <p>
-                      The change in ready state may also cause HTMLMediaElement events to be fired as described <a def-id="ready-states">here</a>.
-                    </p>
-                  </div>
-                </li>
-              </ol>
-            </li>
-          </ol>
-        </section>
-      </section>
-
-      <section id="media-element-restrictions" class="informative">
-        <h3>Media Element Restrictions</h3>
-        <p>Media data processed by a CDM MAY be unavailable through web platform APIs in the usual way (for example using the CanvasRenderingContext2D drawImage() method and the AudioContext MediaElementAudioSourceNode).
-        This specification does not define conditions for such non-availability of media data, however, if media data is not available to through such APIs then they MAY behave as if no media data was present at all.</p>
-        <p>Where media rendering is not performed by the UA, for example in the case of a hardware-based media pipeline, the full set of HTML rendering capabilities, for example CSS Transforms, MAY be unavailable. One likely restriction is that
-        video media MAY be constrained to appear only in rectangular regions with sides parallel to the edges of the window and with normal orientation.</p>
+};</pre>
+          <section>
+            <h2>Dictionary <a class="idlType">MediaEncryptedEventInit</a> Members</h2>
+            <dl class="dictionary-members" data-dfn-for="MediaEncryptedEventInit"
+              data-link-for="MediaEncryptedEventInit">
+              <dt>
+                <dfn>
+                  <code>initDataType</code>
+                </dfn> of type <span class="idlMemberType">{{DOMString}}</span>, defaulting to
+                <code>""</code>
+              </dt>
+              <dd> The <a def-id="initialization-data-type"></a>. </dd>
+              <dt>
+                <dfn>
+                  <code>initData</code>
+                </dfn> of type <span class="idlMemberType">{{ArrayBuffer}}</span>, nullable,
+                defaulting to <code>null</code>
+              </dt>
+              <dd> The <a def-id="initialization-data"></a>. </dd>
+            </dl>
+          </section>
+        </div>
       </section>
     </section>
-
-
-    <section id="implementation-requirements">
-      <h3>Implementation Requirements</h3>
-      <p>
-        This section defines implementation requirements - for both user agents and <a def-id="keysystems"></a>, including the <a def-id="cdm"></a> and server(s) - that may not be explicitly addressed in the algorithms.
-        The requirements here and throughout the spec apply to all implementations, regardless of whether the CDM is separate from or a part of the user agent.
-      </p>
-
-      <section id="cdm-constraint-requirements">
-        <h3>CDM Constraints</h3>
-        <p>
-          User agent implementers MUST ensure that CDMs do not access any information, storage or system capabilities that are not reasonably required for playback of protected media using the features of this specification. 
-          Specifically, the CDM SHALL NOT:
+    <section id="htmlmediaelement-events" class="informative">
+      <h3>Event Summary</h3>
+      <table class="old-table">
+        <thead>
+          <tr>
+            <th>Event name</th>
+            <th>Interface</th>
+            <th>Dispatched when...</th>
+            <th>Preconditions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><a def-id="eventdfn">encrypted</a></td>
+            <td><a>MediaEncryptedEvent</a></td>
+            <td>The user agent encounters <a def-id="initialization-data"></a> in the <a
+                def-id="media-data"></a>.</td>
+            <td>The element's <a def-id="readystate"></a> is equal to or greater than <a
+                def-id="have-metadata"></a>. <p class="note">It is possible that the element is
+                playing or has played.</p>
+            </td>
+          </tr>
+          <tr>
+            <td><a def-id="eventdfn">waitingforkey</a></td>
+            <td><a def-id="event"></a></td>
+            <td>Playback is blocked waiting for a key.</td>
+            <td> The <a def-id="readystate"></a> is equal to or less than <a
+                def-id="have-current-data"></a>. The element's <var>playback blocked waiting for key
+              </var> value is newly <code>true</code>. </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+    <section id="htmlmediaelement-algorithms">
+      <h3>Algorithms</h3>
+      <section id="media-may-contain-encrypted-blocks">
+        <h4>Media Data May Contain Encrypted Blocks</h4>
+        <p> The Media Data May Contain Encrypted Blocks algorithm pauses playback if the user agent
+          requires specification of a <a>MediaKeys</a> object before playing the media data.
+          Requests to run this algorithm include a target <a def-id="htmlmediaelement"></a> object.
         </p>
+        <p>The following steps are run:</p>
+        <ol>
+          <li>
+            <p>Let the <var>media element</var> be the specified <a def-id="htmlmediaelement"></a>
+              object.</p>
+          </li>
+          <li>
+            <p>If the <var>media element</var>'s <a def-id="mediaKeys-attribute"></a> attribute is
+              null and the implementation requires specification of a <a>MediaKeys</a> object before
+              decoding potentially-encrypted <a def-id="media-data"></a>, run the following steps:
+            </p>
+            <p class="note">These steps may be reached when the application provides <a
+                def-id="media-data"></a> before calling <a def-id="setMediaKeys"></a> to provide a
+              <a>MediaKeys</a> object. Selecting a <a def-id="cdm"></a> may affect the pipeline
+              and/or decoders used, so some implementations may delay playback of media data that
+              may contain encrypted blocks until a CDM is specified by passing a <a>MediaKeys</a>
+              object to <a def-id="setMediaKeys"></a>. </p>
+            <ol>
+              <li>
+                <p>Run the <a def-id="wait-for-key-algorithm"></a> algorithm on the <var>media
+                    element</var>.</p>
+              </li>
+              <li>
+                <p>Wait for a signal to resume playback.</p>
+              </li>
+            </ol>
+          </li>
+        </ol>
+      </section>
+      <section id="initdata-encountered">
+        <h4>Initialization Data Encountered</h4>
+        <p> The Initialization Data Encountered algorithm queues an <a def-id="encrypted"></a> event
+          for <a def-id="initialization-data"></a> encounterd in the <a def-id="media-data"></a>.
+          Requests to run this algorithm include a target <a def-id="htmlmediaelement"></a> object.
+        </p>
+        <p>The following steps are run:</p>
+        <ol>
+          <li>
+            <p>Let the <var>media element</var> be the specified <a def-id="htmlmediaelement"></a>
+              object.</p>
+          </li>
+          <li>
+            <p>Let <var>initDataType</var> be the empty string.</p>
+          </li>
+          <li>
+            <p>Let <var>initData</var> be null.</p>
+          </li>
+          <li>
+            <p>If the <a def-id="media-data"></a> is <a def-id="cors-same-origin"></a> and <em>not
+              </em> <a href="#mixed-content">mixed content</a>, run the following steps:</p>
+            <ol>
+              <li>
+                <p>Let <var>initDataType</var> be the string representing the <a
+                    def-id="initialization-data-type"></a> of the Initialization Data.</p>
+              </li>
+              <li>
+                <p>Let <var>initData</var> be the Initialization Data.</p>
+              </li>
+            </ol>
+            <p class="note">While the media element may allow loading of "Optionally-blockable
+              Content" [[MIXED-CONTENT]], the user agent MUST NOT expose Initialization Data from
+              such media data to the application.</p>
+          </li>
+          <li>
+            <p><a def-id="Queue-a-task"></a> to create an event named <a def-id="encrypted"></a>
+              that does not bubble and is not cancellable using the <a>MediaEncryptedEvent</a>
+              interface with its <var>type</var> attribute set to <code>encrypted</code> and its
+              <var>isTrusted</var> attribute initialized to <code>true</code>, and dispatch it at
+              the <var>media element</var>.</p>
+            <p>The event interface <a>MediaEncryptedEvent</a> has:</p>
+            <ul style="list-style-type:none">
+              <li>
+                <a def-id="encrypted-event-initdatatype-attribute"></a> = <var>initDataType</var>
+                <br>
+                <br>
+                <a def-id="encrypted-event-initdata-attribute"></a> = <var>initData</var>
+              </li>
+            </ul>
+            <p class="note"><a def-id="readystate"></a> is <em>not</em> changed and no algorithms
+              are aborted. This event merely provides information.</p>
+            <p class="note">The <a def-id="encrypted-event-initdata-attribute"></a> attribute will
+              be null if the media data is <em>not</em> <a def-id="cors-same-origin"></a> or is <a
+                href="#mixed-content">mixed content</a>. Applications may retrieve the
+              Initialization Data from an alternate source. </p>
+          </li>
+        </ol>
+      </section>
+      <section id="encrypted-block-encountered">
+        <h4>Encrypted Block Encountered</h4>
+        <p> The Encrypted Block Encountered algorithm queues a block of encrypted media data for
+          decryption and attempts to decrypt if possible. Requests to run this algorithm include a
+          target <a def-id="htmlmediaelement"></a> object. </p>
+        <p>The following steps are run:</p>
+        <ol>
+          <li>
+            <p>Let the <var>media element</var> be the specified <a def-id="htmlmediaelement"></a>
+              object.</p>
+          </li>
+          <li>
+            <p>Let <var>block</var> be the block of encrypted media data.</p>
+          </li>
+          <li>
+            <p>Add <var>block</var> to the end of the <var>media element</var>'s <var>encrypted
+                block queue</var>.</p>
+          </li>
+          <li>
+            <p>If the <var>media element</var>'s <var>decryption blocked waiting for key</var> value
+              is <code>false</code>, run the <a def-id="attempt-to-decrypt-algorithm"></a>
+              algorithm.</p>
+            <!-- While media-may-contain-encrypted-blocks may also result in waiting for a key
+                 without setting this variable, it should not be possible to reach this algorithm
+                 in that case. -->
+          </li>
+        </ol>
+      </section>
+      <section id="attempt-to-decrypt">
+        <h4>Attempt to Decrypt</h4>
+        <p> The Attempt to Decrypt algorithm attempts to decrypt media data that is queued for
+          decryption. Requests to run this algorithm include a target <a
+            def-id="htmlmediaelement"></a> object. </p>
+        <p>The following steps are run:</p>
+        <ol>
+          <li>
+            <p>Let the <var>media element</var> be the specified <a def-id="htmlmediaelement"></a>
+              object.</p>
+          </li>
+          <li>
+            <p>If the <var>media element</var>'s <var>encrypted block queue</var> is empty, abort
+              these steps.</p>
+          </li>
+          <li>
+            <p>If the <var>media element</var>'s <a def-id="mediaKeys-attribute"></a> attribute is
+              not null, run the following steps:</p>
+            <ol>
+              <li>
+                <p>Let <var>media keys</var> be the <a>MediaKeys</a> object referenced by that
+                  attribute.</p>
+              </li>
+              <li>
+                <p>Let <var>cdm</var> be the CDM instance represented by <var>media keys</var>'s
+                  <var>cdm instance</var> value.</p>
+              </li>
+              <li>
+                <p>If <var>cdm</var> is no longer usable for any reason, run the following steps:
+                </p>
+                <p class="note">These steps are intended to be run on unrecoverable failures of the
+                  CDM.</p>
+                <ol>
+                  <li>
+                    <p>Run the <a def-id="media-data-is-corrupted"></a> steps of the <a
+                        def-id="resource-fetch-algorithm"></a>.</p>
+                  </li>
+                  <li>
+                    <p>Run the <a def-id="cdm-unavailable-algorithm"></a> algorithm on <var>media
+                        keys</var>.</p>
+                  </li>
+                  <li>
+                    <p>Abort these steps.</p>
+                  </li>
+                </ol>
+              </li>
+              <li>
+                <p>If there is at least one <a>MediaKeySession</a> created by the <var>media keys
+                  </var> that is not <a def-id="media-key-session-closed"></a>, run the following
+                  steps:</p>
+                <p class="note">This check ensures the <var>cdm</var> has finished loading and is a
+                  prerequisite for a matching key being available.</p>
+                <ol>
+                  <li>
+                    <p>Let <var>block</var> be the first entry in the <var>media element</var>'s
+                      <var>encrypted block queue</var>.</p>
+                  </li>
+                  <li>
+                    <p>Let the <var>block key ID</var> be the key ID of <var>block</var>.</p>
+                    <p class="note">The key ID is generally specified by the container.</p>
+                  </li>
+                  <li>
+                    <p>Use the <var>cdm</var> to execute the following steps:</p>
+                    <ol>
+                      <li>
+                        <p>Let <var>available keys</var> be the union of keys in sessions that were
+                          created by the <var>media keys</var>.</p>
+                      </li>
+                      <li>
+                        <p>Let <var>block key</var> be null.</p>
+                      </li>
+                      <li>
+                        <p>If any of the <var>available keys</var> corresponds to the <var>block key
+                            ID</var> and is <a def-id="usable-for-decryption"></a>, let <var>session
+                          </var> be a <a>MediaKeySession</a> object containing that key and let
+                          <var>block key</var> be that key.</p>
+                        <p class="note">If multiple sessions contain a key that is <a
+                            def-id="usable-for-decryption"></a> for the <var>block key ID</var>,
+                          which session and key to use is <a def-id="keysystem"></a>-dependent.</p>
+                      </li>
+                      <li>
+                        <p>If the status of any of the <var>available keys</var> changed as the
+                          result of running the preceding step, <a def-id="queue-a-task"></a> to run
+                          the <a def-id="update-key-statuses-algorithm"></a> algorithm on each
+                          affected <var>session</var>, providing all <a def-id="key-id">key
+                            ID(s)</a> in the session along with the appropriate
+                          <a>MediaKeyStatus</a> value(s) for each.</p>
+                      </li>
+                      <li>
+                        <p>If <var>block key</var> is not null, run the following steps:</p>
+                        <ol>
+                          <li>
+                            <p>If <var>session</var>'s <var>session type</var> is <a
+                                def-id="persistent-usage-record-session"></a>, run the following
+                              steps:</p>
+                            <ol>
+                              <li>
+                                <p>Let <var>usage</var> be <var>session</var>'s <var>record of key
+                                    usage</var>.</p>
+                              </li>
+                              <li>
+                                <p> If the <var>first decrypt time</var> of <var>usage</var> is
+                                  <code>null</code>, set the <var>first decrypt time</var> of <var>
+                                    usage</var> to the current time, accurate to within <a
+                                    def-id="key-usage-accuracy"></a>. </p>
+                              </li>
+                              <li>
+                                <p> Set the <var>latest decrypt time</var> of <var>usage</var> to
+                                  the current time, accurate to within <a
+                                    def-id="key-usage-accuracy"></a>. </p>
+                              </li>
+                            </ol>
+                            <p class="note"> Implementations MAY optimize the times at which this
+                              step is executed, provided the recorded key usage times remain
+                              accurate to within <var>key usage accuracy</var>. </p>
+                          </li>
+                          <li>
+                            <p>Use the <var>cdm</var> to decrypt <var>block</var> using <var>block
+                                key</var>.</p>
+                          </li>
+                          <li>
+                            <p>Follow the steps for the first matching condition from the following
+                              list:</p>
+                            <dl class="switch">
+                              <dt>If decryption fails</dt>
+                              <dd>
+                                <ol>
+                                  <li>
+                                    <p>Run the <a def-id="media-data-is-corrupted"></a> steps of the
+                                      <a def-id="resource-fetch-algorithm"></a>.</p>
+                                  </li>
+                                  <li>
+                                    <p>If <var>cdm</var> is no longer usable for any reason then run
+                                      the <a def-id="cdm-unavailable-algorithm"></a> algorithm on
+                                      <var>media keys</var>.</p>
+                                  </li>
+                                  <li>
+                                    <p>Abort these steps.</p>
+                                  </li>
+                                </ol>
+                              </dd>
+                              <dt>Otherwise</dt>
+                              <dd>
+                                <ol>
+                                  <li>
+                                    <p>Remove <var>block</var> from the front of the <var>media
+                                        element</var>'s <var>encrypted block queue</var>.</p>
+                                  </li>
+                                  <li>
+                                    <p>Process the decrypted block as normal.</p>
+                                    <p class="note">In other words, decode the block.</p>
+                                  </li>
+                                  <li>
+                                    <p>Return to the beginning of this algorithm.</p>
+                                  </li>
+                                </ol>
+                              </dd>
+                            </dl>
+                            <p class="note">Not all decryption problems (e.g., using the wrong key)
+                              will result in a decryption failure. In such cases, no error is fired
+                              here but one may be fired during decode.</p>
+                          </li>
+                        </ol>
+                        <p class="note">Otherwise, there is no key for the <var>block key ID</var>
+                          in any session so continue.</p>
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+          <li>
+            <p>Set the <var>media element</var>'s <var>decryption blocked waiting for key</var>
+              value to <code>true</code>.</p>
+            <p class="note">This step is reached when there is no key that is <a
+                def-id="usable-for-decryption"></a> for <var>block</var>.</p>
+            <div class="note">
+              <p>Once the user agent has rendered the blocks preceding the block that cannot be
+                decrypted (as much as it can, such as, all complete video frames), it will run the
+                <a def-id="wait-for-key-algorithm"></a> algorithm.</p>
+              <p>That algorithm is not run directly here in order to allow implementations to
+                decrypt and decode media data ahead of the ahead of the current playback position
+                without affecting the visible behavior.</p>
+          </li>
+        </ol>
+        <div class="note">
+          <p>For frame-based encryption, this may be implemented as follows when the media element
+            attempts to decode a frame as part of the <a def-id="resource-fetch-algorithm"></a>:</p>
+          <ol>
+            <li>
+              <p>Let <var>encrypted</var> be false.</p>
+            </li>
+            <li>
+              <p>Detect whether the frame is encrypted.</p>
+              <dl class="switch">
+                <dt>If the frame is encrypted</dt>
+                <dd>Run the steps above.</dd>
+                <dt>Otherwise</dt>
+                <dd>Continue.</dd>
+              </dl>
+            </li>
+            <li>
+              <p>Decode the frame.</p>
+            </li>
+            <li>
+              <p>Provide the frame for rendering.</p>
+            </li>
+          </ol>
+        </div>
+      </section>
+      <section id="wait-for-key">
+        <h4>Wait for Key</h4>
+        <p> The Wait for Key algorithm queues a <a def-id="waitingforkey"></a> event and updates <a
+            def-id="readystate"></a>. It should only be called when the <a
+            def-id="htmlmediaelement"></a> object is <a def-id="potentially-playing"></a> and its <a
+            def-id="readystate"></a> is equal to <a def-id="have-future-data"></a> or greater.
+          Requests to run this algorithm include a target <a def-id="htmlmediaelement"></a> object.
+        </p>
+        <p>The following steps are run:</p>
+        <ol>
+          <li>
+            <p>Let the <var>media element</var> be the specified <a def-id="htmlmediaelement"></a>
+              object.</p>
+          </li>
+          <li>
+            <p>If the <var>media element</var>'s <var>playback blocked waiting for key</var> value
+              is <code>true</code>, abort these steps.</p>
+          </li>
+          <li>
+            <p>Set the <var>media element</var>'s <var>playback blocked waiting for key</var> value
+              to <code>true</code>.</p>
+            <p class="note">As a result of the above step, the media element will become a <a
+                def-id="blocked-media-element"></a> if it wasn't already. In that case, the media
+              element will stop playback.</p>
+          </li>
+          <li>
+            <p>Follow the steps for the first matching condition from the following list:</p>
+            <dl class="switch">
+              <dt>If data for the immediate <a def-id="current-playback-position"></a> is available
+              </dt>
+              <dd>
+                <p>Set the <a def-id="readystate"></a> of <var>media element</var> to <a
+                    def-id="have-current-data"></a>.</p>
+              </dd>
+              <dt>Otherwise</dt>
+              <dd>
+                <p>Set the <a def-id="readystate"></a> of <var>media element</var> to <a
+                    def-id="have-metadata"></a>.</p>
+              </dd>
+            </dl>
+            <p class="note"> In other words, if the video frame and audio data for the <a
+                def-id="current-playback-position"></a> have been decoded because they were
+              unencrypted and/or successfully decrypted, set <a def-id="readystate"></a> to <a
+                def-id="have-current-data"></a>. Otherwise, including if this was previously the
+              case but the data is no longer available, set <a def-id="readystate"></a> to <a
+                def-id="have-metadata"></a>. </p>
+          </li>
+          <li>
+            <p><a def-id="Queue-a-task-to-fire-an-event-named"></a> <a def-id="waitingforkey"></a>
+              at the <var>media element</var>.</p>
+          </li>
+          <li>
+            <p>Suspend playback.</p>
+          </li>
+        </ol>
+      </section>
+      <section id="resume-playback">
+        <h4>Attempt to Resume Playback If Necessary</h4>
+        <p> The Attempt to Resume Playback If Necessary algorithm resumes playback if the media
+          element is blocked waiting for a key and necessary key is currently <a
+            def-id="usable-for-decryption"></a> Requests to run this algorithm include a target <a
+            def-id="htmlmediaelement"></a> object. </p>
+        <p>The following steps are run:</p>
+        <ol>
+          <li>
+            <p>Let the <var>media element</var> be the specified <a def-id="htmlmediaelement"></a>
+              object.</p>
+          </li>
+          <li>
+            <p>If the <var>media element</var>'s <var>playback blocked waiting for key</var> is
+              <code>false</code>, abort these steps.</p>
+          </li>
+          <li>
+            <p>Run the <a def-id="attempt-to-decrypt-algorithm"></a> algorithm on the <var>media
+                element</var>.</p>
+          </li>
+          <li>
+            <p>If the user agent can advance the <a def-id="current-playback-position"></a> in the
+              <a def-id="direction-of-playback"></a>:</p>
+            <ol>
+              <li>
+                <p>Set the <var>media element</var>'s <var>decryption blocked waiting for key</var>
+                  value to <code>false</code>.</p>
+              </li>
+              <li>
+                <p>Set the <var>media element</var>'s <var>playback blocked waiting for key</var>
+                  value to <code>false</code>.</p>
+                <p class="note">As a result of the above step, the media element may no longer be a
+                  <a def-id="blocked-media-element"></a> and thus playback may resume.</p>
+              </li>
+              <li>
+                <p> Set the <var>media element</var>'s <a def-id="readystate"></a> value to <a
+                    def-id="have-current-data"></a>, <a def-id="have-future-data"></a> or <a
+                    def-id="have-enough-data"></a> as <a def-id="ready-states">appropriate</a>. </p>
+                <div class="note">
+                  <p> States beyond <a def-id="have-current-data"></a> and the <a
+                      def-id="canplaythrough"></a> event do not (or are unlikely to) consider key
+                    availability beyond the current key. </p>
+                  <p> The change in ready state may also cause HTMLMediaElement events to be fired
+                    as described <a def-id="ready-states">here</a>. </p>
+                </div>
+              </li>
+            </ol>
+          </li>
+        </ol>
+      </section>
+    </section>
+    <section id="media-element-restrictions" class="informative">
+      <h3>Media Element Restrictions</h3>
+      <p>Media data processed by a CDM MAY be unavailable through web platform APIs in the usual way
+        (for example using the CanvasRenderingContext2D drawImage() method and the AudioContext
+        MediaElementAudioSourceNode). This specification does not define conditions for such
+        non-availability of media data, however, if media data is not available to through such APIs
+        then they MAY behave as if no media data was present at all.</p>
+      <p>Where media rendering is not performed by the UA, for example in the case of a
+        hardware-based media pipeline, the full set of HTML rendering capabilities, for example CSS
+        Transforms, MAY be unavailable. One likely restriction is that video media MAY be
+        constrained to appear only in rectangular regions with sides parallel to the edges of the
+        window and with normal orientation.</p>
+    </section>
+  </section>
+  <section id="implementation-requirements">
+    <h3>Implementation Requirements</h3>
+    <p> This section defines implementation requirements - for both user agents and <a
+        def-id="keysystems"></a>, including the <a def-id="cdm"></a> and server(s) - that may not be
+      explicitly addressed in the algorithms. The requirements here and throughout the spec apply to
+      all implementations, regardless of whether the CDM is separate from or a part of the user
+      agent. </p>
+    <section id="cdm-constraint-requirements">
+      <h3>CDM Constraints</h3>
+      <p> User agent implementers MUST ensure that CDMs do not access any information, storage or
+        system capabilities that are not reasonably required for playback of protected media using
+        the features of this specification. Specifically, the CDM SHALL NOT: </p>
+      <ul>
+        <li>
+          <p> Access network resources, either local or remote, except via the user agent as
+            explicitly permitted by this specification. </p>
+        </li>
+        <li>
+          <p> Access storage (e.g., disk or memory), except where reasonably required for playback
+            of protected media using the features of this specification. </p>
+        </li>
+        <li>
+          <p> Access user data other than CDM state and <a
+              href="#persistent-state-requirements">persistent data</a>. </p>
+        </li>
+        <li>
+          <p> Access hardware components or devices, except where reasonably required for playback
+            of protected media using the features of this specification. </p>
+        </li>
+      </ul>
+      <p> User Agent implementers may use various techniques to meet the above requirements. For
+        example, a User Agent implementer also implementing their own CDM may include the above as
+        design requirements for that component. A User Agent implementer making use of a third party
+        CDM may ensure that it executes in a constrained environment (e.g., "sandbox") without
+        access to the prohibited information and components. </p>
+    </section>
+    <section id="messaging-requirements">
+      <h3>Messages and Communication</h3>
+      <p> All messages and communication to and from the CDM, such as between the CDM and a license
+        server, MUST be passed through the user agent. The CDM MUST NOT make direct out-of band
+        network requests. All messages and communication other than those described in <a
+          href="#direct-individualization">Direct Individualization</a> MUST be passed through the
+        application via the APIs defined in this specification. Specifically, all communication that
+        contains application-, <a def-id="origin"></a>-, or content-specific information or is sent
+        to a URL specified by the application or based on its origin, MUST pass through the APIs.
+        This includes all license exchange messages. </p>
+    </section>
+    <section id="persistent-state-requirements">
+      <h3>Persistent Data</h3>
+      <p> Persistent Data includes all data stored by the CDM, or by the User Agent on behalf of the
+        CDM, that exists after the destruction of the <a>MediaKeys</a> object. Specifically, it
+        includes any identifiers (including <a def-id="distinctive-identifier-maybe-plural"></a>),
+        licenses, keys, key IDs, <a def-id="records-of-license-destruction"></a>, or <a
+          def-id="records-of-key-usage"></a> stored by the CDM or by the User Agent on behalf of the
+        CDM. </p>
+      <section id="use-origin-specific-key-system-storage">
+        <h3>Use origin-specific and browsing profile-specific Key System storage</h3>
+        <p>Persistent Data that might impact messages or behavior in an application- or license
+          server-visible way MUST be stored in an <a def-id="origin"></a>-specific and <a
+            def-id="browsing-profile"></a>-specific way and MUST NOT leak to or from private
+          browsing sessions. Specifically but not exhaustively, session data, licenses, keys and
+          per-origin identifiers MUST be stored per-<a def-id="origin"></a> and per-<a
+            def-id="browsing-profile"></a>. </p>
+        <p> See <a def-id="session-storage"></a>. </p>
+      </section>
+      <section id="allow-persistent-data-cleared">
+        <h3>Allow Persistent Data to Be Cleared</h3>
+        <p> Implementations that use Persistent Data MUST allow the user to clear that data such
+          that it is no longer retrievable both outside, such as via the APIs defined in this
+          specification, and on the client device. </p>
+        <p> User Agents SHOULD: </p>
         <ul>
           <li>
-            <p>
-              Access network resources, either local or remote, except via the user agent as explicitly permitted by this specification.
-            </p>
+            <p> Treat Persistent Data like other site data, such as cookies [[COOKIES]].
+              Specifically: </p>
+            <ul>
+              <li>
+                <p id="allow-persistent-data-cleared-with-cookies"> Allow users to clear Persistent
+                  Data along with cookies [[COOKIES]] and other site data. </p>
+              </li>
+              <li>
+                <p> Allow users to clear Persistent Data as part of user agent features to clear
+                  browsing history. </p>
+              </li>
+              <li>
+                <p> Include Persistent Data in "remove all data" features. </p>
+              </li>
+              <li>
+                <p> Present Persistent Data in the same UI locations as other site data. </p>
+              </li>
+            </ul>
           </li>
           <li>
-            <p>
-              Access storage (e.g., disk or memory), except where reasonably required for playback of protected media using the features of this specification.
-            </p>
+            <p> Allow users to clear Persistent Data on a per-<a def-id="origin"></a> and per-<a
+                def-id="browsing-profile"></a> basis, particularly as part of a "Forget about this
+              site" feature that forgets cookies [[COOKIES]], databases, etc. associated with a
+              particular site. </p>
           </li>
           <li>
-            <p>
-              Access user data other than CDM state and <a href="#persistent-state-requirements">persistent data</a>.
-            </p>
+            <p> Ensure that operations which clear Persistent Data are sufficiently atomic to
+              prevent a "cookie resurrection" type of recorrelation of a new identifier with the old
+              by relying on another type of locally stored data that did not get cleared at the same
+              time. See <a href="#incomplete-clearing">incomplete clearing of data</a>.
+          <li>
+            <p> Present these interfaces in a way that helps users to understand the possibility of
+              <a href="#incomplete-clearing">incomplete clearing of data</a> and enables them to
+              delete data associated with all features that persist data, including cookies
+              [[COOKIES]] and web storage, simultaneously. </p>
           </li>
           <li>
-            <p>
-              Access hardware components or devices, except where reasonably required for playback of protected media using the features of this specification.
+            <p> Present the interfaces for disabling and re-enabling a Key System in a way that
+              helps users to understand the possibility of <a href="#incomplete-clearing">incomplete
+                clearing of data</a> and enables them to delete all such data in all persistent
+              storage features simultaneously. </p>
+          </li>
+          <li>
+            <p> Allow users to specifically delete Persistent Data, by <a def-id="origin"></a>
+              and/or for all origins. </p>
+          </li>
+        </ul>
+      </section>
+      <section>
+        <h3>Encrypt or obfuscate Persistent Data</h3>
+        <p>User agents SHOULD treat Persistent Data as potentially sensitive; it is quite possible
+          for user privacy to be compromised by the release of this information. To this end, user
+          agents SHOULD ensure that Persistent Data is securely stored and when deleting data, it is
+          promptly deleted from the underlying storage. </p>
+      </section>
+    </section>
+    <section id="exposed-value-requirements">
+      <h3>Values Exposed to the Application</h3>
+      <p>Values exposed to or inferable by, such as via its use by the CDM, the application could be
+        used to identify the client or user, regardless of whether they are designed to be
+        identifiers. This section defines requirements for avoiding or at least mitigating such
+        concerns. There are additional requirements for <a
+          href="#identifier-requirements">Identifiers</a>. </p>
+      <section id="per-origin-per-profile-values">
+        <h3>Use Per-Origin Per-Profile Values</h3>
+        <!-- Issue #101 may affect this text. -->
+        <p> All <a href="#distinctive-value">distinctive values</a> exposed to or inferable by the
+          application MUST be unique per <a def-id="origin"></a> and <a
+            def-id="browsing-profile"></a>. That is, the value(s) used for one <a
+            def-id="origin"></a> using the APIs defined in this specification MUST be different from
+          those used for any other origin using the APIs, and value(s) used in one <a
+            def-id="browsing-profile"></a> MUST be different from those used for any other profile,
+          regardless of origin. Such values MUST NOT leak to or from private browsing sessions. </p>
+        <p> Values across origins and profiles MUST be <a
+            def-id="non-associable-by-application">non-associable by applications</a>, meaning it
+          MUST NOT be possible to correlate values from multiple origins or profiles, such as to
+          determine that they came from the same client or user. Specifically, implementations that
+          derive per-origin values from an origin-independent and/or profile-independent value, MUST
+          do so in a way that ensures the above non-associability property, such as by using
+          derivation functions with appropriate non-reversible properties. </p>
+      </section>
+      <section>
+        <h3>Allow Values to Be Cleared</h3>
+        <p> As a consequence of the requirements in <a href="#allow-persistent-data-cleared">Allow
+            Persistent Data to Be Cleared</a>, all persisted values exposed to the application MUST
+          be clearable such that the values are no longer retrievable, observable, or inferable both
+          outside, such as via the APIs defined in this specification, and on the client device.
+        </p>
+        <p> Once cleared, new <a def-id="non-associable-by-application"></a> value(s) MUST be
+          generated when values are subsequently needed. </p>
+      </section>
+    </section>
+    <section id="identifier-requirements">
+      <h3>Identifiers</h3>
+      <p>The use of identifiers, especially <a
+          href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">Distinctive
+          Identifier(s) or Distinctive Permanent Identifier(s)</a>, by implementations presents a
+        privacy concern. This section defines requirements for avoiding or at least mitigating such
+        concerns. The requirements for <a href="#exposed-value-requirements">Values Exposed to the
+          Application</a> also apply to identifiers exposed to the application. </p>
+      <div class="note">
+        <p>In summary:</p>
+        <ul>
+          <li>
+            <p><a
+                href="#limit-or-avoid-use-of-distinctive-identifiers-and-permanent-identifiers">Limit
+                or Avoid use of Distinctive Identifiers and Permanent Identifiers</a>.</p>
+          </li>
+          <li>
+            <p> All identifers except <a href="#permanent-identifier">Permanent Identifiers</a> MUST
+              be <a href="#per-origin-per-profile-identifiers">unique per origin and profile</a>, <a
+                href="#non-associable-identifiers">non-associable</a>, and <a
+                href="#allow-identifiers-cleared">clearable</a>. </p>
+          </li>
+          <li>
+            <p> All identifers SHOULD be <a href="#encrypt-identifiers">encrypted</a> when exposed
+              outside the client. </p>
+          </li>
+          <li>
+            <p><a def-id="distinctive-identifiers"></a> MUST be <a
+                href="#encrypt-identifiers">encrypted</a> when exposed outside the client, <a
+                href="#per-origin-per-profile-identifiers">unique per origin and profile</a>, and <a
+                href="#allow-identifiers-cleared">clearable</a>.</p>
+          </li>
+          <li>
+            <p><a def-id="distinctive-permanent-identifiers"></a> MUST be <a
+                href="#encrypt-identifiers">encrypted</a> when exposed outside the client and MUST
+              NOT be exposed to the application.</p>
+          </li>
+          <li>
+            <p> All potential identifiers or <a href="#distinctive-value">distinctive values</a> not
+              covered above that are generated as a result of use of the APIs defined in this
+              specification MUST be <a href="#per-origin-per-profile-identifiers">unique per origin
+                and profile</a> and <a href="#allow-identifiers-cleared">clearable</a>. This
+              includes but is not limited to random identifiers, session data, and other CDM data.
             </p>
           </li>
         </ul>
-        <p>
-          User Agent implementers may use various techniques to meet the above requirements. For example, a User Agent implementer also implementing their own CDM may include the above as design requirements for that component. 
-          A User Agent implementer making use of a third party CDM may ensure that it executes in a constrained environment (e.g., "sandbox") without access to the prohibited information and components.
-        </p>
-      </section>  
-
-      <section id="messaging-requirements">
-        <h3>Messages and Communication</h3>
-        <p>
-          All messages and communication to and from the CDM, such as between the CDM and a license server, MUST be passed through the user agent.
-          The CDM MUST NOT make direct out-of band network requests.
-          All messages and communication other than those described in <a href="#direct-individualization">Direct Individualization</a> MUST be passed through the application via the APIs defined in this specification.
-          Specifically, all communication that contains application-, <a def-id="origin"></a>-, or content-specific information or is sent to a URL specified by the application or based on its origin, MUST pass through the APIs.
-          This includes all license exchange messages.
-        </p>
+      </div>
+      <section id="limit-or-avoid-use-of-distinctive-identifiers-and-permanent-identifiers">
+        <h3>Limit or Avoid use of Distinctive Identifiers and Permanent Identifiers</h3>
+        <ul>
+          <li>
+            <p>Implementations SHOULD avoid <a
+                href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">use of
+                Distinctive Identifier(s) or Distinctive Permanent Identifier(s)</a>.</p>
+            <p class="note">For example, use identifiers or other values that apply to a group of
+              clients or devices rather than individual clients.</p>
+          </li>
+          <li>
+            <p>Implementations SHOULD only <a
+                href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">use
+                Distinctive Identifier(s) or Distinctive Permanent Identifier(s)</a> when necessary
+              to enforce the policies related to the specific CDM instance and session.</p>
+            <p class="note">For example, <a def-id="temporary-session"></a> and <a
+                def-id="persistent-license-session"></a> sessions may have different requirements.
+            </p>
+          </li>
+          <li>
+            <p> Implementations that <a
+                href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">use
+                Distinctive Identifier(s) or Distinctive Permanent Identifier(s)</a> SHOULD support
+              the option to not use them. Implementations with such support SHOULD expose the
+              ability for the user to select this option. </p>
+            <div class="note">
+              <p> When supported, applications can select for this mode using <a
+                  def-id="option-distinctiveIdentifier"></a> = <a
+                  def-id="requirement-not-allowed"></a>. Selecting such an option may affect the
+                results of the <a def-id="requestMediaKeySystemAccess"></a> call and/or the license
+                requests that are generated from subsequently generated sessions. </p>
+              <p> Providing the user access to select or choose this implementation capability may
+                allow the user to access content while maintaining a higher degree of privacy. </p>
+            </div>
+          </li>
+        </ul>
       </section>
-        
-      <section id="persistent-state-requirements">
-        <h3>Persistent Data</h3>
+      <section id="encrypt-identifiers">
+        <h3>Encrypt Identifiers</h3>
         <p>
-          Persistent Data includes all data stored by the CDM, or by the User Agent on behalf of the CDM, that exists after the destruction of the <a>MediaKeys</a> object. Specifically, it includes any identifiers (including <a def-id="distinctive-identifier-maybe-plural"></a>), licenses, keys, key IDs, <a def-id="records-of-license-destruction"></a>, or <a def-id="records-of-key-usage"></a> stored by the CDM or by the User Agent on behalf of the CDM.
-        </p>
-        <section id="use-origin-specific-key-system-storage">
-          <h3>Use origin-specific and browsing profile-specific Key System storage</h3>
-          <p>Persistent Data that might impact messages or behavior in an application- or license server-visible way MUST be stored in an <a def-id="origin"></a>-specific and <a def-id="browsing-profile"></a>-specific way and MUST NOT leak to or from private browsing sessions.
-                Specifically but not exhaustively, session data, licenses, keys and per-origin identifiers MUST be stored per-<a def-id="origin"></a> and per-<a def-id="browsing-profile"></a>.
-          </p>
-          <p>
-                See <a def-id="session-storage"></a>.
-          </p>
-        </section>
-        <section id="allow-persistent-data-cleared">
-          <h3>Allow Persistent Data to Be Cleared</h3>
-          <p>
-            Implementations that use Persistent Data MUST allow the user to clear that data such that it is no longer retrievable both outside, such as via the APIs defined in this specification, and on the client device.
-          </p>
-          <p>
-            User Agents SHOULD:
-          </p>
-          <ul>
-            <li>
-              <p>
-                Treat Persistent Data like other site data, such as cookies [[COOKIES]]. Specifically:
-              </p>
-              <ul>
-                <li>
-                  <p id="allow-persistent-data-cleared-with-cookies">
-                    Allow users to clear Persistent Data along with cookies [[COOKIES]] and other site data.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Allow users to clear Persistent Data as part of user agent features to clear browsing history.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Include Persistent Data in "remove all data" features.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Present Persistent Data in the same UI locations as other site data.
-                  </p>
-                </li>
-              </ul>
-            </li>
-            <li>
-              <p>
-                Allow users to clear Persistent Data on a per-<a def-id="origin"></a> and per-<a def-id="browsing-profile"></a> basis, particularly as part of a "Forget about this site" feature that forgets cookies [[COOKIES]], databases, etc. associated with a particular site.
-              </p>
-            </li>
-            <li>
-              <p>
-                Ensure that operations which clear Persistent Data are sufficiently atomic to prevent a "cookie resurrection" type of recorrelation of a new identifier with the old by relying on another type of locally stored data that did not get cleared at the same time. See <a href="#incomplete-clearing">incomplete clearing of data</a>.
-            <li>
-              <p>
-                Present these interfaces in a way that helps users to understand the possibility of <a href="#incomplete-clearing">incomplete clearing of data</a> and enables them to delete data associated with all features that persist data, including cookies [[COOKIES]] and web storage, simultaneously.
-              </p>
-            </li>
-            <li>
-              <p>
-                Present the interfaces for disabling and re-enabling a Key System in a way that helps users to understand the possibility of <a href="#incomplete-clearing">incomplete clearing of data</a> and enables them to delete all such data in all persistent storage features simultaneously.
-              </p>
-            </li>
-            <li>
-              <p>
-                Allow users to specifically delete Persistent Data, by <a def-id="origin"></a> and/or for all origins.
-              </p>
-            </li>
-          </ul>
-        </section>
-        <section>
-          <h3>Encrypt or obfuscate Persistent Data</h3>
-          <p>User agents SHOULD treat Persistent Data as potentially sensitive; it is quite possible for user privacy to be compromised by the release of this information.
-            To this end, user agents SHOULD ensure that Persistent Data is securely stored and when deleting data, it is promptly deleted from the underlying storage.
-          </p>
-        </section>
-      </section>
-        
-      <section id="exposed-value-requirements">
-        <h3>Values Exposed to the Application</h3>
-        <p>Values exposed to or inferable by, such as via its use by the CDM, the application could be used to identify the client or user, regardless of whether they are designed to be identifiers.
-          This section defines requirements for avoiding or at least mitigating such concerns.
-          There are additional requirements for <a href="#identifier-requirements">Identifiers</a>.
-        </p>
-
-        <section id="per-origin-per-profile-values">
-          <h3>Use Per-Origin Per-Profile Values</h3>
-          <!-- Issue #101 may affect this text. -->
-          <p>
-            All <a href="#distinctive-value">distinctive values</a> exposed to or inferable by the application MUST be unique per <a def-id="origin"></a> and <a def-id="browsing-profile"></a>.
-            That is, the value(s) used for one <a def-id="origin"></a> using the APIs defined in this specification MUST be different from those used for any other origin using the APIs,
-            and value(s) used in one <a def-id="browsing-profile"></a> MUST be different from those used for any other profile, regardless of origin.
-            Such values MUST NOT leak to or from private browsing sessions.
-          </p>
-          <p>
-            Values across origins and profiles MUST be <a def-id="non-associable-by-application">non-associable by applications</a>, meaning it MUST NOT be possible to correlate values from multiple origins or profiles, such as to determine that they came from the same client or user.
-            Specifically, implementations that derive per-origin values from an origin-independent and/or profile-independent value, MUST do so in a way that ensures the above non-associability
-            property, such as by using derivation functions with appropriate non-reversible properties.
-          </p>
-        </section>
-
-        <section>
-          <h3>Allow Values to Be Cleared</h3>
-          <p>
-            As a consequence of the requirements in <a href="#allow-persistent-data-cleared">Allow Persistent Data to Be Cleared</a>,
-            all persisted values exposed to the application MUST be clearable
-            such that the values are no longer retrievable, observable, or inferable both outside, such as via the APIs defined in this specification, and on the client device.
-          </p>
-          <p>
-            Once cleared, new <a def-id="non-associable-by-application"></a> value(s) MUST be generated when values are subsequently needed.
-          </p>
-        </section>
-      </section>
-
-      <section id="identifier-requirements">
-        <h3>Identifiers</h3>
-        <p>The use of identifiers, especially <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">Distinctive Identifier(s) or Distinctive Permanent Identifier(s)</a>, by implementations presents a privacy concern.
-          This section defines requirements for avoiding or at least mitigating such concerns.
-          The requirements for <a href="#exposed-value-requirements">Values Exposed to the Application</a> also apply to identifiers exposed to the application. 
-        </p>
+          <a def-id="distinctive-identifiers"></a> and <a
+            def-id="distinctive-permanent-identifiers"></a> MUST be encrypted at the message
+          exchange level when exposed outside the client. All other identifiers SHOULD be encrypted
+          at the message exchange level when exposed outside the client. The encryption MUST ensure
+          that any two instances of the identifier ciphertext are <a
+            href="#associable-by-entity">associable</a> only by an entity in possession of the
+          decryption key. </p>
         <div class="note">
-          <p>In summary:</p>
+          <p>Identifiers may be exposed in the following ways:</p>
           <ul>
-            <li><p><a href="#limit-or-avoid-use-of-distinctive-identifiers-and-permanent-identifiers">Limit or Avoid use of Distinctive Identifiers and Permanent Identifiers</a>.</p></li>
             <li>
-              <p>
-                All identifers except <a href="#permanent-identifier">Permanent Identifiers</a> MUST be <a href="#per-origin-per-profile-identifiers">unique per origin and profile</a>, <a href="#non-associable-identifiers">non-associable</a>, and <a href="#allow-identifiers-cleared">clearable</a>.
+              <p>To the application via a <a def-id="message"></a> event.</p>
+            </li>
+            <li>
+              <p>In a message from a server, such as one that is passed to <a def-id="update"></a>.
               </p>
             </li>
             <li>
-              <p>
-                All identifers SHOULD be <a href="#encrypt-identifiers">encrypted</a> when exposed outside the client.
-              </p>
-            </li>
-            <li><p><a def-id="distinctive-identifiers"></a> MUST be <a href="#encrypt-identifiers">encrypted</a> when exposed outside the client, <a href="#per-origin-per-profile-identifiers">unique per origin and profile</a>, and <a href="#allow-identifiers-cleared">clearable</a>.</p></li>
-            <li><p><a def-id="distinctive-permanent-identifiers"></a> MUST be <a href="#encrypt-identifiers">encrypted</a> when exposed outside the client and MUST NOT be exposed to the application.</p></li>
-            <li>
-              <p>
-                All potential identifiers or <a href="#distinctive-value">distinctive values</a> not covered above that are generated as a result of use of the APIs defined in this specification MUST be <a href="#per-origin-per-profile-identifiers">unique per origin and profile</a> and <a href="#allow-identifiers-cleared">clearable</a>.
-                This includes but is not limited to random identifiers, session data, and other CDM data.
-              </p>
+              <p>As part of <a href="#individualization">individualization</a>.</p>
             </li>
           </ul>
         </div>
-
-        <section id="limit-or-avoid-use-of-distinctive-identifiers-and-permanent-identifiers">
-          <h3>Limit or Avoid use of Distinctive Identifiers and Permanent Identifiers</h3>
+        <p> The <a def-id="cdm"></a> MUST verify that the encryption key belongs to a valid server
+          for its Key System. For identifers exposed to the application, this MAY be implemented
+          using a <a href="#server-certificate">server certificate</a>. </p>
+        <p>The server MUST NOT expose a <a def-id="distinctive-identifier"></a> to any entity other
+          than the CDM that sent it.</p>
+        <p class="note">Specifically, it should not be provided to the application or included
+          unencrypted in messages to the CDM. This can be accomplished by encrypting the identifier
+          or message with the identifier or such that it is only decryptable by that specific CDM.
+        </p>
+        <div class="note">
+          <p>Among other things, this means that:</p>
           <ul>
             <li>
-              <p>Implementations SHOULD avoid <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">use of Distinctive Identifier(s) or Distinctive Permanent Identifier(s)</a>.</p>
-              <p class="note">For example, use identifiers or other values that apply to a group of clients or devices rather than individual clients.</p>
+              <p>Every signature made with device-specific or user-specific keys MUST be different,
+                even given the same plaintext.</p>
             </li>
             <li>
-              <p>Implementations SHOULD only <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">use Distinctive Identifier(s) or Distinctive Permanent Identifier(s)</a> when necessary to enforce the policies related to the specific CDM instance and session.</p>
-              <p class="note">For example, <a def-id="temporary-session"></a> and <a def-id="persistent-license-session"></a> sessions may have different requirements.</p>
+              <p>Identifiers, keys, or certificates relating to device-specific or user-specific
+                keys MUST be encrypted for the license or <a
+                  href="#individualization">individualization</a> server.</p>
             </li>
             <li>
-              <p>
-                Implementations that <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">use Distinctive Identifier(s) or Distinctive Permanent Identifier(s)</a> SHOULD support the option to not use them.
-                Implementations with such support SHOULD expose the ability for the user to select this option.
-              </p>
-              <div class="note">
-                <p>
-                  When supported, applications can select for this mode using <a def-id="option-distinctiveIdentifier"></a> = <a def-id="requirement-not-allowed"></a>.
-                  Selecting such an option may affect the results of the <a def-id="requestMediaKeySystemAccess"></a> call and/or the license requests that are generated from subsequently generated sessions.
-                </p>
-                <p>
-                  Providing the user access to select or choose this implementation capability may allow the user to access content while maintaining a higher degree of privacy.
-                </p>
-              </div>
+              <p>Messages from the license server to the CDM MUST NOT expose recipient-unique
+                identifiers, such as the ID of the intended decryption key, on the outside of the
+                encryption envelope.</p>
             </li>
           </ul>
-        </section>
-
-        <section id="encrypt-identifiers">
-          <h3>Encrypt Identifiers</h3>
-          <p>
-            <a def-id="distinctive-identifiers"></a> and <a def-id="distinctive-permanent-identifiers"></a> MUST be encrypted at the message exchange level when exposed outside the client.
-            All other identifiers SHOULD be encrypted at the message exchange level when exposed outside the client.
-            The encryption MUST ensure that any two instances of the identifier ciphertext are <a href="#associable-by-entity">associable</a> only by an entity in possession of the decryption key.
-          </p>
-          <div class="note">
-            <p>Identifiers may be exposed in the following ways:</p>
-            <ul>
-              <li><p>To the application via a <a def-id="message"></a> event.</p></li>
-              <li><p>In a message from a server, such as one that is passed to <a def-id="update"></a>.</p></li>
-              <li><p>As part of <a href="#individualization">individualization</a>.</p></li>
-            </ul>
-          </div>
-          <p>
-            The <a def-id="cdm"></a> MUST verify that the encryption key belongs to a valid server for its Key System.
-            For identifers exposed to the application, this MAY be implemented using a <a href="#server-certificate">server certificate</a>.
-          </p>
-          <p>The server MUST NOT expose a <a def-id="distinctive-identifier"></a> to any entity other than the CDM that sent it.</p>
-          <p class="note">Specifically, it should not be provided to the application or included unencrypted in messages to the CDM.
-            This can be accomplished by encrypting the identifier or message with the identifier or such that it is only decryptable by that specific CDM.
-          </p>
-          <div class="note">
-            <p>Among other things, this means that:</p>
-            <ul>
-              <li><p>Every signature made with device-specific or user-specific keys MUST be different, even given the same plaintext.</p></li>
-              <li><p>Identifiers, keys, or certificates relating to device-specific or user-specific keys MUST be encrypted for the license or <a href="#individualization">individualization</a> server.</p></li>
-              <li><p>Messages from the license server to the CDM MUST NOT expose recipient-unique identifiers, such as the ID of the intended decryption key, on the outside of the encryption envelope.</p></li>
-            </ul>
-          </div>
-        </section>
-
-        <section id="per-origin-per-profile-identifiers">
-          <h3>Use Per-Origin Per-Profile Identifiers</h3>
-          <p>
-            All identifiers except <a def-id="distinctive-permanent-identifiers"></a> MUST be unique per <a def-id="origin"></a> and <a def-id="browsing-profile"></a>.
-            See <a href="#per-origin-per-profile-values"></a>.
-          </p>
-          <div class="note">
-            <p>This includes but is not limited to <a def-id="distinctive-identifiers"></a>.</p>
-            <p><a def-id="distinctive-permanent-identifiers"></a> MUST NOT be exposed to the application or origin.</p>
-          </div>
-        </section>
-
-        <section id="non-associable-identifiers">
-          <h3>Use Non-Associable Identifiers</h3>
-          <p>
-            All identifiers, including <a def-id="distinctive-identifiers"></a>, exposed by the implementation to applications, even in encrypted form, MUST be <a def-id="non-associable-by-application">non-associable by application(s)</a> across <a def-id="origin">origins</a>, <a def-id="browsing-profile">browsing profiles</a>, and <a href="#allow-identifiers-cleared">clearing of identifiers</a>.
-          </p>
-          <p class="note">
-            For all such identifiers, it MUST NOT be possible for one or more applications, including related license or other servers to achieve such correlation or association.
-          </p>
-        </section> 
-
-        <section id="allow-identifiers-cleared">
-          <h3>Allow Identifiers to Be Cleared</h3>
-          <p>
-            As a consequence of the requirements in <a href="#allow-persistent-data-cleared">Allow Persistent Data to Be Cleared</a>,
-            all potential identifiers or <a href="#distinctive-value">distinctive values</a> except <a def-id="distinctive-permanent-identifiers"></a> MUST be clearable
-            such that the values are no longer retrievable, observable, or inferable both outside, such as via the APIs defined in this specification, and on the client device.
-          </p>
-          <p>
-            Implementations that <a href="#uses-distinctive-identifiers">use Distinctive Identifier(s)</a> MUST allow the user to clear the <a def-id="distinctive-identifier-maybe-plural"></a>.
-            Implementations that <a href="#uses-distinctive-permanent-identifiers">use Distinctive Permanent Identifier(s)</a> MUST allow the user to clear values associated with the <a def-id="distinctive-permanent-identifier-maybe-plural"></a>.
-          </p>
-          <p>
-            Once cleared, new <a def-id="non-associable-by-application"></a> value(s) MUST be generated when values, such as <a def-id="distinctive-identifiers"></a>, are subsequently needed.
-          </p>
-        </section>
+        </div>
       </section>
-
-      <section id="individualization">
-        <h4>Individualization</h4>
-        <p>
-          Identifiers, especially <a def-id="distinctive-identifiers"></a>, are sometimes generated or obtained via a process called individualization or provisioning.
-          The resulting identifier(s) MUST be <a def-id="non-associable-by-application"></a> and <a href="#uses-distinctive-identifiers">use of them</a> MUST only be exposed to a <a href="#per-origin-per-profile-identifiers">single origin from a single profile</a>.
-          This process MAY be performed multiple times, such as after identifier(s) are <a href="#allow-identifiers-cleared">cleared</a>.
-        </p>
-        <p>This process MUST be performed either <a href="#direct-individualization">directly by the user agent</a> or <a href="#app-assisted-individualization">through the application</a>.
-          The mechanisms, flow, and restrictions for the two types of individualization are different, as described in the following sections.
-          Which method is used depends on the CDM implementation and application of the requirements of this specification, especially those below.
-        </p>
-        <p class="note">
-          <a def-id="option-distinctiveIdentifier"></a> controls whether <a def-id="distinctive-identifiers"></a> and <a def-id="distinctive-permanent-identifiers"></a> may be <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">used</a>, including for individualization.
-          Specifically, such identifiers may only be <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">used</a> when the value of the <a def-id="option-distinctiveIdentifier"></a> member of the <a>MediaKeySystemAccess</a> used to create the <a>MediaKeys</a> object is <a def-id="requirement-required"></a>.
-        </p>
-
-        <section id="direct-individualization">
-          <h5>Direct Individualization</h5>
-          <p>
-            Direct Individualization is performed between the <a def-id="cdm"></a> and an origin- and application-independent server.
-            Although the server is origin-independent, the result of the individualization enables the CDM to provide origin-specific identifiers per the other
-            requirements of this specification.
-            The process MUST be performed by the user agent and MUST NOT use the APIs defined in this specification.
-          </p>
-          <p class="note">For example, such a process may initialize a client device and/or obtain a <a href="#per-origin-per-profile-identifiers">per-origin</a> <a href="#allow-identifiers-cleared">clearable</a> identifier for <a href="#per-origin-per-profile-identifiers">a single browsing profile</a> by communicating with a pre-determined server hosted by the user agent or CDM vendor, possibly <a href="#uses-distinctive-permanent-identifiers">using Distinctive Permanent Identifier(s)</a> or other <a href="#permanent-identifier">Permanent Identifier(s)</a> from the client device.
-          </p>
-          <p>For such individualization, all message exchanges:</p>
-          <ul>
-            <li><p>MUST be handled by the user agent and performed by the user agent via the user agent's network stack.</p></li>
-            <li><p>MUST NOT be performed directly by the CDM.</p></li>
-            <li><p>MUST NOT be passed to or through the application via the APIs defined in this specification.</p></li>
-            <li><p>MUST be sent to a URL selected independently of any origin and application.</p></li>
-            <li><p>MUST encrypt all <a def-id="distinctive-identifiers"></a> and <a def-id="distinctive-permanent-identifiers"></a>.</p></li>
-            <li><p>MUST use TLS.</p></li>
-          </ul>
-          <p>
-            Implementations MUST NOT expose, even in encrypted form, <a def-id="origin">origin(s)</a>, origin- or application-specific information, or values that are <a def-id="associable"></a> with origin(s) to centralized servers since this could create a central record of all origins visited by a user or device.
-          </p>
-        </section>
-
-        <section id="app-assisted-individualization">
-          <h5>App-Assisted Individualization</h5>
-          <p>App-Assisted Individualization is performed between the <a def-id="cdm"></a> and the application, including an application-selected server, and results in a per-origin identifier.
-            The process MUST be performed via the APIs defined in this specification and MUST NOT involve other methods of communication.
-            As with all other uses of the APIs, the process MAY <a href="#uses-distinctive-identifiers">use one or more Distinctive Identifier(s)</a>, but it MUST NOT <a href="#uses-distinctive-permanent-identifiers">use Distinctive Permanent Identifier(s)</a> or non-origin-specific values, even in encrypted form.
-            If the process <a href="#uses-distinctive-identifiers">use one or more Distinctive Identifier(s)</a>, the resulting identifier is by definition also a <a def-id="distinctive-identifier"></a>.
-          </p>
-          <p>For such individualization, all message exchanges:</p>
-          <ul>
-            <li><p>MUST be passed to or through the application via the APIs defined in this specification.</p></li>
-            <li><p>SHALL use the message type <a def-id="message-type-individualization-request"></a> for all related <a def-id="message"></a> events.</p></li>
-            <li><p>MUST NOT be performed by the user agent.</p></li>
-            <li><p>MUST NOT be performed directly by the CDM.</p></li>
-            <li><p>MUST NOT contain or otherwise <a href="#uses-distinctive-permanent-identifiers">use Distinctive Permanent Identifier(s)</a>.</p></li>
-            <li><p>MUST NOT contain non-origin-specific per-client information</p></li>
-            <li>
-              <p>MUST adhere to the <a href="#identifier-requirements">identifier requirements</a>.</p>
-              <p class="note">This includes only using values that are <a href="#per-origin-per-profile-identifiers">unique per origin and profile</a> and <a href="#allow-identifiers-cleared">clearable</a> and <a href="#encrypt-identifiers">encrypting</a> them as required.</p>
-            </li>
-            <li><p>MUST NOT provide executable code to the CDM.</p></li>
-          </ul>
-          <p>
-            When <a def-id="associable"></a> values, including <a def-id="distinctive-identifier-maybe-plural"></a>, are <a href="#uses-distinctive-identifiers">used</a> in the process,
-            implementations MUST NOT expose, even in encrypted form, <a def-id="origin">origin(s)</a>-, origin- or application-specific information, or values that are <a def-id="associable"></a> with origin(s) to centralized servers since this could create a central record of all origins visited by a user or device.
-          </p>
-          <p>With appropriate precautions, such individualization can provide better privacy than <a href="#direct-individualization">Direct Individualization</a>, though not as good as models that do not <a href="#uses-distinctive-identifiers">use Distinctive Identifier(s)</a>.
-            To preserve the benefits of such a design and to avoid introducing other privacy concerns,
-            such implementations and the applications that support them SHOULD avoid deferring or forwarding individualization messages to a central server or other server not controlled by the application author.
-          </p>
-        </section>
+      <section id="per-origin-per-profile-identifiers">
+        <h3>Use Per-Origin Per-Profile Identifiers</h3>
+        <p> All identifiers except <a def-id="distinctive-permanent-identifiers"></a> MUST be unique
+          per <a def-id="origin"></a> and <a def-id="browsing-profile"></a>. See <a
+            href="#per-origin-per-profile-values"></a>. </p>
+        <div class="note">
+          <p>This includes but is not limited to <a def-id="distinctive-identifiers"></a>.</p>
+          <p><a def-id="distinctive-permanent-identifiers"></a> MUST NOT be exposed to the
+            application or origin.</p>
+        </div>
       </section>
-
-      <section>
-        <h4>Support Multiple Keys</h4>
-        <p>Implementations MUST support multiple keys in each <a>MediaKeySession</a> object.</p>
-        <p class="note">The mechanics of how multiple keys are supported is an implementation detail, but it MUST be transparent to the application and the APIs defined in this specification.</p>
-
-        <p>Implementations MUST support seamless switching between keys during playback.
-          This includes both keys in the same <a>MediaKeySession</a> and keys in separate <a>MediaKeySession</a> objects.
-        </p>
+      <section id="non-associable-identifiers">
+        <h3>Use Non-Associable Identifiers</h3>
+        <p> All identifiers, including <a def-id="distinctive-identifiers"></a>, exposed by the
+          implementation to applications, even in encrypted form, MUST be <a
+            def-id="non-associable-by-application">non-associable by application(s)</a> across <a
+            def-id="origin">origins</a>, <a def-id="browsing-profile">browsing profiles</a>, and <a
+            href="#allow-identifiers-cleared">clearing of identifiers</a>. </p>
+        <p class="note"> For all such identifiers, it MUST NOT be possible for one or more
+          applications, including related license or other servers to achieve such correlation or
+          association. </p>
       </section>
-
-      <section id="initialization-data-type-support-requirements">
-        <h3>Initialization Data Type Support</h3>
-        <section>
-          <h4>Licenses Generated are Independent of Content Type</h4>
-          <p>Implementations SHOULD allow licenses generated with any <a def-id="initialization-data-type"></a> they support to be used with any content type.</p>
-          <p class="note">Otherwise, the <a def-id="requestMediaKeySystemAccess"></a> algorithm might, for example, reject a <a>MediaKeySystemConfiguration</a> because one of the <a def-id="option-initDataTypes"></a> is not supported with one of the <a def-id="option-videoCapabilities"></a>.</p>
-        </section>
-
-        <section>
-          <h4>Support Extraction From Media Data</h4>
-          <p>For any supported <a def-id="initialization-data-type"></a> that may appear in a supported container, the user agents MUST support <a href="#initdata-encountered">extracting</a> that type of <a def-id="initialization-data"></a> from each such supported container.</p>
-          <p class="note">In other words, indicating support for an <a def-id="initialization-data-type"></a> implies both CDM support for generating license requests and, for container-specific types, user agent support for extracting it from the container.
-            This does <strong>not</strong> mean that implementations must be able to parse <em>any</em> supported <a def-id="initialization-data"></a> from <em>any</em> supported content type.
-          </p>
-        </section>
+      <section id="allow-identifiers-cleared">
+        <h3>Allow Identifiers to Be Cleared</h3>
+        <p> As a consequence of the requirements in <a href="#allow-persistent-data-cleared">Allow
+            Persistent Data to Be Cleared</a>, all potential identifiers or <a
+            href="#distinctive-value">distinctive values</a> except <a
+            def-id="distinctive-permanent-identifiers"></a> MUST be clearable such that the values
+          are no longer retrievable, observable, or inferable both outside, such as via the APIs
+          defined in this specification, and on the client device. </p>
+        <p> Implementations that <a href="#uses-distinctive-identifiers">use Distinctive
+            Identifier(s)</a> MUST allow the user to clear the <a
+            def-id="distinctive-identifier-maybe-plural"></a>. Implementations that <a
+            href="#uses-distinctive-permanent-identifiers">use Distinctive Permanent
+            Identifier(s)</a> MUST allow the user to clear values associated with the <a
+            def-id="distinctive-permanent-identifier-maybe-plural"></a>. </p>
+        <p> Once cleared, new <a def-id="non-associable-by-application"></a> value(s) MUST be
+          generated when values, such as <a def-id="distinctive-identifiers"></a>, are subsequently
+          needed. </p>
       </section>
-
-      <section id="media-requirements">
-        <h3>Supported Media</h3>
-        <p>This section defines properties of content (<a def-id="media-resource"></a>) supported by implementations of this specification.</p>
-
-        <section>
-          <h4>Unencrypted Container</h4>
-          <p>
-            The media container MUST NOT be encrypted.
-            This specification relies on the user agent's ability to parse the media container without having to decrypt any of the media data.
-            This includes the <a def-id="encrypted-block-encountered-algorithm"></a> and <a def-id="initdata-encountered-algorithm"></a> algorithms as well as supporting standard <a def-id="htmlmediaelement"></a> [[HTML]] functionality, such as <a def-id="seeking"></a>.
-          </p>
-        </section>
-
-        <section>
-          <h4>Interoperably Encrypted</h4>
-          <p>
-            <a def-id="media-resource">Media resources</a>, including all tracks, MUST be encrypted and packaged per a container-specific "common encryption" specification that allows the content to be decrypted in a fully specified and compatible way when a key or keys are provided.
-          </p>
-          <p class="note">
-            The Encrypted Media Extensions Stream Format and Initialization Data Format Registry [[EME-STREAM-REGISTRY]] provides references to such stream formats.
-          </p>
-        </section>
-
-        <section>
-          <h4>Unencrypted In-band Support Content</h4>
-          <p>
-            In-band support content, such as captions, described audio, and transcripts, SHOULD NOT be encrypted.
-          </p>
-          <p class="note">
-            Decryption of such tracks - especially such that they can be provided back the user agent - is not generally supported by implementations.
-            Thus, encrypting such tracks would prevent them from being widely available for use with accessibility features in user agent implementations.
-          </p>
-          <p>
-            To ensure accessibility information is available in usable form, for implementations that choose to support encrypted in-band support content: a) the CDM MUST provide the decrypted data to the user agent and 
-            b) the user agent MUST process it in the same way as equivalent unencrypted support content. For example, to be exposed as <a def-id="timed-text-tracks"></a> [[HTML]].            
-          </p>
-        </section>
-      </section>
-
     </section>
-
-    <section id="common-key-systems">
-      <h2>Common Key Systems</h2>
-      <p>All user agents MUST support the common key systems described in this section.</p>
-      <p class="note">This ensures that there is a common baseline level of functionality that is guaranteed to be supported in all user agents, including those that are entirely open source.
-        Thus, content providers that need only basic decryption can build simple applications that will work on all platforms without needing to work with any content protection providers.
+    <section id="individualization">
+      <h4>Individualization</h4>
+      <p> Identifiers, especially <a def-id="distinctive-identifiers"></a>, are sometimes generated
+        or obtained via a process called individualization or provisioning. The resulting
+        identifier(s) MUST be <a def-id="non-associable-by-application"></a> and <a
+          href="#uses-distinctive-identifiers">use of them</a> MUST only be exposed to a <a
+          href="#per-origin-per-profile-identifiers">single origin from a single profile</a>. This
+        process MAY be performed multiple times, such as after identifier(s) are <a
+          href="#allow-identifiers-cleared">cleared</a>. </p>
+      <p>This process MUST be performed either <a href="#direct-individualization">directly by the
+          user agent</a> or <a href="#app-assisted-individualization">through the application</a>.
+        The mechanisms, flow, and restrictions for the two types of individualization are different,
+        as described in the following sections. Which method is used depends on the CDM
+        implementation and application of the requirements of this specification, especially those
+        below. </p>
+      <p class="note">
+        <a def-id="option-distinctiveIdentifier"></a> controls whether <a
+          def-id="distinctive-identifiers"></a> and <a
+          def-id="distinctive-permanent-identifiers"></a> may be <a
+          href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">used</a>,
+        including for individualization. Specifically, such identifiers may only be <a
+          href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">used</a> when
+        the value of the <a def-id="option-distinctiveIdentifier"></a> member of the
+        <a>MediaKeySystemAccess</a> used to create the <a>MediaKeys</a> object is <a
+          def-id="requirement-required"></a>. </p>
+      <section id="direct-individualization">
+        <h5>Direct Individualization</h5>
+        <p> Direct Individualization is performed between the <a def-id="cdm"></a> and an origin-
+          and application-independent server. Although the server is origin-independent, the result
+          of the individualization enables the CDM to provide origin-specific identifiers per the
+          other requirements of this specification. The process MUST be performed by the user agent
+          and MUST NOT use the APIs defined in this specification. </p>
+        <p class="note">For example, such a process may initialize a client device and/or obtain a
+          <a href="#per-origin-per-profile-identifiers">per-origin</a> <a
+            href="#allow-identifiers-cleared">clearable</a> identifier for <a
+            href="#per-origin-per-profile-identifiers">a single browsing profile</a> by
+          communicating with a pre-determined server hosted by the user agent or CDM vendor,
+          possibly <a href="#uses-distinctive-permanent-identifiers">using Distinctive Permanent
+            Identifier(s)</a> or other <a href="#permanent-identifier">Permanent Identifier(s)</a>
+          from the client device. </p>
+        <p>For such individualization, all message exchanges:</p>
+        <ul>
+          <li>
+            <p>MUST be handled by the user agent and performed by the user agent via the user
+              agent's network stack.</p>
+          </li>
+          <li>
+            <p>MUST NOT be performed directly by the CDM.</p>
+          </li>
+          <li>
+            <p>MUST NOT be passed to or through the application via the APIs defined in this
+              specification.</p>
+          </li>
+          <li>
+            <p>MUST be sent to a URL selected independently of any origin and application.</p>
+          </li>
+          <li>
+            <p>MUST encrypt all <a def-id="distinctive-identifiers"></a> and <a
+                def-id="distinctive-permanent-identifiers"></a>.</p>
+          </li>
+          <li>
+            <p>MUST use TLS.</p>
+          </li>
+        </ul>
+        <p> Implementations MUST NOT expose, even in encrypted form, <a
+            def-id="origin">origin(s)</a>, origin- or application-specific information, or values
+          that are <a def-id="associable"></a> with origin(s) to centralized servers since this
+          could create a central record of all origins visited by a user or device. </p>
+      </section>
+      <section id="app-assisted-individualization">
+        <h5>App-Assisted Individualization</h5>
+        <p>App-Assisted Individualization is performed between the <a def-id="cdm"></a> and the
+          application, including an application-selected server, and results in a per-origin
+          identifier. The process MUST be performed via the APIs defined in this specification and
+          MUST NOT involve other methods of communication. As with all other uses of the APIs, the
+          process MAY <a href="#uses-distinctive-identifiers">use one or more Distinctive
+            Identifier(s)</a>, but it MUST NOT <a href="#uses-distinctive-permanent-identifiers">use
+            Distinctive Permanent Identifier(s)</a> or non-origin-specific values, even in encrypted
+          form. If the process <a href="#uses-distinctive-identifiers">use one or more Distinctive
+            Identifier(s)</a>, the resulting identifier is by definition also a <a
+            def-id="distinctive-identifier"></a>. </p>
+        <p>For such individualization, all message exchanges:</p>
+        <ul>
+          <li>
+            <p>MUST be passed to or through the application via the APIs defined in this
+              specification.</p>
+          </li>
+          <li>
+            <p>SHALL use the message type <a def-id="message-type-individualization-request"></a>
+              for all related <a def-id="message"></a> events.</p>
+          </li>
+          <li>
+            <p>MUST NOT be performed by the user agent.</p>
+          </li>
+          <li>
+            <p>MUST NOT be performed directly by the CDM.</p>
+          </li>
+          <li>
+            <p>MUST NOT contain or otherwise <a href="#uses-distinctive-permanent-identifiers">use
+                Distinctive Permanent Identifier(s)</a>.</p>
+          </li>
+          <li>
+            <p>MUST NOT contain non-origin-specific per-client information</p>
+          </li>
+          <li>
+            <p>MUST adhere to the <a href="#identifier-requirements">identifier requirements</a>.
+            </p>
+            <p class="note">This includes only using values that are <a
+                href="#per-origin-per-profile-identifiers">unique per origin and profile</a> and <a
+                href="#allow-identifiers-cleared">clearable</a> and <a
+                href="#encrypt-identifiers">encrypting</a> them as required.</p>
+          </li>
+          <li>
+            <p>MUST NOT provide executable code to the CDM.</p>
+          </li>
+        </ul>
+        <p> When <a def-id="associable"></a> values, including <a
+            def-id="distinctive-identifier-maybe-plural"></a>, are <a
+            href="#uses-distinctive-identifiers">used</a> in the process, implementations MUST NOT
+          expose, even in encrypted form, <a def-id="origin">origin(s)</a>-, origin- or
+          application-specific information, or values that are <a def-id="associable"></a> with
+          origin(s) to centralized servers since this could create a central record of all origins
+          visited by a user or device. </p>
+        <p>With appropriate precautions, such individualization can provide better privacy than <a
+            href="#direct-individualization">Direct Individualization</a>, though not as good as
+          models that do not <a href="#uses-distinctive-identifiers">use Distinctive
+            Identifier(s)</a>. To preserve the benefits of such a design and to avoid introducing
+          other privacy concerns, such implementations and the applications that support them SHOULD
+          avoid deferring or forwarding individualization messages to a central server or other
+          server not controlled by the application author. </p>
+      </section>
+    </section>
+    <section>
+      <h4>Support Multiple Keys</h4>
+      <p>Implementations MUST support multiple keys in each <a>MediaKeySession</a> object.</p>
+      <p class="note">The mechanics of how multiple keys are supported is an implementation detail,
+        but it MUST be transparent to the application and the APIs defined in this specification.
       </p>
-
-      <section id="clear-key">
-        <h3>Clear Key</h3>
-        <p>The <code>"org.w3.clearkey"</code> <a def-id="keysystem"></a> uses plain-text clear (unencrypted) key(s) to decrypt the source.
-        No additional client-side content protection is required.
-        This Key System is described below.
+      <p>Implementations MUST support seamless switching between keys during playback. This includes
+        both keys in the same <a>MediaKeySession</a> and keys in separate <a>MediaKeySession</a>
+        objects. </p>
+    </section>
+    <section id="initialization-data-type-support-requirements">
+      <h3>Initialization Data Type Support</h3>
+      <section>
+        <h4>Licenses Generated are Independent of Content Type</h4>
+        <p>Implementations SHOULD allow licenses generated with any <a
+            def-id="initialization-data-type"></a> they support to be used with any content type.
         </p>
-
-        <section id="clear-key-capabilities">
-          <h4>Capabilities</h4>
-          <p>The following describe how Clear Key supports key system-specific capabilities:</p>
-          <ul>
-            <li>
-              <p><a>MediaKeySystemConfiguration</a>:</p>
-              <ol>
-                <li><p><a def-id="capability-encryptionScheme"></a>: Implementations MUST support the <a def-id="scheme-cenc"></a> scheme, and MAY support other schemes.</p></li>
-                <li><p><a def-id="capability-robustness"></a>: Only the empty string is supported.</p></li>
-                <li><p><a def-id="option-distinctiveIdentifier"></a>: <a def-id="requirement-required"></a> is not supported.</p></li>
-                <li><p><a def-id="option-persistentState"></a>: Not <a def-id="requirement-required"></a> unless the application intends to create non-<a def-id="temporary-session"></a> sessions, if supported.</p></li>
-              </ol>
-            </li>
-            <li><p>The <a def-id="persistent-license-session"></a> <a>MediaKeySessionType</a>: Implementations MAY support this type.</p></li>
-            <li><p>The <a def-id="persistent-usage-record-session"></a> <a>MediaKeySessionType</a>: Implementations MAY support this type.</p></li>
-            
-            <li><p>The <a def-id="setServerCertificate"></a> method: Not supported.</p></li>
-            <li><p>The <a def-id="setMediaKeys"></a> method: Implementations MAY support associating the <a>MediaKeys</a> object with more than one <a def-id="htmlmediaelement"></a>.</p></li>
-          </ul>
-        </section>
-
-        <section id="clear-key-behavior">
-          <h4>Behavior</h4>
-          <p>The following describe how Clear Key implements key system-specific behaviors:</p>
-          <ul>
-            <li><p>In the <a def-id="generateRequest"></a> algorithm:</p>
-              <ul>
-                <li><p>The generated <var>message</var> is a JSON object encoded in UTF-8 as described in <a href="#clear-key-request-format">License Request Format</a>.</p></li>
-                <li><p>The request is generated by extracting the key IDs from the <var>sanitized init data</var>.</p></li>
-                <li><p>The "type" member value is the value of the <var>sessionType</var> parameter.</p></li>
-              </ul>
-            </li>
-            <li><p>The <a def-id="sessionId"></a> attribute is a numerical value representable by a 32-bit integer.</p></li>
-            <li><p>The <a def-id="expiration"></a> attribute is always <code>NaN</code>.</p></li>
-            <li><p>In the <a def-id="update"></a> algorithm:</p>
-              <ul>
-                <li>
-                  <p>
-                    The <var>response</var> parameter is either a JWK Set as described in <a href="#clear-key-license-format">License Format</a>,
-                    or a JSON object encoded in UTF-8 as described in <a href="#clear-key-release-ack-format">License Release Acknowledgement Format</a>.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    In the first case, <var>sanitized response</var> is considered invalid if it is not a valid JWK Set with at least one valid JWK key of a valid length for the audio/video type.
-                    In the second case <var>sanitized response</var> is considered invalid if it is not a valid JSON object.
-                  </p>
-                </li>
-              </ul>
-            </li>
-            <li>
-              <p>
-                For sessions of type <a def-id="persistent-license-session"></a>, in the <a def-id="remove"></a> algorithm, the <var>message</var> reflecting
-                the <var>record of license destruction</var> is a JSON object encoded in UTF-8 as described in <a href="#clear-key-release-format">License Release Format</a>.
-              </p>
-            </li>
-            <li>
-              <p>
-                For sessions of type <a def-id="persistent-usage-record-session"></a>, in the <a def-id="remove"></a> and <a def-id="load"></a> algorithms, the <var>message</var> reflecting
-                the object's <var>record of key usage</var> is a JSON object encoded in UTF-8 as described in <a href="#clear-key-release-format">License Release Format</a>.
-              </p>
-            </li>
-            <li>
-              <p>
-                The <a def-id="keyStatuses"></a> attribute method initially contains all key IDs that have been provided via <a def-id="update"></a>, with status <a def-id="status-usable"></a>.
-                When the <a def-id="remove"></a> algorithm is executed, the <a def-id="keyStatuses"></a> attribute will be set to an empty list.
-              </p>
-            </li>
-            <li>
-              <p>
-                <a def-id="initialization-data"></a>: Implementations MAY support any combination of registered Initialization Data Types [[EME-INITDATA-REGISTRY]].
-                Implementations SHOULD support the <code>"keyids"</code> type [[EME-INITDATA-KEYIDS]] and other types appropriate for content types supported by the user agent.
-              </p>
-            </li>
-          </ul>
-        </section>
-
-        <section id="clear-key-request-format">
-          <h4>License Request Format</h4>
-          <p>This section describes the format of the license request provided to the application via the <a def-id="message-event-message-attribute"></a> attribute of the <a def-id="message"></a> event.</p>
-
-          <p>The format is a JSON object containing the following members:</p>
-          <dl>
-            <dt>"kids"</dt>
-            <dd>An array of <a def-id="key-id">key IDs</a>. Each element of the array is the base64url encoding of the octet sequence containing the key ID value.</dd>
-            <dt>"type"</dt>
-            <dd>The requested <a>MediaKeySessionType</a></dd>
-          </dl>
-
-          <p>When contained in the ArrayBuffer <a def-id="message-event-message-attribute"></a> attribute of a <a>MediaKeyMessageEvent</a> object, the JSON string is encoded in UTF-8 as specified in the Encoding specification [[ENCODING]].
-            Applications MAY decode the contents of the ArrayBuffer to a JSON string using the <a def-id="interface-textdecoder"></a> [[ENCODING]].
-          </p>
-
-          <section id="clear-key-request-format-example" class="informative">
-            <h5>Example</h5>
-            <p>The following example is a license request for a temporary license for two key IDs. (Line breaks are for readability only.)</p>
-            <pre class="example highlight">{
+        <p class="note">Otherwise, the <a def-id="requestMediaKeySystemAccess"></a> algorithm might,
+          for example, reject a <a>MediaKeySystemConfiguration</a> because one of the <a
+            def-id="option-initDataTypes"></a> is not supported with one of the <a
+            def-id="option-videoCapabilities"></a>.</p>
+      </section>
+      <section>
+        <h4>Support Extraction From Media Data</h4>
+        <p>For any supported <a def-id="initialization-data-type"></a> that may appear in a
+          supported container, the user agents MUST support <a
+            href="#initdata-encountered">extracting</a> that type of <a
+            def-id="initialization-data"></a> from each such supported container.</p>
+        <p class="note">In other words, indicating support for an <a
+            def-id="initialization-data-type"></a> implies both CDM support for generating license
+          requests and, for container-specific types, user agent support for extracting it from the
+          container. This does <strong>not</strong> mean that implementations must be able to parse
+          <em>any</em> supported <a def-id="initialization-data"></a> from <em>any</em> supported
+          content type. </p>
+      </section>
+    </section>
+    <section id="media-requirements">
+      <h3>Supported Media</h3>
+      <p>This section defines properties of content (<a def-id="media-resource"></a>) supported by
+        implementations of this specification.</p>
+      <section>
+        <h4>Unencrypted Container</h4>
+        <p> The media container MUST NOT be encrypted. This specification relies on the user agent's
+          ability to parse the media container without having to decrypt any of the media data. This
+          includes the <a def-id="encrypted-block-encountered-algorithm"></a> and <a
+            def-id="initdata-encountered-algorithm"></a> algorithms as well as supporting standard
+          <a def-id="htmlmediaelement"></a> [[HTML]] functionality, such as <a
+            def-id="seeking"></a>. </p>
+      </section>
+      <section>
+        <h4>Interoperably Encrypted</h4>
+        <p>
+          <a def-id="media-resource">Media resources</a>, including all tracks, MUST be encrypted
+          and packaged per a container-specific "common encryption" specification that allows the
+          content to be decrypted in a fully specified and compatible way when a key or keys are
+          provided. </p>
+        <p class="note"> The Encrypted Media Extensions Stream Format and Initialization Data Format
+          Registry [[EME-STREAM-REGISTRY]] provides references to such stream formats. </p>
+      </section>
+      <section>
+        <h4>Unencrypted In-band Support Content</h4>
+        <p> In-band support content, such as captions, described audio, and transcripts, SHOULD NOT
+          be encrypted. </p>
+        <p class="note"> Decryption of such tracks - especially such that they can be provided back
+          the user agent - is not generally supported by implementations. Thus, encrypting such
+          tracks would prevent them from being widely available for use with accessibility features
+          in user agent implementations. </p>
+        <p> To ensure accessibility information is available in usable form, for implementations
+          that choose to support encrypted in-band support content: a) the CDM MUST provide the
+          decrypted data to the user agent and b) the user agent MUST process it in the same way as
+          equivalent unencrypted support content. For example, to be exposed as <a
+            def-id="timed-text-tracks"></a> [[HTML]]. </p>
+      </section>
+    </section>
+  </section>
+  <section id="common-key-systems">
+    <h2>Common Key Systems</h2>
+    <p>All user agents MUST support the common key systems described in this section.</p>
+    <p class="note">This ensures that there is a common baseline level of functionality that is
+      guaranteed to be supported in all user agents, including those that are entirely open source.
+      Thus, content providers that need only basic decryption can build simple applications that
+      will work on all platforms without needing to work with any content protection providers. </p>
+    <section id="clear-key">
+      <h3>Clear Key</h3>
+      <p>The <code>"org.w3.clearkey"</code> <a def-id="keysystem"></a> uses plain-text clear
+        (unencrypted) key(s) to decrypt the source. No additional client-side content protection is
+        required. This Key System is described below. </p>
+      <section id="clear-key-capabilities">
+        <h4>Capabilities</h4>
+        <p>The following describe how Clear Key supports key system-specific capabilities:</p>
+        <ul>
+          <li>
+            <p><a>MediaKeySystemConfiguration</a>:</p>
+            <ol>
+              <li>
+                <p><a def-id="capability-encryptionScheme"></a>: Implementations MUST support the <a
+                    def-id="scheme-cenc"></a> scheme, and MAY support other schemes.</p>
+              </li>
+              <li>
+                <p><a def-id="capability-robustness"></a>: Only the empty string is supported.</p>
+              </li>
+              <li>
+                <p><a def-id="option-distinctiveIdentifier"></a>: <a
+                    def-id="requirement-required"></a> is not supported.</p>
+              </li>
+              <li>
+                <p><a def-id="option-persistentState"></a>: Not <a
+                    def-id="requirement-required"></a> unless the application intends to create
+                  non-<a def-id="temporary-session"></a> sessions, if supported.</p>
+              </li>
+            </ol>
+          </li>
+          <li>
+            <p>The <a def-id="persistent-license-session"></a> <a>MediaKeySessionType</a>:
+              Implementations MAY support this type.</p>
+          </li>
+          <li>
+            <p>The <a def-id="persistent-usage-record-session"></a> <a>MediaKeySessionType</a>:
+              Implementations MAY support this type.</p>
+          </li>
+          <li>
+            <p>The <a def-id="setServerCertificate"></a> method: Not supported.</p>
+          </li>
+          <li>
+            <p>The <a def-id="setMediaKeys"></a> method: Implementations MAY support associating the
+              <a>MediaKeys</a> object with more than one <a def-id="htmlmediaelement"></a>.</p>
+          </li>
+        </ul>
+      </section>
+      <section id="clear-key-behavior">
+        <h4>Behavior</h4>
+        <p>The following describe how Clear Key implements key system-specific behaviors:</p>
+        <ul>
+          <li>
+            <p>In the <a def-id="generateRequest"></a> algorithm:</p>
+            <ul>
+              <li>
+                <p>The generated <var>message</var> is a JSON object encoded in UTF-8 as described
+                  in <a href="#clear-key-request-format">License Request Format</a>.</p>
+              </li>
+              <li>
+                <p>The request is generated by extracting the key IDs from the <var>sanitized init
+                    data</var>.</p>
+              </li>
+              <li>
+                <p>The "type" member value is the value of the <var>sessionType</var> parameter.</p>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <p>The <a def-id="sessionId"></a> attribute is a numerical value representable by a
+              32-bit integer.</p>
+          </li>
+          <li>
+            <p>The <a def-id="expiration"></a> attribute is always <code>NaN</code>.</p>
+          </li>
+          <li>
+            <p>In the <a def-id="update"></a> algorithm:</p>
+            <ul>
+              <li>
+                <p> The <var>response</var> parameter is either a JWK Set as described in <a
+                    href="#clear-key-license-format">License Format</a>, or a JSON object encoded in
+                  UTF-8 as described in <a href="#clear-key-release-ack-format">License Release
+                    Acknowledgement Format</a>. </p>
+              </li>
+              <li>
+                <p> In the first case, <var>sanitized response</var> is considered invalid if it is
+                  not a valid JWK Set with at least one valid JWK key of a valid length for the
+                  audio/video type. In the second case <var>sanitized response</var> is considered
+                  invalid if it is not a valid JSON object. </p>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <p> For sessions of type <a def-id="persistent-license-session"></a>, in the <a
+                def-id="remove"></a> algorithm, the <var>message</var> reflecting the <var>record of
+                license destruction</var> is a JSON object encoded in UTF-8 as described in <a
+                href="#clear-key-release-format">License Release Format</a>. </p>
+          </li>
+          <li>
+            <p> For sessions of type <a def-id="persistent-usage-record-session"></a>, in the <a
+                def-id="remove"></a> and <a def-id="load"></a> algorithms, the <var>message</var>
+              reflecting the object's <var>record of key usage</var> is a JSON object encoded in
+              UTF-8 as described in <a href="#clear-key-release-format">License Release Format</a>.
+            </p>
+          </li>
+          <li>
+            <p> The <a def-id="keyStatuses"></a> attribute method initially contains all key IDs
+              that have been provided via <a def-id="update"></a>, with status <a
+                def-id="status-usable"></a>. When the <a def-id="remove"></a> algorithm is executed,
+              the <a def-id="keyStatuses"></a> attribute will be set to an empty list. </p>
+          </li>
+          <li>
+            <p>
+              <a def-id="initialization-data"></a>: Implementations MAY support any combination of
+              registered Initialization Data Types [[EME-INITDATA-REGISTRY]]. Implementations SHOULD
+              support the <code>"keyids"</code> type [[EME-INITDATA-KEYIDS]] and other types
+              appropriate for content types supported by the user agent. </p>
+          </li>
+        </ul>
+      </section>
+      <section id="clear-key-request-format">
+        <h4>License Request Format</h4>
+        <p>This section describes the format of the license request provided to the application via
+          the <a def-id="message-event-message-attribute"></a> attribute of the <a
+            def-id="message"></a> event.</p>
+        <p>The format is a JSON object containing the following members:</p>
+        <dl>
+          <dt>"kids"</dt>
+          <dd>An array of <a def-id="key-id">key IDs</a>. Each element of the array is the base64url
+            encoding of the octet sequence containing the key ID value.</dd>
+          <dt>"type"</dt>
+          <dd>The requested <a>MediaKeySessionType</a></dd>
+        </dl>
+        <p>When contained in the ArrayBuffer <a def-id="message-event-message-attribute"></a>
+          attribute of a <a>MediaKeyMessageEvent</a> object, the JSON string is encoded in UTF-8 as
+          specified in the Encoding specification [[ENCODING]]. Applications MAY decode the contents
+          of the ArrayBuffer to a JSON string using the <a def-id="interface-textdecoder"></a>
+          [[ENCODING]]. </p>
+        <section id="clear-key-request-format-example" class="informative">
+          <h5>Example</h5>
+          <p>The following example is a license request for a temporary license for two key IDs.
+            (Line breaks are for readability only.)</p>
+          <pre class="example highlight">{
   "kids":
     [
      "LwVHf8JLtPrv2GUXFW2v_A",
@@ -3901,38 +6116,39 @@ interface MediaEncryptedEvent : Event {
   "type":<a def-id="temporary-session"></a>
 }
 </pre>
-          </section>
         </section>
-
-        <section id="clear-key-license-format">
-          <h4>License Format</h4>
-          <p>This section describes the format of the license to be provided via the <var>response</var> parameter of the <a def-id="update"></a> method.</p>
-
-          <p>The format is a JSON Web Key (JWK) Set containing representation of the symmetric key to be used for decryption, as defined in the JSON Web Key (JWK) specification [[RFC7517]].</p>
-
-          <p>For each JWK in the set, the parameter values are as follows:</p>
-          <dl>
-            <dt>"kty" (key type)</dt>
-            <dd>"oct" (octet sequence)</dd>
-            <dt>"k" (key value)</dt>
-            <dd>The base64url encoding of the octet sequence containing the symmetric <a href="#decryption-key">key</a> value</dd>
-            <dt>"kid" (key ID)</dt>
-            <dd>The base64url encoding of the octet sequence containing the <a def-id="key-id"></a> value</dd>
-          </dl>
-
-          <p>The JSON object MAY have an optional "type" member value, which MUST be one of the <a>MediaKeySessionType</a> values.
-            If not specified, the default value of <a def-id="temporary-session"></a> is used.
-            The <a def-id="update"></a> algorithm compares this value to the <var>sessionType</var>.
-          </p>
-
-          <p>When passed to the <a def-id="update"></a> method as the ArrayBuffer <var>response</var> parameter, the JSON string MUST be encoded in UTF-8 as specified in the Encoding specification [[ENCODING]].
-            Applications MAY encode the JSON string using the <a def-id="interface-textencoder"></a> [[ENCODING]].
-          </p>
-
-          <section id="clear-key-license-format-example" class="informative">
-            <h5>Example</h5>
-            <p>The following example is a JWK Set containing a single symmetric key. (Line breaks are for readability only.)</p>
-            <pre class="example highlight">{
+      </section>
+      <section id="clear-key-license-format">
+        <h4>License Format</h4>
+        <p>This section describes the format of the license to be provided via the <var>response
+          </var> parameter of the <a def-id="update"></a> method.</p>
+        <p>The format is a JSON Web Key (JWK) Set containing representation of the symmetric key to
+          be used for decryption, as defined in the JSON Web Key (JWK) specification [[RFC7517]].
+        </p>
+        <p>For each JWK in the set, the parameter values are as follows:</p>
+        <dl>
+          <dt>"kty" (key type)</dt>
+          <dd>"oct" (octet sequence)</dd>
+          <dt>"k" (key value)</dt>
+          <dd>The base64url encoding of the octet sequence containing the symmetric <a
+              href="#decryption-key">key</a> value</dd>
+          <dt>"kid" (key ID)</dt>
+          <dd>The base64url encoding of the octet sequence containing the <a def-id="key-id"></a>
+            value</dd>
+        </dl>
+        <p>The JSON object MAY have an optional "type" member value, which MUST be one of the
+          <a>MediaKeySessionType</a> values. If not specified, the default value of <a
+            def-id="temporary-session"></a> is used. The <a def-id="update"></a> algorithm compares
+          this value to the <var>sessionType</var>. </p>
+        <p>When passed to the <a def-id="update"></a> method as the ArrayBuffer <var>response</var>
+          parameter, the JSON string MUST be encoded in UTF-8 as specified in the Encoding
+          specification [[ENCODING]]. Applications MAY encode the JSON string using the <a
+            def-id="interface-textencoder"></a> [[ENCODING]]. </p>
+        <section id="clear-key-license-format-example" class="informative">
+          <h5>Example</h5>
+          <p>The following example is a JWK Set containing a single symmetric key. (Line breaks are
+            for readability only.)</p>
+          <pre class="example highlight">{
   "keys":
     [{
       "kty":"oct",
@@ -3941,80 +6157,79 @@ interface MediaEncryptedEvent : Event {
     }],
   'type':<a def-id="temporary-session"></a>
 }</pre>
-          </section>
         </section>
-
-        <section id="clear-key-release-format">
-
-          <h4>License Release Format</h4>
-          <p>This section describes the format of the license release message to be provided via the <a def-id="message-event-message-attribute"></a> attribute of the <a def-id="message"></a> event.</p>
-          <p>
-            The format is a JSON object. For sessions of type <a def-id="persistent-license-session"></a> and <a def-id="persistent-usage-record-session"></a>,
-            the object shall contain the following member:
-          </p>
-          <dl>
-            <dt>"kids"</dt>
-            <dd>An array of <a def-id="key-id">key IDs</a>. Each element of the array is the base64url encoding of the octet sequence containing the key ID value.</dd>
-          </dl>
-          <p>
-            For sessions of type <a def-id="persistent-usage-record-session"></a> the object shall also contain the following members:
-          </p>
-          <dl>
-            <dt>"firstTime"</dt>
-            <dd>The <a def-id="first-decryption-time"></a> expressed as a number giving the time, in milliseconds since 01 January, 1970 UTC.</dd>
-            <dt>"latestTime"</dt>
-            <dd>The <a def-id="latest-decryption-time"></a> expressed as a number giving the time, in milliseconds since 01 January, 1970 UTC.</dd>
-          </dl>
-
-          <p>When contained in the ArrayBuffer <a def-id="message-event-message-attribute"></a> attribute of a <a>MediaKeyMessageEvent</a> object, the JSON string is encoded in UTF-8 as specified in the Encoding specification [[ENCODING]].
-            Applications MAY decode the contents of the ArrayBuffer to a JSON string using the <a def-id="interface-textdecoder"></a> [[ENCODING]].
-          </p>
-
-          <section id="clear-key-release-format-example-1" class="informative">
-            <h5>Example message reflecting a <a def-id="record-of-license-destruction"></a></h5>
-            <p>
-              The following example is a license release for a <a def-id="persistent-license-session"></a> session that contained two keys.
-              (Line breaks are for readability only.)
-            </p>
-            <pre class="example highlight">{
+      </section>
+      <section id="clear-key-release-format">
+        <h4>License Release Format</h4>
+        <p>This section describes the format of the license release message to be provided via the
+          <a def-id="message-event-message-attribute"></a> attribute of the <a def-id="message"></a>
+          event.</p>
+        <p> The format is a JSON object. For sessions of type <a
+            def-id="persistent-license-session"></a> and <a
+            def-id="persistent-usage-record-session"></a>, the object shall contain the following
+          member: </p>
+        <dl>
+          <dt>"kids"</dt>
+          <dd>An array of <a def-id="key-id">key IDs</a>. Each element of the array is the base64url
+            encoding of the octet sequence containing the key ID value.</dd>
+        </dl>
+        <p> For sessions of type <a def-id="persistent-usage-record-session"></a> the object shall
+          also contain the following members: </p>
+        <dl>
+          <dt>"firstTime"</dt>
+          <dd>The <a def-id="first-decryption-time"></a> expressed as a number giving the time, in
+            milliseconds since 01 January, 1970 UTC.</dd>
+          <dt>"latestTime"</dt>
+          <dd>The <a def-id="latest-decryption-time"></a> expressed as a number giving the time, in
+            milliseconds since 01 January, 1970 UTC.</dd>
+        </dl>
+        <p>When contained in the ArrayBuffer <a def-id="message-event-message-attribute"></a>
+          attribute of a <a>MediaKeyMessageEvent</a> object, the JSON string is encoded in UTF-8 as
+          specified in the Encoding specification [[ENCODING]]. Applications MAY decode the contents
+          of the ArrayBuffer to a JSON string using the <a def-id="interface-textdecoder"></a>
+          [[ENCODING]]. </p>
+        <section id="clear-key-release-format-example-1" class="informative">
+          <h5>Example message reflecting a <a def-id="record-of-license-destruction"></a></h5>
+          <p> The following example is a license release for a <a
+              def-id="persistent-license-session"></a> session that contained two keys. (Line breaks
+            are for readability only.) </p>
+          <pre class="example highlight">{
   "kids": [ "LwVHf8JLtPrv2GUXFW2v_A", "0DdtU9od-Bh5L3xbv0Xf_A" ]
 }
 </pre>
-          </section>
-
-          <section id="clear-key-release-format-example-2" class="informative">
-            <h5>Example message reflecting a <a def-id="record-of-key-usage"></a></h5>
-            <p>
-              The following example is a license release for a <a def-id="persistent-usage-record-session"></a> session that contained two keys.
-              (Line breaks are for readability only.)
-            </p>
-            <pre class="example highlight">{
+        </section>
+        <section id="clear-key-release-format-example-2" class="informative">
+          <h5>Example message reflecting a <a def-id="record-of-key-usage"></a></h5>
+          <p> The following example is a license release for a <a
+              def-id="persistent-usage-record-session"></a> session that contained two keys. (Line
+            breaks are for readability only.) </p>
+          <pre class="example highlight">{
   "kids": [ "LwVHf8JLtPrv2GUXFW2v_A", "0DdtU9od-Bh5L3xbv0Xf_A" ],
   "firstTime" : 1430425323757,
   "latestTime" : 1430425383757
 }
 </pre>
-          </section>
         </section>
-
-        <section id="clear-key-release-ack-format">
-          <h4>License Release Acknowledgement Format</h4>
-          <p>This section describes the format of the license release acknowledgement provided via the <var>response</var> parameter of the <a def-id="update"></a> method.</p>
-
-          <p>The format is a JSON object containing the following members:</p>
-          <dl>
-            <dt>"kids"</dt>
-            <dd>An array of <a def-id="key-id">key IDs</a>. Each element of the array is the base64url encoding of the octet sequence containing the key ID value.</dd>
-          </dl>
-
-          <p>When passed to the <a def-id="update"></a> method as the ArrayBuffer <var>response</var> parameter, the JSON string MUST be encoded in UTF-8 as specified in the Encoding specification [[ENCODING]].
-            Applications MAY encode the JSON string using the <a def-id="interface-textencoder"></a> [[ENCODING]].
-          </p>
-
-          <section id="clear-key-release-ack-format-example" class="informative">
-            <h5>Example</h5>
-            <p>The following example is a license request for a temporary license for two key IDs. (Line breaks are for readability only.)</p>
-            <pre class="example highlight">{
+      </section>
+      <section id="clear-key-release-ack-format">
+        <h4>License Release Acknowledgement Format</h4>
+        <p>This section describes the format of the license release acknowledgement provided via the
+          <var>response</var> parameter of the <a def-id="update"></a> method.</p>
+        <p>The format is a JSON object containing the following members:</p>
+        <dl>
+          <dt>"kids"</dt>
+          <dd>An array of <a def-id="key-id">key IDs</a>. Each element of the array is the base64url
+            encoding of the octet sequence containing the key ID value.</dd>
+        </dl>
+        <p>When passed to the <a def-id="update"></a> method as the ArrayBuffer <var>response</var>
+          parameter, the JSON string MUST be encoded in UTF-8 as specified in the Encoding
+          specification [[ENCODING]]. Applications MAY encode the JSON string using the <a
+            def-id="interface-textencoder"></a> [[ENCODING]]. </p>
+        <section id="clear-key-release-ack-format-example" class="informative">
+          <h5>Example</h5>
+          <p>The following example is a license request for a temporary license for two key IDs.
+            (Line breaks are for readability only.)</p>
+          <pre class="example highlight">{
   "kids":
     [
      "LwVHf8JLtPrv2GUXFW2v_A",
@@ -4022,486 +6237,674 @@ interface MediaEncryptedEvent : Event {
     ]
 }
 </pre>
-          </section>
         </section>
-        <section id="using-base64url" class="informative">
-          <h4>Using base64url</h4>
-          <p>For more information on base64url and working with it, see the "Base64url Encoding" terminology definition and "Notes on implementing base64url encoding without padding" in [[RFC7515]].
-            Specifically, there is no '=' padding, and the characters '-' and '_' MUST be used instead of '+' and '/', respectively.
-          </p>
-        </section>
+      </section>
+      <section id="using-base64url" class="informative">
+        <h4>Using base64url</h4>
+        <p>For more information on base64url and working with it, see the "Base64url Encoding"
+          terminology definition and "Notes on implementing base64url encoding without padding" in
+          [[RFC7515]]. Specifically, there is no '=' padding, and the characters '-' and '_' MUST be
+          used instead of '+' and '/', respectively. </p>
       </section>
     </section>
-
-
-    <section id="security">
-      <h2>Security</h2>
-
-      <section id="input-data-security">
-        <h3>Input Data Attacks and Vulnerabilities</h3>
-        <p>User Agent and Key System implementations MUST consider <a def-id="media-data"></a>, <a def-id="initialization-data"></a>, data passed to <a def-id="update"></a>, licenses, key data, and all other data provided by the application as untrusted content and potential attack vectors.
-          They MUST use appropriate safeguards to mitigate any associated threats and take care to safely parse, decrypt, etc. such data.
-          User Agents SHOULD validate data before passing it to the CDM.
-        </p>
-        <p class="note">Such validation is especially important if the CDM does not run in the same (sandboxed) context as, for example, the DOM.</p>
-
-        <p>Implementations MUST NOT return active content or passive content that affects program control flow to the application.</p>
-        <p class="note">For example, it is not safe to expose URLs or other information that may have come from media data, such as is the case for the <a def-id="initialization-data"></a> passed to <a def-id="generateRequest"></a>.
-          Applications must determine the URLs to use. The <a def-id="message-event-messagetype-attribute"></a> attribute of the <a def-id="message"></a> event can be used by the application to select among a set of URLs if applicable.
-        </p>
+  </section>
+  <section id="security">
+    <h2>Security</h2>
+    <section id="input-data-security">
+      <h3>Input Data Attacks and Vulnerabilities</h3>
+      <p>User Agent and Key System implementations MUST consider <a def-id="media-data"></a>, <a
+          def-id="initialization-data"></a>, data passed to <a def-id="update"></a>, licenses, key
+        data, and all other data provided by the application as untrusted content and potential
+        attack vectors. They MUST use appropriate safeguards to mitigate any associated threats and
+        take care to safely parse, decrypt, etc. such data. User Agents SHOULD validate data before
+        passing it to the CDM. </p>
+      <p class="note">Such validation is especially important if the CDM does not run in the same
+        (sandboxed) context as, for example, the DOM.</p>
+      <p>Implementations MUST NOT return active content or passive content that affects program
+        control flow to the application.</p>
+      <p class="note">For example, it is not safe to expose URLs or other information that may have
+        come from media data, such as is the case for the <a def-id="initialization-data"></a>
+        passed to <a def-id="generateRequest"></a>. Applications must determine the URLs to use. The
+        <a def-id="message-event-messagetype-attribute"></a> attribute of the <a
+          def-id="message"></a> event can be used by the application to select among a set of URLs
+        if applicable. </p>
+    </section>
+    <section id="cdm-security">
+      <h3>CDM Attacks and Vulnerabilities</h3>
+      <p>User Agents are responsible for providing users with a secure way to browse the web. This
+        responsibility applies to any functionality used by User Agents, including functionalities
+        from third parties. User agent implementers MUST obtain sufficient information from Key
+        System implementers to enable them to properly assess the security implications of
+        integrating with the Key System. User agent implementers MUST ensure CDM implementations
+        provide and/or support sufficient controls for the user agent to provide security for the
+        user. User agent implementers MUST ensure CDM implementations can and will be quickly and
+        proactively updated in the event of security vulnerabilities. </p>
+      <p>Exploiting a CDM implementation that is not fully sandboxed and/or uses platform features
+        may allow an attacker to access OS or platform features, elevate privilege (e.g., to run as
+        system or root), and/or access drivers, kernel, firmware, hardware, etc. Such features,
+        software, and hardware may not be written to be robust against hostile software or web-based
+        attacks and may not be updated with security fixes, especially compared to the user agent.
+        Lack of, infrequent, or slow updates for fixes to security vulnerabilities in CDM
+        implementations increases the risk. Such CDM implementations and UAs that expose them MUST
+        be especially careful in all areas of security, including parsing of <a
+          href="#input-data-security">all data</a>. </p>
+      <p class="note">User agents should be especially diligent when using a CDM or underlying
+        mechanism that is part of or provided by the client OS, platform and/or hardware.</p>
+      <p>If a user agent chooses to support a Key System implementation that cannot be sufficiently
+        sandboxed or otherwise secured, the user agent SHOULD <a href="#security-consent">ensure
+          that users are fully informed and/or give explicit consent</a> before loading or invoking
+        it. </p>
+      <p class="note">Granting permissions to unauthenticated origins is equivalent to granting the
+        permissions to any origin in the presence of a network attacker. See <a
+          href="#persisted-consent-abuse">abuse of persisted consent</a>. </p>
+    </section>
+    <section id="network-attacks">
+      <h3>Network Attacks</h3>
+      <section class="informative">
+        <h4>Potential Attacks</h4>
+        <p>Potential network attacks and their implications include:</p>
+        <ul>
+          <li>
+            <p>DNS spoofing attacks: One cannot guarantee that a host claiming to be in a certain
+              domain (<a def-id="origin"></a>) really is from that domain.</p>
+          </li>
+          <li>
+            <p>Passive network attacks: One cannot guarantee that data, including <a
+                def-id="distinctive-identifiers"></a> and <a
+                def-id="distinctive-permanent-identifiers"></a>, transmitted between the client and
+              server is not viewed by other entities. See <a href="#user-tracking">User
+                Tracking</a>.</p>
+          </li>
+          <li>
+            <p>Active network attacks: One cannot guarantee that Additional scripts or iframes are
+              not injected into pages (both those that use the APIs defined in this specification
+              for legitimate purposes and pages that do not use them). The consequences are that:
+            </p>
+            <ul>
+              <li>
+                <p>Calls to the APIs defined in this specification can be injected into any page.
+                </p>
+              </li>
+              <li>
+                <p>Calls to the APIs defined in this specification from pages using them for
+                  legitimate reasons can be manipulated, including modifying the requested
+                  functionality, modifying or adding calls, and modifying or injecting data. See
+                  also <a href="#input-data-security">Input Data Attacks and Vulnerabilities</a></p>
+              </li>
+              <li>
+                <p>Data, including <a def-id="distinctive-identifiers"></a> and <a
+                    def-id="distinctive-permanent-identifiers"></a>, transmitted between the client
+                  and server can be viewed and/or modified by other entities. See <a
+                    href="#user-tracking">User Tracking</a>.</p>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <p>
+              <span id="persisted-consent-abuse">Abuse of persisted consent</span>: One cannot
+              guarantee that the host requesting use of the APIs defined in this specification is
+              the host to which the user previously provided consent. The consequences are that
+              granting permissions to unauthenticated origins is equivalent to granting the
+              permissions to any origin in the presence of a network attacker.
+            </p>
+          </li>
+        </ul>
       </section>
-
-      <section id="cdm-security">
-        <h3>CDM Attacks and Vulnerabilities</h3>
-        <p>User Agents are responsible for providing users with a secure way to browse the web.
-          This responsibility applies to any functionality used by User Agents, including functionalities from third parties.
-          User agent implementers MUST obtain sufficient information from Key System implementers to enable them to properly assess the security implications of integrating with the Key System.
-          User agent implementers MUST ensure CDM implementations provide and/or support sufficient controls for the user agent to provide security for the user.
-          User agent implementers MUST ensure CDM implementations can and will be quickly and proactively updated in the event of security vulnerabilities.
-        </p>
-        <p>Exploiting a CDM implementation that is not fully sandboxed and/or uses platform features may allow an attacker to access OS or platform features, elevate privilege (e.g., to run as system or root), and/or access drivers, kernel, firmware, hardware, etc.
-          Such features, software, and hardware may not be written to be robust against hostile software or web-based attacks and may not be updated with security fixes, especially compared to the user agent.
-          Lack of, infrequent, or slow updates for fixes to security vulnerabilities in CDM implementations increases the risk.
-          Such CDM implementations and UAs that expose them MUST be especially careful in all areas of security, including parsing of <a href="#input-data-security">all data</a>.
-        </p>
-        <p class="note">User agents should be especially diligent when using a CDM or underlying mechanism that is part of or provided by the client OS, platform and/or hardware.</p>
-
-        <p>If a user agent chooses to support a Key System implementation that cannot be sufficiently sandboxed or otherwise secured, the user agent SHOULD <a href="#security-consent">ensure that users are fully informed and/or give explicit consent</a> before loading or invoking it.
-        </p>
-        <p class="note">Granting permissions to unauthenticated origins is equivalent to granting the permissions to any origin in the presence of a network attacker.
-          See <a href="#persisted-consent-abuse">abuse of persisted consent</a>.
-        </p>
+      <section>
+        <h4>Mitigations</h4>
+        <p>The following techniques may mitigate the risks:</p>
+        <dl>
+          <dt>Use TLS</dt>
+          <dd>
+            <p>Applications using TLS can be sure that only the user, software working on behalf of
+              the user, and other pages using TLS that have certificates identifying them as being
+              from the same domain, can interact with that application. Furthermore, <a
+                def-id="origin"></a>-specific permissions in combination with a secure origin,
+              ensure that permissions granted to an application cannot be abused by a network
+              attacker. </p>
+            <p>The APIs defined in this specification are only exposed on secure contexts. See also
+              <a href="#privacy-secureorigin">Secure Origin and Transport</a>. </p>
+          </dd>
+          <dt>Block Mixed Content</dt>
+          <dd>
+            <p>User agents MUST properly handle Mixed Content [[MIXED-CONTENT]], including blocking
+              "Blockable Content" [[MIXED-CONTENT]] to avoid potential exposure to insecure content.
+              Such exposure could compromise other mitigations, such as use of TLS. </p>
+            <p>User agents MAY choose to block all Mixed Content, including "Optionally-blockable
+              Content" [[MIXED-CONTENT]] to further increase security by preventing <a
+                href="#input-data-security">untrusted media data</a> from being passed to the CDM
+              (see <a href="#cdm-security">CDM Attacks and Vulnerabilities</a>).</p>
+          </dd>
+          <dt id="security-consent">Fully inform users and/or require explicit user consent</dt>
+          <dd>
+            <p>User agents SHOULD ensure that users are fully informed and/or give explicit consent
+              before a Key System that presents security concerns that are greater than other user
+              agent features (e.g., DOM content) may be accessed by an <a def-id="origin"></a>. </p>
+            <p>Such mechanisms MUST be per <a def-id="origin"></a> to avoid valid uses enabling
+              subsequent malicious access and MUST be per <a def-id="browsing-profile"></a>. </p>
+            <p class="note">The restriction of the APIs defined in this specification to secure
+              contexts ensures that a <a href="#network-attacks">network attacker</a> cannot exploit
+              permissions granted to an unauthenticated origin. See <a
+                href="#persisted-consent-abuse">abuse of persisted consent</a>. </p>
+          </dd>
+        </dl>
       </section>
-
-      <section id="network-attacks">
-        <h3>Network Attacks</h3>
-        <section class="informative">
-          <h4>Potential Attacks</h4>
-          <p>Potential network attacks and their implications include:</p>
-          <ul>
-            <li><p>DNS spoofing attacks: One cannot guarantee that a host claiming to be in a certain domain (<a def-id="origin"></a>) really is from that domain.</p></li>
-            <li><p>Passive network attacks: One cannot guarantee that data, including <a def-id="distinctive-identifiers"></a> and <a def-id="distinctive-permanent-identifiers"></a>, transmitted between the client and server is not viewed by other entities. See <a href="#user-tracking">User Tracking</a>.</p></li>
-            <li>
-              <p>Active network attacks: One cannot guarantee that Additional scripts or iframes are not injected into pages (both those that use the APIs defined in this specification for legitimate purposes and pages that do not use them).
-                The consequences are that:
+    </section>
+    <section id="iframe-attacks">
+      <h3>
+        <code>iframe</code> Attacks
+      </h3>
+      <section class="informative">
+        <h4>Potential Attacks</h4>
+        <p>Malicious pages could host legitimate applications in an iframe in an attempt hide an
+          attack or deceive the user as to the source, such as making the use appear to be from a
+          legitimate content provider. This is especially relevent for implementations that <a
+            href="#security-consent">inform the user or require consent</a>, such as for security
+          and/or <a href="#privacy-consent">privacy reasons</a>. In addition to <a
+            href="#network-attacks">Network Attacks</a>, attackers could try to exploit legitimate
+          uses of the APIs defined in this specification by hosting them in an <code>iframe</code>.
+          By having the legitimate application performing the actions, the attacker can reuse
+          existing granted permissions (or whitelisting) and/or appear to be a legitimate request or
+          use. </p>
+      </section>
+      <section>
+        <h4>Mitigations</h4>
+        <p>User agents that <a href="#security-consent">inform the user or require consent</a>,
+          including for security and/or <a href="#privacy-consent">privacy reasons</a>, SHOULD base
+          the UI and persistence of consent on the combination of <a def-id="origin"></a> of the
+          top-level <a def-id="document-concept"></a> and the <a def-id="origin"></a> using the APIs
+          defined in this specification. This ensures that users are informed of the main document
+          making the request and that persisting a permission for one (legitimate) combination does
+          not inadvertently allow malicious use to go undetected. </p>
+        <p>Authors SHOULD prevent other entities from hosting their applications in <code>iframe
+          </code>s. Applications that must support being hosted for legitimate application-design
+          reasons SHOULD NOT allow hosting documents to provide <a href="#input-data-security">any
+            data to be passed to the CDM</a> - either via the APIs defined in this specification or
+          as media data - and SHOULD NOT allow hosting frames to invoke the APIs defined in this
+          specification. </p>
+      </section>
+    </section>
+    <section id="cross-directory-attacks" class="informative">
+      <h3>Cross-Directory Attacks</h3>
+      <p>Different authors sharing one host name, for example users hosting content on <code>
+          geocities.com</code>, all share one <a def-id="origin"></a>. User agents do not provide
+        features to restrict access to APIs by pathname. </p>
+      <p>Using the APIs defined in this specification on shared hosts compromises origin-based
+        security and privacy mitigations implemented by user agents. For example, per-origin <a
+          def-id="distinctive-identifiers"></a> are shared by all authors on one host name, and
+        peristed data may be accessed and manipulated by any author on the host. The latter is
+        especially important if, for example, modification or deletion of such data could erase a
+        user's right to specific content. </p>
+      <p class="note">Even if a path-restriction feature was made available by user agents, the
+        usual DOM scripting security model would make it trivial to bypass this protection and
+        access the data from any path.</p>
+      <p>Authors on shared hosts are therefore RECOMMENDED to avoid using the APIs defined in this
+        specification because doing so compromises origin-based security and privacy mitigations in
+        user agents.</p>
+    </section>
+  </section>
+  <section id="privacy">
+    <h2>Privacy</h2>
+    <p>The presence or use of Key System(s) on a user's device raises a number of privacy issues,
+      falling into two categories: (a) user-specific information that may be disclosed by the EME
+      interface itself or within Key System messages and (b) user-specific information that may be
+      persistently stored on the user's device.</p>
+    <p>User Agents MUST take responsibility for providing users with adequate control over their own
+      privacy. Since User Agents may integrate with third party CDM implementations, CDM
+      implementers MUST provide sufficient information and controls to user agent implementers to
+      enable them to implement appropriate techniques to ensure users have control over their
+      privacy, including but not limited to the techniques described below. </p>
+    <section id="privacy-disclosure">
+      <h3>Information Disclosed by EME and Key Systems</h3>
+      <p>Concerns regarding information disclosed by EME and Key Systems fall into two categories:
+        (a) concerns about non-specific information that may nevertheless contribute to the
+        possibility of fingerprinting a user agent or device and (b) user-specific information that
+        may be used directly for <a href="#user-tracking">user tracking</a>.</p>
+    </section>
+    <section id="privacy-fingerprinting">
+      <h3>Fingerprinting</h3>
+      <p>Malicious applications may be able to fingerprint users or user agents by detecting or
+        enumerating the list of Key Systems that are supported and related information. If proper
+        origin protections are not provided this could include detection of sites that have been
+        visited and information stored for those sites. In particular, Key Systems MUST not share
+        key or other data between <a def-id="origin">origins</a>. </p>
+    </section>
+    <section id="privacy-leakage">
+      <h3>Information Leakage</h3>
+      <section class="informative">
+        <h4>Concerns</h4>
+        <p>CDMs, especially those implemented outside the user agent, may not have the same
+          fundamental isolations as the web platform. It is important that steps be taken to avoid
+          information leakage, especially across origins. This includes both in-memory and stored
+          data. Failure to do so could lead to information leakage to/from private browsing
+          sessions, across <a def-id="browsing-profile">browsing profiles</a> (including across
+          operating system user accounts) and even across different browsers or applications. </p>
+      </section>
+      <section>
+        <h4>Mitigations</h4>
+        <p>To avoid such issues, user agent and CDM implementations MUST ensure that:</p>
+        <ul>
+          <li>
+            <p>CDMs have a concept of a CDM instance that is associated one-to-one with a MediaKeys
+              object.</p>
+          </li>
+          <li>
+            <p>Keys, licenses, other session data, and the presence of sessions are restricted to
+              the CDM instance associated with the MediaKeys object that created the session.</p>
+          </li>
+          <li>
+            <p>Session data is not shared between MediaKeys objects or CDM instances.</p>
+          </li>
+          <li>
+            <p> Session data is not shared with media elements not associated with the MediaKeys
+              object that created the session. Among other things, this means a session's keys MUST
+              not be used to decrypt content loaded by a media element whose <a
+                def-id="mediaKeys-attribute"></a> attribute is not that MediaKeys object. </p>
+          </li>
+          <li>
+            <p>MediaKeys objects and the underlying implementation do not expose information outside
+              the <a def-id="origin"></a>.</p>
+          </li>
+          <li>
+            <p>Persisted session data, if applicable, is stored on a per-<a def-id="origin"></a>
+              basis.</p>
+          </li>
+          <li>
+            <p>Only data stored by the requesting <a def-id="origin"></a> may be loaded.</p>
+          </li>
+          <li>
+            <p> It is not possible to extract, derive or infer information from the CDM that is not
+              either explicitly described in this specification or available to the page through
+              other web platform APIs without user permission. This applies to any information that
+              is exposed outside the client device or to the application, including, for example, in
+              CDM messages. </p>
+            <div class="note">
+              <p>The type of information covered by this requirement includes but is not limited to:
               </p>
               <ul>
-                <li><p>Calls to the APIs defined in this specification can be injected into any page.</p></li>
-                <li><p>Calls to the APIs defined in this specification from pages using them for legitimate reasons can be manipulated, including modifying the requested functionality, modifying or adding calls, and modifying or injecting data. See also <a href="#input-data-security">Input Data Attacks and Vulnerabilities</a></p></li>
-                <li><p>Data, including <a def-id="distinctive-identifiers"></a> and <a def-id="distinctive-permanent-identifiers"></a>, transmitted between the client and server can be viewed and/or modified by other entities. See <a href="#user-tracking">User Tracking</a>.</p></li>
+                <li>
+                  <p>Location, including geolocation</p>
+                </li>
+                <li>
+                  <p>Credentials or identifiers other than Distinctive Identifiers</p>
+                </li>
+                <li>
+                  <p>OS account name and other potential PII</p>
+                </li>
+                <li>
+                  <p>Local directory paths, which may contain similar information.</p>
+                </li>
+                <li>
+                  <p>Local network details (for example, the device's local IP address)</p>
+                </li>
+                <li>
+                  <p>Local devices, including but not limited to Bluetooth, USB, and user media.</p>
+                </li>
+                <li>
+                  <p>User state not associated with or stored as a result of the APIs defined in
+                    this specification.</p>
+                </li>
               </ul>
-            </li>
-            <li>
-              <p>
-                <span id="persisted-consent-abuse">Abuse of persisted consent</span>: One cannot guarantee that the host requesting use of the APIs defined in this specification is the host to which the user previously provided consent.
-                The consequences are that granting permissions to unauthenticated origins is equivalent to granting the permissions to any origin in the presence of a network attacker.
-              </p>
-            </li>
-          </ul>
-        </section>
-        <section>
-          <h4>Mitigations</h4>
-          <p>The following techniques may mitigate the risks:</p>
-          <dl>
-            <dt>Use TLS</dt>
-            <dd>
-              <p>Applications using TLS can be sure that only the user, software working on behalf of the user, and other pages using TLS that have certificates identifying them as being from the same domain, can interact with that application.
-                Furthermore, <a def-id="origin"></a>-specific permissions in combination with a secure origin, ensure that permissions granted to an application cannot be abused by a network attacker.
-              </p>
-              <p>The APIs defined in this specification are only exposed on secure contexts.
-                See also <a href="#privacy-secureorigin">Secure Origin and Transport</a>.
-              </p>
-            </dd>
-
-            <dt>Block Mixed Content</dt>
-            <dd>
-              <p>User agents MUST properly handle Mixed Content [[MIXED-CONTENT]], including blocking "Blockable Content" [[MIXED-CONTENT]] to avoid potential exposure to insecure content.
-                Such exposure could compromise other mitigations, such as use of TLS.
-              </p>
-              <p>User agents MAY choose to block all Mixed Content, including "Optionally-blockable Content" [[MIXED-CONTENT]] to further increase security by preventing <a href="#input-data-security">untrusted media data</a> from being passed to the CDM (see <a href="#cdm-security">CDM Attacks and Vulnerabilities</a>).</p>
-            </dd>
-
-            <dt id="security-consent">Fully inform users and/or require explicit user consent</dt>
-            <dd>
-              <p>User agents SHOULD ensure that users are fully informed and/or give explicit consent before a Key System that presents security concerns that are greater than other user agent features (e.g., DOM content) may be accessed by an <a def-id="origin"></a>.
-              </p>
-              <p>Such mechanisms MUST be per <a def-id="origin"></a> to avoid valid uses enabling subsequent malicious access and MUST be per <a def-id="browsing-profile"></a>.
-              </p>
-              <p class="note">The restriction of the APIs defined in this specification to secure contexts ensures that a <a href="#network-attacks">network attacker</a> cannot exploit permissions granted to an unauthenticated origin.
-                See <a href="#persisted-consent-abuse">abuse of persisted consent</a>.
-              </p>
-            </dd>
-          </dl>
-        </section>
+            </div>
+          </li>
+        </ul>
       </section>
-
-      <section id="iframe-attacks">
-        <h3><code>iframe</code> Attacks</h3>
-        <section class="informative">
-          <h4>Potential Attacks</h4>
-          <p>Malicious pages could host legitimate applications in an iframe in an attempt hide an attack or deceive the user as to the source, such as making the use appear to be from a legitimate content provider.
-            This is especially relevent for implementations that <a href="#security-consent">inform the user or require consent</a>, such as for security and/or <a href="#privacy-consent">privacy reasons</a>.
-            In addition to <a href="#network-attacks">Network Attacks</a>, attackers could try to exploit legitimate uses of the APIs defined in this specification by hosting them in an <code>iframe</code>.
-            By having the legitimate application performing the actions, the attacker can reuse existing granted permissions (or whitelisting) and/or appear to be a legitimate request or use.
-          </p>
-        </section>
-        <section>
-          <h4>Mitigations</h4>
-          <p>User agents that <a href="#security-consent">inform the user or require consent</a>, including for security and/or <a href="#privacy-consent">privacy reasons</a>,
-            SHOULD base the UI and persistence of consent on the combination of <a def-id="origin"></a> of the top-level <a def-id="document-concept"></a> and the <a def-id="origin"></a> using the APIs defined in this specification.
-            This ensures that users are informed of the main document making the request and that persisting a permission for one (legitimate) combination does not inadvertently allow malicious use to go undetected.
-          </p>
-          <p>Authors SHOULD prevent other entities from hosting their applications in <code>iframe</code>s.
-            Applications that must support being hosted for legitimate application-design reasons SHOULD NOT allow hosting documents to provide <a href="#input-data-security">any data to be passed to the CDM</a> - either via the APIs defined in this specification or as media data - and SHOULD NOT allow hosting frames to invoke the APIs defined in this specification.
-          </p>
-        </section>
-      </section>
-
-      <section id="cross-directory-attacks" class="informative">
-        <h3>Cross-Directory Attacks</h3>
-        <p>Different authors sharing one host name, for example users hosting content on <code>geocities.com</code>, all share one <a def-id="origin"></a>.
-          User agents do not provide features to restrict access to APIs by pathname.
-        </p>
-        <p>Using the APIs defined in this specification on shared hosts compromises origin-based security and privacy mitigations implemented by user agents.
-          For example, per-origin <a def-id="distinctive-identifiers"></a> are shared by all authors on one host name, and peristed data may be accessed and manipulated by any author on the host.
-          The latter is especially important if, for example, modification or deletion of such data could erase a user's right to specific content.
-        </p>
-        <p class="note">Even if a path-restriction feature was made available by user agents, the usual DOM scripting security model would make it trivial to bypass this protection and access the data from any path.</p>
-        <p>Authors on shared hosts are therefore RECOMMENDED to avoid using the APIs defined in this specification because doing so compromises origin-based security and privacy mitigations in user agents.</p>
-      </section>
-
     </section>
-
-    <section id="privacy">
-      <h2>Privacy</h2>
-
-      <p>The presence or use of Key System(s) on a user's device raises a number of privacy issues, falling into two categories: (a) user-specific information that may be disclosed by the EME interface itself or within Key System messages and (b) user-specific information that may be persistently stored on the user's device.</p>
-      <p>User Agents MUST take responsibility for providing users with adequate control over their own privacy.
-        Since User Agents may integrate with third party CDM implementations, CDM implementers MUST provide sufficient information and controls to user agent implementers to enable them to implement appropriate techniques to ensure users have control over their privacy, including but not limited to the techniques described below.
-      </p>
-
-      <section id="privacy-disclosure">
-        <h3>Information Disclosed by EME and Key Systems</h3>
-        <p>Concerns regarding information disclosed by EME and Key Systems fall into two categories: (a) concerns about non-specific information that may nevertheless contribute to the possibility of fingerprinting a user agent or device and (b) user-specific information that may be used directly for <a href="#user-tracking">user tracking</a>.</p>
-      </section>
-
-      <section id="privacy-fingerprinting">
-        <h3>Fingerprinting</h3>
-        <p>Malicious applications may be able to fingerprint users or user agents by detecting or enumerating the list of Key Systems that are supported and related information.
-          If proper origin protections are not provided this could include detection of sites that have been visited and information stored for those sites. In particular, Key Systems MUST not share key or other data between <a def-id="origin">origins</a>.
+    <section id="user-tracking">
+      <h3>User Tracking</h3>
+      <section class="informative">
+        <h4>Concerns</h4>
+        <p>A third-party host (or any entity, such as an advertiser, capable of getting content
+          distributed to multiple sites) could use a <a def-id="distinctive-identifier"></a> or
+          persistent data, including licenses, keys, key IDs, <a
+            def-id="records-of-license-destruction"></a>, or <a def-id="records-of-key-usage"></a>,
+          stored by or on behalf of the <a def-id="cdm"></a> to track a user across multiple
+          sessions (including across <a def-id="origin">origins</a> and <a
+            def-id="browsing-profile">browsing profiles</a>), building a profile of the user's
+          activities or interests. Such tracking would undermine the privacy protections provided by
+          the rest of the web platform and could, for example, enable highly-targeted advertising
+          not otherwise possible. In conjunction with a site that is aware of the user's real
+          identity (for example, a content provider or e-commerce site that requires authenticated
+          credentials), this could allow oppressive groups to target individuals with greater
+          accuracy than in a world with purely anonymous web usage. </p>
+        <p>User- or client-specific information that could be obtained via implementations of the
+          APIs in this specification includes:</p>
+        <ul>
+          <li>
+            <p><a def-id="distinctive-identifier-maybe-plural"></a></p>
+          </li>
+          <li>
+            <p><a def-id="distinctive-permanent-identifier-maybe-plural"></a></p>
+          </li>
+          <li>
+            <p>Origins visited (via stored or in-memory data, permissions, etc.)</p>
+          </li>
+          <li>
+            <p>Content viewed (via stored or in-memory licenses, keys, key IDs, <a
+                def-id="records-of-license-destruction"></a>, <a def-id="records-of-key-usage"></a>,
+              etc.)</p>
+          </li>
+        </ul>
+        <p>This specification presents a specific concern because such information is commonly
+          stored outside the user agent (and associated <a def-id="browsing-profile"></a> storage),
+          often in the CDM.</p>
+        <p>Since the content of licenses, <a def-id="records-of-license-destruction"></a>, and <a
+            def-id="records-of-key-usage"></a> are Key System-specific and since key IDs may contain
+          any value, these data items could be abused to store user-identifying information.</p>
+        <p>Key Systems may access or create persistent or semi-persistent identifier(s) for a device
+          or user of a device. In some cases these identifiers may be bound to a specific device in
+          a secure manner. If these identifiers are present in Key System messages, then devices
+          and/or users may be tracked. If the mitigations below are not applied, this could include
+          both tracking of users / devices over time and associating multiple users of a given
+          device. </p>
+        <p>It is important to note that such identifiers, especially those that are non-clearable,
+          non-<a def-id="origin"></a>-specific, or <a href="#permanent-identifier">permanent</a>,
+          exceed the tracking impact of existing techniques such as cookies [[COOKIES]] or session
+          identifiers embedded in URLs.</p>
+        <p>If not mitigated, such tracking may take three forms depending on the design of the Key
+          System:</p>
+        <ul>
+          <li>
+            <p>In all cases, such identifiers are expected to be available to sites and/or servers
+              that fully support the Key System (and thus can interpret Key System messages)
+              enabling tracking by such sites.</p>
+          </li>
+          <li>
+            <p>If identifiers exposed by Key Systems are not origin-specific, then two sites and/or
+              servers that fully support the Key System may collude to track the user.</p>
+          </li>
+          <li>
+            <p>If Key System messages contain information derived from a user identifier in a
+              consistent manner, for example such that a portion of the initial Key System message
+              for a specific content item does not change over time and is dependent on the user
+              identifier, then this information could be used by any application to track the device
+              or user over time.</p>
+          </li>
+        </ul>
+        <p>In addition, if a Key System permits keys or other data to be stored and to be re-used
+          between origins, then it may be possible for two origins to collude and track a unique
+          user by recording their ability to access a common key.</p>
+        <p>Finally, if any user interface for user control of Key Systems presents data separately
+          from data in HTTP session cookies [[COOKIES]] or persistent storage, then users are likely
+          to modify site authorization or delete data in one and not the others. This would allow
+          sites to use the various features as redundant backup for each other, defeating a user's
+          attempts to protect his or her privacy. </p>
+        <p> In addition to the potential for sites and other third-parties to track users, the user
+          agent implementer, CDM vendor, or device vendor could build a profile of the user's
+          activities or interests, such as sites using the APIs defined in this specification that
+          the user visits. Such tracking would undermine the privacy protections provided by the
+          rest of the web platform, especially those related to isolation of origins. </p>
+        <p> Identifiers, such as <a def-id="distinctive-identifiers"></a>, may be obtained from a
+          server operated or provided by the CDM vendor, such as via an <a
+            href="#individualization">individualization</a> process. The process may include
+          providing client identifier(s), including <a
+            def-id="distinctive-permanent-identifier-maybe-plural"></a>, to the server. In order to
+          generate a per-origin identifier, a value representing the origin may also be provided.
         </p>
+        <p> In such an implementation, the CDM vendor may be able to track the activity of the user,
+          such as number of origins visited or number of times a new identifier is required. If the
+          origin or a value <a def-id="associable"></a> with the origin is provided in the
+          identifier request, the CDM vendor could track the sites visited by the user or user(s) of
+          a device. </p>
+        <p>The following section describes techniques that may mitigate the risks of tracking
+          without user consent.</p>
       </section>
-
-      <section id="privacy-leakage">
-        <h3>Information Leakage</h3>
-        <section class="informative">
-          <h4>Concerns</h4>
-          <p>CDMs, especially those implemented outside the user agent, may not have the same fundamental isolations as the web platform.
-            It is important that steps be taken to avoid information leakage, especially across origins.
-            This includes both in-memory and stored data.
-            Failure to do so could lead to information leakage to/from private browsing sessions, across <a def-id="browsing-profile">browsing profiles</a> (including across operating system user accounts) and even across different browsers or applications.
-          </p>
-        </section>
-        <section>
-          <h4>Mitigations</h4>
-          <p>To avoid such issues, user agent and CDM implementations MUST ensure that:</p>
-          <ul>
-            <li><p>CDMs have a concept of a CDM instance that is associated one-to-one with a MediaKeys object.</p></li>
-            <li><p>Keys, licenses, other session data, and the presence of sessions are restricted to the CDM instance associated with the MediaKeys object that created the session.</p></li>
-            <li><p>Session data is not shared between MediaKeys objects or CDM instances.</p></li>
-            <li>
-              <p>
-                Session data is not shared with media elements not associated with the MediaKeys object that created the session.
-                Among other things, this means a session's keys MUST not be used to decrypt content loaded by a media element whose <a def-id="mediaKeys-attribute"></a> attribute is not that MediaKeys object.
-              </p>
-            </li>
-            <li><p>MediaKeys objects and the underlying implementation do not expose information outside the <a def-id="origin"></a>.</p></li>
-            <li><p>Persisted session data, if applicable, is stored on a per-<a def-id="origin"></a> basis.</p></li>
-            <li><p>Only data stored by the requesting <a def-id="origin"></a> may be loaded.</p></li>
-            <li>
-              <p>
-                It is not possible to extract, derive or infer information from the CDM that is not either explicitly described in this specification
-                or available to the page through other web platform APIs without user permission. This applies to any information that is exposed outside
-                the client device or to the application, including, for example, in CDM messages.
-              </p>
-              <div class="note">
-                <p>The type of information covered by this requirement includes but is not limited to:</p>
-                <ul>
-                  <li><p>Location, including geolocation</p></li>
-                  <li><p>Credentials or identifiers other than Distinctive Identifiers</p></li>
-                  <li><p>OS account name and other potential PII</p></li>
-                  <li><p>Local directory paths, which may contain similar information.</p></li>
-                  <li><p>Local network details (for example, the device's local IP address)</p></li>
-                  <li><p>Local devices, including but not limited to Bluetooth, USB, and user media.</p></li>
-                  <li><p>User state not associated with or stored as a result of the APIs defined in this specification.</p></li>
-                </ul>
-              </div>
-            </li>
-          </ul>
-        </section>
+      <section>
+        <h4>Mitigations</h4>
+        <dl>
+          <dt>Do not <a
+              href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">use
+              Distinctive Identifiers or Distinctive Permanent Identifiers</a></dt>
+          <dd>
+            <p>Key System implementations SHOULD avoid <a
+                href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">using
+                Distinctive Identifiers and Distinctive Permanent Identifiers</a> whenever possible
+              and only use them when they meaningfully contribute to the robustness of the
+              implementation. See <a
+                href="#limit-or-avoid-use-of-distinctive-identifiers-and-permanent-identifiers">Limit
+                or Avoid use of Distinctive Identifiers and Permanent Identifiers</a>. </p>
+          </dd>
+          <dt>Do not expose <a def-id="distinctive-permanent-identifiers"></a> to the application
+          </dt>
+          <dd>
+            <p> Implementations MUST NOT expose <a def-id="distinctive-permanent-identifiers"></a>
+              to the application or origin. </p>
+          </dd>
+          <dt>Encrypt <a def-id="distinctive-identifiers"></a></dt>
+          <dd>
+            <p><a def-id="distinctive-identifiers"></a> in Key System messages MUST be encrypted,
+              together with a timestamp or nonce, such that the Key System messages are always
+              different. This prevents the use of Key System messages for tracking except by servers
+              fully supporting the Key System. See <a href="#encrypt-identifiers">Encrypt
+                Identifiers</a>. </p>
+          </dd>
+          <dt id="like-cookies">Treat <a def-id="distinctive-identifiers"></a> and Key System stored
+            data like cookies / web storage</dt>
+          <dd>
+            <p>User agents SHOULD present the presence of <a def-id="distinctive-identifiers"></a>
+              and data stored by Key Systems to the user in a way that associates them strongly with
+              HTTP session cookies [[COOKIES]], including it in "remove all data", and presenting it
+              in the same UI locations. This might encourage users to view such identifiers with
+              healthy suspicion. User agents SHOULD help the user avoid <a
+                href="#incomplete-clearing">Incomplete Clearing of Data</a>. </p>
+          </dd>
+          <dt>Do not expose per-origin information to unrelated entities</dt>
+          <dd>
+            <p> Do not provide <a def-id="origin">origin(s)</a> or values <a
+                def-id="associable"></a> with origins to individualization servers or other entities
+              not related to the origin. Follow the requirements and recommendations in the <a
+                href="#individualization">Individualization</a> section if such a process is used by
+              the implementation. </p>
+          </dd>
+          <dt>Use non-associable per-origin per-profile values and identifiers</dt>
+          <dd>
+            <!-- Issue #101 may affect this text. -->
+            <p> For all <a href="#distinctive-value">distinctive values</a> exposed to the
+              application, implementations MUST use a different <a
+                def-id="non-associable-by-application"></a> value for each <a def-id="origin"></a>
+              and <a def-id="browsing-profile"></a>. See <a
+                href="#per-origin-per-profile-values"></a>. </p>
+            <p> This is especially important for implementations that <a
+                href="#uses-distinctive-identifiers">use Distinctive Identifier(s)</a>. See <a
+                href="#per-origin-per-profile-identifiers"></a>. </p>
+          </dd>
+          <dt>Use origin-specific and browsing profile-specific Key System storage</dt>
+          <dd>
+            <p>Any data used by the CDM that might impact messages or behavior in an application- or
+              license server-visible way MUST be partitioned by <a def-id="origin"></a> and <a
+                def-id="browsing-profile"></a> and MUST NOT leak to or from private browsing
+              sessions. This includes both in-memory and persisted data. Specifically but not
+              exhaustively, session data, licenses, keys, and per-origin identifiers MUST be
+              partitioned per-<a def-id="origin"></a> and per-<a def-id="browsing-profile"></a>. See
+              <a href="#use-origin-specific-key-system-storage"></a> and <a
+                href="#per-origin-per-profile-values"></a>. </p>
+          </dd>
+          <dt>Provide user deletion of persistent data, including <a
+              def-id="distinctive-identifiers"></a></dt>
+          <dd>
+            <p>User agents MUST provide users with the ability to clear any persistent data,
+              including <a def-id="distinctive-identifiers"></a>, maintained by Key Systems. See <a
+                href="#allow-persistent-data-cleared">Allow Persistent Data to Be Cleared</a>. </p>
+          </dd>
+          <dt>Expire stored data</dt>
+          <dd>
+            <p>User agents MAY, possibly in a manner configured by the user, automatically delete <a
+                def-id="distinctive-identifiers"></a> and/or other Key System data after a period of
+              time.</p>
+            <div class="note">
+              <p>For example, a user agent could be configured to store such data as session-only
+                storage, deleting the data once the user had closed all the browsing contexts that
+                could access it.</p>
+              <p>This can restrict the ability of a site to track a user, as the site would then
+                only be able to track the user across multiple sessions when the user authenticates
+                with the site itself (e.g., by making a purchase or signing in to a service).</p>
+              <p>However, this can also put the user's access to content, especially purchased or
+                rented content, at risk if the user does not fully understand the implications of
+                such expiration.</p>
+            </div>
+          </dd>
+          <dt>Block third-party access</dt>
+          <dd>
+            <!-- Issue #101 may affect this text. -->
+            <p>User agents MAY restrict access to Key Systems and/or features to scripts originating
+              at the <a def-id="origin"></a> of the top-level <a def-id="document-concept"></a> of
+              the browsing context. For example, <a def-id="requestMediaKeySystemAccess"></a> may
+              deny requests for certain configurations for pages from other origins running in
+              <code>iframe</code>s. </p>
+          </dd>
+          <dt id="privacy-consent">Fully inform users and/or require explicit user consent</dt>
+          <dd>
+            <p>User agents MUST ensure that users are fully informed and/or give explicit consent
+              before <a
+                href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">using
+                Distinctive Identifier(s) and Distinctive Permanent Identifier(s)</a>. </p>
+            <p>Such mechanisms MUST be per <a def-id="origin"></a> to avoid valid uses enabling
+              subsequent malicious access and MUST be per <a def-id="browsing-profile"></a>. </p>
+            <p class="note">The restriction of the APIs defined in this specification to secure
+              contexts ensures that a <a href="#network-attacks">network attacker</a> cannot exploit
+              permissions granted to an unauthenticated origin. See <a
+                href="#persisted-consent-abuse">abuse of persisted consent</a>. </p>
+          </dd>
+          <dt>Provide user controls to disable Key Systems or Key System use of identifiers</dt>
+          <dd>
+            <p>User Agents SHOULD provide users with a global control of whether a Key System is
+              enabled and/or whether Key System <a
+                href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">use of
+                Distinctive Identifier(s) and Distinctive Permanent Identifier(s)</a> is enabled (if
+              supported by the Key System). User agents SHOULD help the user avoid <a
+                href="#incomplete-clearing">Incomplete Clearing of Data</a>. </p>
+          </dd>
+          <dt>Require site-specific whitelisting of access to each Key System</dt>
+          <dd>
+            <p>User agents MAY require the user to explicitly authorize access to each Key System -
+              and/or certain features - before a site can use it. User agents SHOULD enable users to
+              revoke this authorization either temporarily or permanently. </p>
+          </dd>
+          <dt>Use shared blacklists</dt>
+          <dd>
+            <p>User agents MAY allow users to share blacklists of <a def-id="origin">origins</a>
+              and/or Key Systems. This would allow communities to act together to protect their
+              privacy. </p>
+          </dd>
+        </dl>
+        <p class="note">While these suggestions prevent trivial use of the APIs defined in this
+          specification for user tracking, they do not block it altogether. Within a single origin,
+          a site can continue to track the user during a session, and can then pass all this
+          information to a third party along with any identifying information (names, credit card
+          numbers, addresses) obtained by the site. If a third party cooperates with multiple sites
+          to obtain such information, and if identifiers are not
+          <!-- Issue #101 may affect this text. --><a
+            href="#per-origin-per-profile-identifiers">unique per origin and profile</a>, then a
+          profile can still be created. </p>
       </section>
-
-      <section id="user-tracking">
-        <h3>User Tracking</h3>
-        <section class="informative">
-          <h4>Concerns</h4>
-          <p>A third-party host (or any entity, such as an advertiser, capable of getting content distributed to multiple sites) could use a <a def-id="distinctive-identifier"></a> or persistent data, including licenses, keys, key IDs, <a def-id="records-of-license-destruction"></a>, or <a def-id="records-of-key-usage"></a>, stored by or on behalf of the <a def-id="cdm"></a> to track a user across multiple sessions (including across <a def-id="origin">origins</a> and <a def-id="browsing-profile">browsing profiles</a>), building a profile of the user's activities or interests.
-            Such tracking would undermine the privacy protections provided by the rest of the web platform and could, for example, enable highly-targeted advertising not otherwise possible.
-            In conjunction with a site that is aware of the user's real identity (for example, a content provider or e-commerce site that requires authenticated credentials), this could allow oppressive groups to target individuals with greater accuracy than in a world with purely anonymous web usage.
-          </p>
-
-          <p>User- or client-specific information that could be obtained via implementations of the APIs in this specification includes:</p>
-          <ul>
-            <li><p><a def-id="distinctive-identifier-maybe-plural"></a></p></li>
-            <li><p><a def-id="distinctive-permanent-identifier-maybe-plural"></a></p></li>
-            <li><p>Origins visited (via stored or in-memory data, permissions, etc.)</p></li>
-            <li><p>Content viewed (via stored or in-memory licenses, keys, key IDs, <a def-id="records-of-license-destruction"></a>, <a def-id="records-of-key-usage"></a>, etc.)</p></li>
-          </ul>
-          <p>This specification presents a specific concern because such information is commonly stored outside the user agent (and associated <a def-id="browsing-profile"></a> storage), often in the CDM.</p>
-          
-          <p>Since the content of licenses, <a def-id="records-of-license-destruction"></a>, and <a def-id="records-of-key-usage"></a> are Key System-specific and since key IDs may contain any value, these data items could be abused to store user-identifying information.</p>
-
-          <p>Key Systems may access or create persistent or semi-persistent identifier(s) for a device or user of a device.
-            In some cases these identifiers may be bound to a specific device in a secure manner.
-            If these identifiers are present in Key System messages, then devices and/or users may be tracked.
-            If the mitigations below are not applied, this could include both tracking of users / devices over time and associating multiple users of a given device.
-          </p>
-
-          <p>It is important to note that such identifiers, especially those that are non-clearable, non-<a def-id="origin"></a>-specific, or <a href="#permanent-identifier">permanent</a>, exceed the tracking impact of existing techniques such as cookies [[COOKIES]] or session identifiers embedded in URLs.</p>
-
-          <p>If not mitigated, such tracking may take three forms depending on the design of the Key System:</p>
-          <ul>
-            <li><p>In all cases, such identifiers are expected to be available to sites and/or servers that fully support the Key System (and thus can interpret Key System messages) enabling tracking by such sites.</p></li>
-            <li><p>If identifiers exposed by Key Systems are not origin-specific, then two sites and/or servers that fully support the Key System may collude to track the user.</p></li>
-            <li><p>If Key System messages contain information derived from a user identifier in a consistent manner, for example such that a portion of the initial Key System message for a specific content item does not change over time and is dependent on the user identifier, then this information could be used by any application to track the device or user over time.</p></li>
-          </ul>
-
-          <p>In addition, if a Key System permits keys or other data to be stored and to be re-used between origins, then it may be possible for two origins to collude and track a unique user by recording their ability to access a common key.</p>
-          <p>Finally, if any user interface for user control of Key Systems presents data separately from data in HTTP session cookies [[COOKIES]] or persistent storage, then users are likely to modify site authorization or delete data in one and not the others.
-            This would allow sites to use the various features as redundant backup for each other, defeating a user's attempts to protect his or her privacy.
-          </p>
-          
-          <p>
-            In addition to the potential for sites and other third-parties to track users, the user agent implementer, CDM vendor, or device vendor could build a profile of the user's activities or interests, such as sites using the APIs defined in this specification that the user visits.
-            Such tracking would undermine the privacy protections provided by the rest of the web platform, especially those related to isolation of origins.
-          </p>
-          
-          <p>
-            Identifiers, such as <a def-id="distinctive-identifiers"></a>, may be obtained from a server operated or provided by the CDM vendor, such as via an <a href="#individualization">individualization</a> process.
-            The process may include providing client identifier(s), including <a def-id="distinctive-permanent-identifier-maybe-plural"></a>, to the server.
-            In order to generate a per-origin identifier, a value representing the origin may also be provided.
-          </p>
-
-          <p>
-            In such an implementation, the CDM vendor may be able to track the activity of the user, such as number of origins visited or number of times a new identifier is required.
-            If the origin or a value <a def-id="associable"></a> with the origin is provided in the identifier request, the CDM vendor could track the sites visited by the user or user(s) of a device.
-          </p>
-          <p>The following section describes techniques that may mitigate the risks of tracking without user consent.</p>
-        </section>
-        <section>
-          <h4>Mitigations</h4>
-          <dl>
-            <dt>Do not <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">use Distinctive Identifiers or Distinctive Permanent Identifiers</a></dt>
-            <dd>
-              <p>Key System implementations SHOULD avoid <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">using Distinctive Identifiers and Distinctive Permanent Identifiers</a> whenever possible and only use them when they meaningfully contribute to the robustness of the implementation.
-                See <a href="#limit-or-avoid-use-of-distinctive-identifiers-and-permanent-identifiers">Limit or Avoid use of Distinctive Identifiers and Permanent Identifiers</a>.
-              </p>
-            </dd>
-
-            <dt>Do not expose <a def-id="distinctive-permanent-identifiers"></a> to the application</dt>
-            <dd>
-              <p>
-                Implementations MUST NOT expose <a def-id="distinctive-permanent-identifiers"></a> to the application or origin. 
-              </p>
-            </dd>
-
-            <dt>Encrypt <a def-id="distinctive-identifiers"></a></dt>
-            <dd>
-              <p><a def-id="distinctive-identifiers"></a> in Key System messages MUST be encrypted, together with a timestamp or nonce, such that the Key System messages are always different.
-                This prevents the use of Key System messages for tracking except by servers fully supporting the Key System.
-                See <a href="#encrypt-identifiers">Encrypt Identifiers</a>.
-              </p>
-            </dd>
-
-            <dt id="like-cookies">Treat <a def-id="distinctive-identifiers"></a> and Key System stored data like cookies / web storage</dt>
-            <dd>
-              <p>User agents SHOULD present the presence of <a def-id="distinctive-identifiers"></a> and data stored by Key Systems to the user in a way that associates them strongly with HTTP session cookies [[COOKIES]], including it in "remove all data", and presenting it in the same UI locations.
-                This might encourage users to view such identifiers with healthy suspicion.
-                User agents SHOULD help the user avoid <a href="#incomplete-clearing">Incomplete Clearing of Data</a>.
-              </p>
-            </dd>
-
-            <dt>Do not expose per-origin information to unrelated entities</dt>
-            <dd>
-              <p>
-                Do not provide <a def-id="origin">origin(s)</a> or values <a def-id="associable"></a> with origins to individualization servers or other entities not related to the origin.
-                Follow the requirements and recommendations in the <a href="#individualization">Individualization</a> section if such a process is used by the implementation. 
-              </p>
-            </dd>
-
-            <dt>Use non-associable per-origin per-profile values and identifiers</dt>
-            <dd>
-              <!-- Issue #101 may affect this text. -->
-              <p>
-                For all <a href="#distinctive-value">distinctive values</a> exposed to the application,
-                implementations MUST use a different <a def-id="non-associable-by-application"></a> value for each <a def-id="origin"></a> and <a def-id="browsing-profile"></a>.
-                See <a href="#per-origin-per-profile-values"></a>.
-              </p>
-              <p>
-                This is especially important for implementations that <a href="#uses-distinctive-identifiers">use Distinctive Identifier(s)</a>.
-                See <a href="#per-origin-per-profile-identifiers"></a>.
-              </p>
-            </dd>
-
-            <dt>Use origin-specific and browsing profile-specific Key System storage</dt>
-            <dd>
-              <p>Any data used by the CDM that might impact messages or behavior in an application- or license server-visible way MUST be partitioned by <a def-id="origin"></a> and <a def-id="browsing-profile"></a> and MUST NOT leak to or from private browsing sessions.
-                This includes both in-memory and persisted data.
-                Specifically but not exhaustively, session data, licenses, keys, and per-origin identifiers MUST be partitioned per-<a def-id="origin"></a> and per-<a def-id="browsing-profile"></a>.
-                See <a href="#use-origin-specific-key-system-storage"></a> and <a href="#per-origin-per-profile-values"></a>.
-              </p>
-            </dd>
-
-            <dt>Provide user deletion of persistent data, including <a def-id="distinctive-identifiers"></a></dt>
-            <dd>
-              <p>User agents MUST provide users with the ability to clear any persistent data, including <a def-id="distinctive-identifiers"></a>, maintained by Key Systems.
-                See <a href="#allow-persistent-data-cleared">Allow Persistent Data to Be Cleared</a>.
-              </p>
-            </dd>
-
-            <dt>Expire stored data</dt>
-            <dd>
-              <p>User agents MAY, possibly in a manner configured by the user, automatically delete <a def-id="distinctive-identifiers"></a> and/or other Key System data after a period of time.</p>
-              <div class="note">
-                <p>For example, a user agent could be configured to store such data as session-only storage, deleting the data once the user had closed all the browsing contexts that could access it.</p>
-                <p>This can restrict the ability of a site to track a user, as the site would then only be able to track the user across multiple sessions when the user authenticates with the site itself (e.g., by making a purchase or signing in to a service).</p>
-                <p>However, this can also put the user's access to content, especially purchased or rented content, at risk if the user does not fully understand the implications of such expiration.</p>
-              </div>
-            </dd>
-
-            <dt>Block third-party access</dt>
-            <dd>
-              <!-- Issue #101 may affect this text. -->
-              <p>User agents MAY restrict access to Key Systems and/or features to scripts originating at the <a def-id="origin"></a> of the top-level <a def-id="document-concept"></a> of the browsing context.
-                For example, <a def-id="requestMediaKeySystemAccess"></a> may deny requests for certain configurations for pages from other origins running in <code>iframe</code>s.
-              </p>
-            </dd>
-
-            <dt id="privacy-consent">Fully inform users and/or require explicit user consent</dt>
-            <dd>
-              <p>User agents MUST ensure that users are fully informed and/or give explicit consent before <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">using Distinctive Identifier(s) and Distinctive Permanent Identifier(s)</a>.
-              </p>
-              <p>Such mechanisms MUST be per <a def-id="origin"></a> to avoid valid uses enabling subsequent malicious access and MUST be per <a def-id="browsing-profile"></a>.
-              </p>
-              <p class="note">The restriction of the APIs defined in this specification to secure contexts ensures that a <a href="#network-attacks">network attacker</a> cannot exploit permissions granted to an unauthenticated origin.
-                See <a href="#persisted-consent-abuse">abuse of persisted consent</a>.
-              </p>
-            </dd>
-
-            <dt>Provide user controls to disable Key Systems or Key System use of identifiers</dt>
-            <dd>
-              <p>User Agents SHOULD provide users with a global control of whether a Key System is enabled and/or whether Key System <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">use of Distinctive Identifier(s) and Distinctive Permanent Identifier(s)</a> is enabled (if supported by the Key System).
-                User agents SHOULD help the user avoid <a href="#incomplete-clearing">Incomplete Clearing of Data</a>.
-              </p>
-            </dd>
-
-            <dt>Require site-specific whitelisting of access to each Key System</dt>
-            <dd>
-              <p>User agents MAY require the user to explicitly authorize access to each Key System - and/or certain features - before a site can use it.
-                User agents SHOULD enable users to revoke this authorization either temporarily or permanently.
-              </p>
-            </dd>
-
-            <dt>Use shared blacklists</dt>
-            <dd>
-              <p>User agents MAY allow users to share blacklists of <a def-id="origin">origins</a> and/or Key Systems.
-                This would allow communities to act together to protect their privacy.
-              </p>
-            </dd>
-          </dl>
-
-          <p class="note">While these suggestions prevent trivial use of the APIs defined in this specification for user tracking, they do not block it altogether.
-            Within a single origin, a site can continue to track the user during a session, and can then pass all this information to a third party along with any identifying information (names, credit card numbers, addresses) obtained by the site.
-            If a third party cooperates with multiple sites to obtain such information, and if identifiers are not <!-- Issue #101 may affect this text. --><a href="#per-origin-per-profile-identifiers">unique per origin and profile</a>, then a profile can still be created.
-          </p>
-        </section>
-      </section>
-
-      <section id="privacy-storedinfo">
-        <h3>Information Stored on User Devices</h3>
-        <section class="informative">
-          <h4>Concerns</h4>
-          <p>Key Systems may store information on a user's device, or user agents may store information on behalf of Key Systems.
-            Potentially, this could reveal information about a user to another user of the same device, including potentially the <a def-id="origin">origins</a> that have used a particular Key System (i.e., sites visited) or even the content that has been decrypted using a Key System.
-          </p>
-          <p>If information stored by one origin affects the operation of the Key System for another origin, then potentially the sites visited or content viewed by a user on one site may be revealed to another, potentially malicious, site.</p>
-          <p>If information stored for one <a def-id="browsing-profile"></a> on the client device affects the operation of the Key System for other <a def-id="browsing-profile">browsing profiles</a>, or browsers, then potentially the sites visited or content viewed in one may be revealed by or correlatable with another <a def-id="browsing-profile">browsing profile</a>, even including for different operating system user accounts or browsers.</p>
-        </section>
-        <section>
-          <h4>Mitigations</h4>
-          <p>Requirements mitigating these concerns are defined in <a href="#persistent-state-requirements"></a>.</p>
-        </section>
-      </section>
-
-      <section id="incomplete-clearing">
-        <h3>Incomplete Clearing of Data</h3>
-        <section class="informative">
-          <h4>Concerns</h4>
-          <p>A user's attempts to protect his or her privacy by clearing <a def-id="distinctive-identifiers"></a> and stored data and/or disabling a Key System may be defeated if all such data and functionality as well as cookies [[COOKIES]] and other site data are not cleared and/or disabled at the same time.
-            For example:
-          </p>
-          <ul>
-            <li><p>If a user clears cookies or other persistent storage without also clearing <a def-id="distinctive-identifiers"></a> and data stored by Key Systems, sites can defeat those attempts by using the various features as redundant backup for each other.</p></li>
-            <li><p>If a user clears <a def-id="distinctive-identifiers"></a> without also clearing data stored by Key Systems, including persistent sessions, as well as cookies and other persistent storage, sites can defeat those attempts by using the remaining data to associate the old and new identifiers.</p></li>
-            <li><p>If a user disables a key system, especially for a specific <a def-id="origin"></a>, without also clearing cookies or other persistent storage, sites can defeat those attempts by using the remaining features.</p></li>
-            <li><p>If a user disables a key system, then later decide to enable the key system, without also clearing clearing cookies or other persistent storage, <a def-id="distinctive-identifiers"></a>, and data stored by Key Systems, sites may be able to associate data prior to the disabling with data and behavior after the key system is re-enabled.</p></li>
-          </ul>
-        </section>
-        <section>
-          <h4>Mitigations</h4>
-          <p>Recommendations mitigating these concerns are defined in <a href="#persistent-state-requirements"></a>.</p>
-        </section>
-      </section>
-
-      <section id="private-browsing">
-        <h3>Private Browsing Modes</h3>
-        <p>User agents may support a mode (e.g., private browsing) of operation intended to preserve user anonymity and/or ensure records of browsing activity are not persisted on the client.
-          The privacy concerns discussed in previous sections may be especially concerning for users employing such modes.
-        </p>
-        <p>User agent implementers that support such mode(s) SHOULD carefully consider whether access to Key Systems should be disabled in these mode(s).
-          For example, such modes MAY prohibit creation of <a>MediaKeySystemAccess</a> objects that support or use <a def-id="option-persistentState"></a> or a <a def-id="option-distinctiveIdentifier"></a> (either as part of the CDM implementation or because the application indicated they were <a def-id="requirement-required"></a>).
-          If implementations do not prohibit such creation, they SHOULD inform the user of the implications and potential consequences for the expected privacy properties of such modes before allowing their use.
-        </p>
-      </section>
-
-      <section id="privacy-secureorigin">
-        <h3>Secure Origin and Transport</h3>
-        <p>
-          The APIs defined in this specification are only supported on secure origins, protecting information discussed in previous sections.
-          Identifiers are additionally encrypted as specified in <a href="#encrypt-identifiers">Encrypt Identifiers</a>.
-        </p>
-        <p>Applications, including the servers they use, SHOULD use secure transport for all traffic involving or containing data or messages from the CDM, including but is not limited to all data passed from <a def-id="message"></a> events and to <a def-id="update"></a>.</p>
-        <p>All user agents MUST properly handle Mixed Content [[MIXED-CONTENT]] to avoid exposure to insecure content or transport when the user agent or application wish to enforce secure origin and transport.</p>
-      </section>
-
     </section>
-    
-    <section id="conformance"></section>
-
-    <section id="examples" class="informative">
-      <h2>Examples</h2>
-      <p>This section contains example solutions for various use cases using the proposed extensions.
-      These are not the only solutions to these use cases.
-      Video elements are used in the examples, but the same would apply to all media elements.
-      In some cases, such as using synchronous XHR, the examples are simplified to keep the focus on the extensions.
-      </p>
-
-      <section id="example-source-and-key-known">
-        <h3>Source and Key Known at Page Load (Clear Key)</h3>
-        <p class="exampledescription">In this simple example, the source file and <a href="#clear-key">clear-text license</a> are hard-coded in the page.
-        Only one session will ever be created.</p>
-
-        <pre class="example highlight">&lt;script&gt;
+    <section id="privacy-storedinfo">
+      <h3>Information Stored on User Devices</h3>
+      <section class="informative">
+        <h4>Concerns</h4>
+        <p>Key Systems may store information on a user's device, or user agents may store
+          information on behalf of Key Systems. Potentially, this could reveal information about a
+          user to another user of the same device, including potentially the <a
+            def-id="origin">origins</a> that have used a particular Key System (i.e., sites visited)
+          or even the content that has been decrypted using a Key System. </p>
+        <p>If information stored by one origin affects the operation of the Key System for another
+          origin, then potentially the sites visited or content viewed by a user on one site may be
+          revealed to another, potentially malicious, site.</p>
+        <p>If information stored for one <a def-id="browsing-profile"></a> on the client device
+          affects the operation of the Key System for other <a def-id="browsing-profile">browsing
+            profiles</a>, or browsers, then potentially the sites visited or content viewed in one
+          may be revealed by or correlatable with another <a def-id="browsing-profile">browsing
+            profile</a>, even including for different operating system user accounts or browsers.
+        </p>
+      </section>
+      <section>
+        <h4>Mitigations</h4>
+        <p>Requirements mitigating these concerns are defined in <a
+            href="#persistent-state-requirements"></a>.</p>
+      </section>
+    </section>
+    <section id="incomplete-clearing">
+      <h3>Incomplete Clearing of Data</h3>
+      <section class="informative">
+        <h4>Concerns</h4>
+        <p>A user's attempts to protect his or her privacy by clearing <a
+            def-id="distinctive-identifiers"></a> and stored data and/or disabling a Key System may
+          be defeated if all such data and functionality as well as cookies [[COOKIES]] and other
+          site data are not cleared and/or disabled at the same time. For example: </p>
+        <ul>
+          <li>
+            <p>If a user clears cookies or other persistent storage without also clearing <a
+                def-id="distinctive-identifiers"></a> and data stored by Key Systems, sites can
+              defeat those attempts by using the various features as redundant backup for each
+              other.</p>
+          </li>
+          <li>
+            <p>If a user clears <a def-id="distinctive-identifiers"></a> without also clearing data
+              stored by Key Systems, including persistent sessions, as well as cookies and other
+              persistent storage, sites can defeat those attempts by using the remaining data to
+              associate the old and new identifiers.</p>
+          </li>
+          <li>
+            <p>If a user disables a key system, especially for a specific <a def-id="origin"></a>,
+              without also clearing cookies or other persistent storage, sites can defeat those
+              attempts by using the remaining features.</p>
+          </li>
+          <li>
+            <p>If a user disables a key system, then later decide to enable the key system, without
+              also clearing clearing cookies or other persistent storage, <a
+                def-id="distinctive-identifiers"></a>, and data stored by Key Systems, sites may be
+              able to associate data prior to the disabling with data and behavior after the key
+              system is re-enabled.</p>
+          </li>
+        </ul>
+      </section>
+      <section>
+        <h4>Mitigations</h4>
+        <p>Recommendations mitigating these concerns are defined in <a
+            href="#persistent-state-requirements"></a>.</p>
+      </section>
+    </section>
+    <section id="private-browsing">
+      <h3>Private Browsing Modes</h3>
+      <p>User agents may support a mode (e.g., private browsing) of operation intended to preserve
+        user anonymity and/or ensure records of browsing activity are not persisted on the client.
+        The privacy concerns discussed in previous sections may be especially concerning for users
+        employing such modes. </p>
+      <p>User agent implementers that support such mode(s) SHOULD carefully consider whether access
+        to Key Systems should be disabled in these mode(s). For example, such modes MAY prohibit
+        creation of <a>MediaKeySystemAccess</a> objects that support or use <a
+          def-id="option-persistentState"></a> or a <a def-id="option-distinctiveIdentifier"></a>
+        (either as part of the CDM implementation or because the application indicated they were <a
+          def-id="requirement-required"></a>). If implementations do not prohibit such creation,
+        they SHOULD inform the user of the implications and potential consequences for the expected
+        privacy properties of such modes before allowing their use. </p>
+    </section>
+    <section id="privacy-secureorigin">
+      <h3>Secure Origin and Transport</h3>
+      <p> The APIs defined in this specification are only supported on secure origins, protecting
+        information discussed in previous sections. Identifiers are additionally encrypted as
+        specified in <a href="#encrypt-identifiers">Encrypt Identifiers</a>. </p>
+      <p>Applications, including the servers they use, SHOULD use secure transport for all traffic
+        involving or containing data or messages from the CDM, including but is not limited to all
+        data passed from <a def-id="message"></a> events and to <a def-id="update"></a>.</p>
+      <p>All user agents MUST properly handle Mixed Content [[MIXED-CONTENT]] to avoid exposure to
+        insecure content or transport when the user agent or application wish to enforce secure
+        origin and transport.</p>
+    </section>
+  </section>
+  <section id="conformance"></section>
+  <section id="examples" class="informative">
+    <h2>Examples</h2>
+    <p>This section contains example solutions for various use cases using the proposed extensions.
+      These are not the only solutions to these use cases. Video elements are used in the examples,
+      but the same would apply to all media elements. In some cases, such as using synchronous XHR,
+      the examples are simplified to keep the focus on the extensions. </p>
+    <section id="example-source-and-key-known">
+      <h3>Source and Key Known at Page Load (Clear Key)</h3>
+      <p class="exampledescription">In this simple example, the source file and <a
+          href="#clear-key">clear-text license</a> are hard-coded in the page. Only one session will
+        ever be created.</p>
+      <pre class="example highlight">&lt;script&gt;
   function onLoad() {
     var video = document.getElementById('video');
 
@@ -4552,16 +6955,16 @@ interface MediaEncryptedEvent : Event {
   &lt;video src='foo.webm' autoplay id='video'&gt;&lt;/video&gt;
 &lt;/body&gt;
 </pre>
-      </section>
-
-      <section id="example-selecting-key-system">
-        <h3>Selecting a Supported Key System and Using Initialization Data from the "encrypted" Event</h3>
-        <p class="exampledescription">This example selects a supported <a def-id="keysystem"></a> using the <a def-id="requestMediaKeySystemAccess"></a> method then uses
-        the <a def-id="initialization-data"></a> from the <a def-id="media-data"></a> to generate the license request and send it to the appropriate license server.
-        One of the supported key systems uses a serverCertificate, which is provided proactively.
-        </p>
-
-        <pre class="example highlight">&lt;script&gt;
+    </section>
+    <section id="example-selecting-key-system">
+      <h3>Selecting a Supported Key System and Using Initialization Data from the "encrypted" Event
+      </h3>
+      <p class="exampledescription">This example selects a supported <a def-id="keysystem"></a>
+        using the <a def-id="requestMediaKeySystemAccess"></a> method then uses the <a
+          def-id="initialization-data"></a> from the <a def-id="media-data"></a> to generate the
+        license request and send it to the appropriate license server. One of the supported key
+        systems uses a serverCertificate, which is provided proactively. </p>
+      <pre class="example highlight">&lt;script&gt;
   var licenseUrl;
   var serverCertificate;
 
@@ -4692,16 +7095,14 @@ interface MediaEncryptedEvent : Event {
 
 &lt;video autoplay <a def-id="onencrypted"></a>='handleInitData(event)'&gt;&lt;/video&gt;
 </pre>
-      </section>
-
-      <section id="example-mediakeys-before-source">
-        <h3>Create MediaKeys Before Loading Media</h3>
-        <p class="exampledescription">Initialization is much simpler if encrypted events do not need to be handled during MediaKeys initialization.
-        This can be accomplished either by providing the <a def-id="initialization-data"></a> in other ways or setting the source after the MediaKeys object has been created.
-        This example does the latter.
-        </p>
-
-        <pre class="example highlight">&lt;script&gt;
+    </section>
+    <section id="example-mediakeys-before-source">
+      <h3>Create MediaKeys Before Loading Media</h3>
+      <p class="exampledescription">Initialization is much simpler if encrypted events do not need
+        to be handled during MediaKeys initialization. This can be accomplished either by providing
+        the <a def-id="initialization-data"></a> in other ways or setting the source after the
+        MediaKeys object has been created. This example does the latter. </p>
+      <pre class="example highlight">&lt;script&gt;
   var licenseUrl;
   var serverCertificate;
   var mediaKeys;
@@ -4731,14 +7132,15 @@ interface MediaEncryptedEvent : Event {
 
 &lt;video id="v" autoplay <a def-id="onencrypted"></a>='handleInitData(event)'&gt;&lt;/video&gt;
 </pre>
-      </section>
-
-      <section id="example-using-all-events">
-        <h3>Using All Events</h3>
-        <p class="exampledescription">This is a more complete example showing all events being used.</p>
-        <p class="exampledescription">Note that <code>handleMessage()</code> could be called multiple times, including in response to the <a def-id="update"></a> call if multiple round trips are required and for any other reason the Key System might need to send a message.</p>
-
-        <pre class="example highlight">&lt;script&gt;
+    </section>
+    <section id="example-using-all-events">
+      <h3>Using All Events</h3>
+      <p class="exampledescription">This is a more complete example showing all events being used.
+      </p>
+      <p class="exampledescription">Note that <code>handleMessage()</code> could be called multiple
+        times, including in response to the <a def-id="update"></a> call if multiple round trips are
+        required and for any other reason the Key System might need to send a message.</p>
+      <pre class="example highlight">&lt;script&gt;
   var licenseUrl;
   var serverCertificate;
   var mediaKeys;
@@ -4824,13 +7226,13 @@ interface MediaEncryptedEvent : Event {
 
 &lt;video id="v" autoplay <a def-id="onencrypted"></a>='handleInitData(event)'&gt;&lt;/video&gt;
 </pre>
-      </section>
-
-      <section id="example-stored-license">
-        <h3>Stored License</h3>
-        <p class="exampledescription">This example requests a persistent license for future use and stores it. It also provides functions for later retrieving the license and for destroying it.</p>
-
-        <pre class="example highlight">&lt;script&gt;
+    </section>
+    <section id="example-stored-license">
+      <h3>Stored License</h3>
+      <p class="exampledescription">This example requests a persistent license for future use and
+        stores it. It also provides functions for later retrieving the license and for destroying
+        it.</p>
+      <pre class="example highlight">&lt;script&gt;
   var licenseUrl;
   var serverCertificate;
   var mediaKeys;
@@ -4926,12 +7328,13 @@ interface MediaEncryptedEvent : Event {
 
 &lt;video id='v' src='foo.webm' autoplay&gt;&lt;/video&gt;
 </pre>
-      </section>
     </section>
+  </section>
+  <section id="acknowledgements">
+    <h2>Acknowledgments</h2> The editors would like to thank <a def-id="contributors"></a> for their
+    contributions to this specification. Thank you also to the many others who contributed to the
+    specification, including through their participation on the mailing list and in the issues.
+  </section>
+</body>
 
-    <section id="acknowledgements">
-      <h2>Acknowledgments</h2>
-      The editors would like to thank <a def-id="contributors"></a> for their contributions to this specification.  Thank you also to the many others who contributed to the specification, including through their participation on the mailing list and in the issues. 
-    </section>
-
-</body></html>
+</html>

--- a/format-registry/initdata/cenc-respec.html
+++ b/format-registry/initdata/cenc-respec.html
@@ -1,86 +1,86 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <title>"cenc" Initialization Data Format</title>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
-    <script src="../../encrypted-media.js" class="remove"></script>
-    <script class="remove">
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <title>"cenc" Initialization Data Format</title>
+  <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
+  <script src="../../encrypted-media.js" class="remove"></script>
+  <script class="remove">
     var respecConfig = {
       // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
       specStatus: "ED",
-
       // the specification's short name, as in https://www.w3.org/TR/short-name/
       shortName: "eme-initdata-cenc",
-
       // if there a publicly available Editor's Draft, this is the link
       edDraftURI: "https://w3c.github.io/encrypted-media/format-registry/initdata/cenc.html",
-
       // if this is a LCWD, uncomment and set the end of its review period
       // lcEnd: "2009-08-05",
-
       // editors, add as many as you like
       // only "name" is required
-      editors: [
-        { name: "Joey Parrish", w3cid: "105371",
-          company: "Google Inc.", companyURL: "https://www.google.com/" },
-        { name: "Greg Freedman",
-          company: "Netflix Inc.", companyURL: "https://www.netflix.com/" },
-      ],
-
-      formerEditors: [
-        { name: "Mark Watson", note: "Until September 2019", w3cid: "46379",
-          company: "Netflix Inc.", companyURL: "https://www.netflix.com/" },
-        { name: "David Dorwin", note: "Until September 2017", w3cid: "52505",
-          company: "Google Inc.", companyURL: "https://www.google.com/" },
-        { name: "Jerry Smith", note: "Until September 2017", w3cid: "60176",
-          company: "Microsoft Corporation", companyURL: "https://www.microsoft.com/" },
-        { name: "Adrian Bateman", note: "Until May 2014", w3cid: "42763",
-          company: "Microsoft Corporation", companyURL: "https://www.microsoft.com/" },
-      ],
-
-      otherLinks: [
-        { key: "Repository", href: "https://github.com/w3c/encrypted-media/" },
-      ],
-
+      editors: [{
+        name: "Joey Parrish",
+        w3cid: "105371",
+        company: "Google Inc.",
+        companyURL: "https://www.google.com/"
+      }, {
+        name: "Greg Freedman",
+        company: "Netflix Inc.",
+        companyURL: "https://www.netflix.com/"
+      }],
+      formerEditors: [{
+        name: "Mark Watson",
+        note: "Until September 2019",
+        w3cid: "46379",
+        company: "Netflix Inc.",
+        companyURL: "https://www.netflix.com/"
+      }, {
+        name: "David Dorwin",
+        note: "Until September 2017",
+        w3cid: "52505",
+        company: "Google Inc.",
+        companyURL: "https://www.google.com/"
+      }, {
+        name: "Jerry Smith",
+        note: "Until September 2017",
+        w3cid: "60176",
+        company: "Microsoft Corporation",
+        companyURL: "https://www.microsoft.com/"
+      }, {
+        name: "Adrian Bateman",
+        note: "Until May 2014",
+        w3cid: "42763",
+        company: "Microsoft Corporation",
+        companyURL: "https://www.microsoft.com/"
+      }],
+      otherLinks: [{
+        key: "Repository",
+        href: "https://github.com/w3c/encrypted-media/"
+      }],
       emeDefGroupName: "cenc-format",
-      emeUnusedGroupNameExcludeList: [
-        "encrypted-media",
-        "eme-references-from-registry",
-      ],
-
+      emeUnusedGroupNameExcludeList: ["encrypted-media", "eme-references-from-registry", ],
       // name of the WG
       wg: "Media Working Group",
-
       // URI of the public WG page
       wgURI: "https://www.w3.org/media-wg/",
-
       // name (without the @w3c.org) of the public mailing to which comments are due
       wgPublicList: "public-media-wg",
-
       // URI of the patent status for this WG, for Rec-track documents
       // !!!! IMPORTANT !!!!
       // This is important for Rec-track documents, do not copy a patent URI from a random
       // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
       // Team Contact.
       wgPatentURI: "https://www.w3.org/2004/01/pp-impl/115198/status",
-
       noIDLIn: true,
-
       scheme: "https",
-
       // Empty definitions for objects declared in the document are here to
       // prevent error messages from being displayed for references to these objects.
       definitionMap: {},
-
-      preProcess: [ encryptedMediaPreProcessor ],
-
+      preProcess: [encryptedMediaPreProcessor],
       // Empty definitions for objects declared in the document are here to
       // prevent error messages from being displayed for references to these objects.
       definitionMap: {},
-
-      postProcess: [ encryptedMediaPostProcessor ],
-
+      postProcess: [encryptedMediaPostProcessor],
       localBiblio: {
         "CENC": {
           title: "ISO/IEC 23001-7:2016, Information technology — MPEG systems technologies — Part 7: Common encryption in ISO base media file format files",
@@ -90,86 +90,96 @@
         },
       },
     };
-    </script>
-    <!-- script to register bugs -->
-    <!-- Disabled unless/until it supports GitHub issues.
-    <script src="https://w3c.github.io/webcomponents/assets/scripts/bug-assist.js"></script>
-    <meta name="bug.product" content="HTML WG">
-    <meta name="bug.component" content="Encrypted Media Extensions">
-    -->
+  </script>
+</head>
 
-  </head>
-  <body>
-    <!-- TODO: Use styles for ISO boxes like the MSE registry. -->
-    <section id="abstract">
-      <p>This specification defines the <code>"cenc"</code> <a def-id="initialization-data"></a> format for use with the <a def-id="eme-spec"></a> [[!ENCRYPTED-MEDIA]].
-        This format is commonly used with the <a def-id="stream-registry-mp4"></a> [[EME-STREAM-REGISTRY]].
-      </p>
-      <p>This specification also defines a common SystemID and PSSH box format for use with Encrypted Media Extensions.</p>
-      <p class="note">This format's <a def-id="initialization-data-type"></a> string <code>"cenc"</code> refers to the [[CENC]] spec that defines the PSSH boxes that comprise the format.
-        It does not relate to or imply a stream format, including the use of the 'cenc' protection scheme.
-        Stream formats are indicated by the content types as defined in <a def-id="stream-registry"></a> [[EME-STREAM-REGISTRY]].
-    </section>
-
-    <section id="sotd">
-    </section>
-
-    <section id="format">
-      <h2>Format</h2>
-      <p>The format is one or more concatenated Protection System Specific Header ('pssh') boxes [[!CENC]], each for a unique SystemID.
-        One of the concatenated 'pssh' boxes SHOULD use the <a href="#common-system">Common SystemID and PSSH Box Format</a>.
-      </p>
-
-      <p class="note">[[!CENC]] also specifies storage of a 'pssh' box base64-encoded in an XML element of the form <code>&lt;cenc:pssh (base64 'pssh')&gt;</code>.
-        For example, [[MPEGDASH]] manifests may provide 'pssh' boxes in this format, each contained in a ContentProtection Descriptor element identified by a SystemID.
-        These 'pssh' boxes may be decoded and concatenated by an application to provide equivalent Initialization Data to that stored in movie or movie fragment boxes.
-      </p>
-    </section>
-
-    <section id="processing">
-      <h2>Processing</h2>
-      <p>When such Initialization Data is provided by the application, an implementation (the user agent and/or CDM) MUST :</p>
-      <ol>
-        <li><p>Examine the series of 'pssh' boxes to find the <em>first</em> 'pssh' box that the CDM instance supports. This includes checking the SystemID, box version, and system-specific values.</p></li>
-        <li><p>If no such supported box is found, the provided data SHALL be considered "not supported by the CDM."</p></li>
-      </ol>
-    </section>
-
-    <section id="clear-key">
-      <h3>Use with Clear Key</h3>
-      <p>When Initialization data is provided with <var>initDataType</var> <code>"cenc"</code>, <a def-id="clear-key"></a> implementations MUST look for and use the PSSH box with the <a href="#common-system">Common SystemID</a>.</p>
-    </section>
-
-    <section id="common-system">
-      <h2>Common SystemID and PSSH Box Format</h2>
-      <p>This section defines a common open SystemID and PSSH box format.
-        Key System implementations supporting the <code>"cenc"</code> Initialization Data Format MUST support this SystemID and format.
-        Media resources for use with Encrypted Media Extensions SHOULD contain appropriate PSSH box(es) for this SystemID.
-      <p class="note">
-        Use of this SystemID is RECOMMENDED for applications, packagers, and implementors.
-        Use of other SystemIDs with the Encrypted Media Extensions APIs is discouraged.
-        'pssh' box(es) for this SystemID SHOULD be included in all new or repackaged content so that the content can be used with any compliant Key System.
-        For existing content, applications may alternatively obtain a 'pssh' box containing this SystemID or another Initialization Data Type (e.g., <a def-id="initdata-registry-keyids"></a>  [[EME-STREAM-REGISTRY]]) from another source.
-      </p>
-      <p class="note">Implementations MAY support other SystemIDs for backwards compatibility with existing streams.</p>
-
+<body>
+  <!-- TODO: Use styles for ISO boxes like the MSE registry. -->
+  <section id="abstract">
+    <p>This specification defines the <code>"cenc"</code> <a def-id="initialization-data"></a>
+      format for use with the <a def-id="eme-spec"></a> [[!ENCRYPTED-MEDIA]]. This format is
+      commonly used with the <a def-id="stream-registry-mp4"></a> [[EME-STREAM-REGISTRY]]. </p>
+    <p>This specification also defines a common SystemID and PSSH box format for use with Encrypted
+      Media Extensions.</p>
+    <p class="note">This format's <a def-id="initialization-data-type"></a> string <code>"cenc"
+      </code> refers to the [[CENC]] spec that defines the PSSH boxes that comprise the format. It
+      does not relate to or imply a stream format, including the use of the 'cenc' protection
+      scheme. Stream formats are indicated by the content types as defined in <a
+        def-id="stream-registry"></a> [[EME-STREAM-REGISTRY]].
+  </section>
+  <section id="sotd">
+  </section>
+  <section id="format">
+    <h2>Format</h2>
+    <p>The format is one or more concatenated Protection System Specific Header ('pssh') boxes
+      [[!CENC]], each for a unique SystemID. One of the concatenated 'pssh' boxes SHOULD use the <a
+        href="#common-system">Common SystemID and PSSH Box Format</a>. </p>
+    <p class="note">[[!CENC]] also specifies storage of a 'pssh' box base64-encoded in an XML
+      element of the form <code>&lt;cenc:pssh (base64 'pssh')&gt;</code>. For example, [[MPEGDASH]]
+      manifests may provide 'pssh' boxes in this format, each contained in a ContentProtection
+      Descriptor element identified by a SystemID. These 'pssh' boxes may be decoded and
+      concatenated by an application to provide equivalent Initialization Data to that stored in
+      movie or movie fragment boxes. </p>
+  </section>
+  <section id="processing">
+    <h2>Processing</h2>
+    <p>When such Initialization Data is provided by the application, an implementation (the user
+      agent and/or CDM) MUST :</p>
+    <ol>
+      <li>
+        <p>Examine the series of 'pssh' boxes to find the <em>first</em> 'pssh' box that the CDM
+          instance supports. This includes checking the SystemID, box version, and system-specific
+          values.</p>
+      </li>
+      <li>
+        <p>If no such supported box is found, the provided data SHALL be considered "not supported
+          by the CDM."</p>
+      </li>
+    </ol>
+  </section>
+  <section id="clear-key">
+    <h3>Use with Clear Key</h3>
+    <p>When Initialization data is provided with <var>initDataType</var>
+      <code>"cenc"</code>, <a def-id="clear-key"></a> implementations MUST look for and use the PSSH
+      box with the <a href="#common-system">Common SystemID</a>.
+    </p>
+  </section>
+  <section id="common-system">
+    <h2>Common SystemID and PSSH Box Format</h2>
+    <p>This section defines a common open SystemID and PSSH box format. Key System implementations
+      supporting the <code>"cenc"</code> Initialization Data Format MUST support this SystemID and
+      format. Media resources for use with Encrypted Media Extensions SHOULD contain appropriate
+      PSSH box(es) for this SystemID. <p class="note"> Use of this SystemID is RECOMMENDED for
+        applications, packagers, and implementors. Use of other SystemIDs with the Encrypted Media
+        Extensions APIs is discouraged. 'pssh' box(es) for this SystemID SHOULD be included in all
+        new or repackaged content so that the content can be used with any compliant Key System. For
+        existing content, applications may alternatively obtain a 'pssh' box containing this
+        SystemID or another Initialization Data Type (e.g., <a
+          def-id="initdata-registry-keyids"></a> [[EME-STREAM-REGISTRY]]) from another source. </p>
+      <p class="note">Implementations MAY support other SystemIDs for backwards compatibility with
+        existing streams.</p>
       <section id="common-system-definition">
         <h3>Definition</h3>
         <p>The SystemID is <code>1077efec-c0b2-4d02-ace3-3c1e52e2fb4b</code>.</p>
-        <p>The PSSH box format is as follows. It follows version 1 of the 'pssh' box as defined in [[!CENC]].</p>
+        <p>The PSSH box format is as follows. It follows version 1 of the 'pssh' box as defined in
+          [[!CENC]].</p>
         <dl>
           <dt>version</dt>
-          <dd><code>1</code></dd>
+          <dd>
+            <code>1</code>
+          </dd>
           <dt>KID and KID_count</dt>
-          <dd>The <a def-id="key-id"></a>(s) represented by the PSSH box. For example, those key ID(s) used by the Movie ('moov') or Movie Fragment ('moof').</dd>
+          <dd>The <a def-id="key-id"></a>(s) represented by the PSSH box. For example, those key
+            ID(s) used by the Movie ('moov') or Movie Fragment ('moof').</dd>
           <dt>Data and DataSize</dt>
-          <dd>Reserved for future use. DataSize SHALL be set to <code>0</code> when constructing this box. When processing, if dataSize is non-zero the Data field SHALL be ignored.</dd>
+          <dd>Reserved for future use. DataSize SHALL be set to <code>0</code> when constructing
+            this box. When processing, if dataSize is non-zero the Data field SHALL be ignored.</dd>
         </dl>
       </section>
       <section class="informative">
         <h2>Example</h2>
         <p>The following example contains two key IDs.</p>
-          <pre class="example">
+        <pre class="example">
 var pssh = [
     0x00, 0x00, 0x00, 0x44, 0x70, 0x73, 0x73, 0x68, // BMFF box header (68 bytes, 'pssh')
     0x01, 0x00, 0x00, 0x00,                         // Full box header (version = 1, flags = 0)
@@ -184,6 +194,6 @@ var pssh = [
 ];
 </pre>
       </section>
+</body>
 
-  </body>
 </html>

--- a/format-registry/initdata/index-respec.html
+++ b/format-registry/initdata/index-respec.html
@@ -1,180 +1,197 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <title>Encrypted Media Extensions Initialization Data Format Registry</title>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
-    <script src="../../encrypted-media.js" class="remove"></script>
-    <script class="remove">
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <title>Encrypted Media Extensions Initialization Data Format Registry</title>
+  <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
+  <script src="../../encrypted-media.js" class="remove"></script>
+  <script class="remove">
     var respecConfig = {
       // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
       specStatus: "ED",
-
       // the specification's short name, as in https://www.w3.org/TR/short-name/
       shortName: "eme-initdata-registry",
-
       // if there a publicly available Editor's Draft, this is the link
       edDraftURI: "https://w3c.github.io/encrypted-media/format-registry/initdata/",
-
       // if this is a LCWD, uncomment and set the end of its review period
       // lcEnd: "2009-08-05",
-
       // editors, add as many as you like
       // only "name" is required
-      editors: [
-        { name: "Joey Parrish", w3cid: "105371",
-          company: "Google Inc.", companyURL: "https://www.google.com/" },
-        { name: "Greg Freedman",
-          company: "Netflix Inc.", companyURL: "https://www.netflix.com/" },
-      ],
-
-      formerEditors: [
-        { name: "Mark Watson", note: "Until September 2019", w3cid: "46379",
-          company: "Netflix Inc.", companyURL: "https://www.netflix.com/" },
-        { name: "David Dorwin", note: "Until September 2017", w3cid: "52505",
-          company: "Google Inc.", companyURL: "https://www.google.com/" },
-        { name: "Jerry Smith", note: "Until September 2017", w3cid: "60176",
-          company: "Microsoft Corporation", companyURL: "https://www.microsoft.com/" },
-        { name: "Adrian Bateman", note: "Until May 2014", w3cid: "42763",
-          company: "Microsoft Corporation", companyURL: "https://www.microsoft.com/" },
-      ],
-
-      otherLinks: [
-        { key: "Repository", href: "https://github.com/w3c/encrypted-media/" },
-      ],
-
+      editors: [{
+        name: "Joey Parrish",
+        w3cid: "105371",
+        company: "Google Inc.",
+        companyURL: "https://www.google.com/"
+      }, {
+        name: "Greg Freedman",
+        company: "Netflix Inc.",
+        companyURL: "https://www.netflix.com/"
+      }],
+      formerEditors: [{
+        name: "Mark Watson",
+        note: "Until September 2019",
+        w3cid: "46379",
+        company: "Netflix Inc.",
+        companyURL: "https://www.netflix.com/"
+      }, {
+        name: "David Dorwin",
+        note: "Until September 2017",
+        w3cid: "52505",
+        company: "Google Inc.",
+        companyURL: "https://www.google.com/"
+      }, {
+        name: "Jerry Smith",
+        note: "Until September 2017",
+        w3cid: "60176",
+        company: "Microsoft Corporation",
+        companyURL: "https://www.microsoft.com/"
+      }, {
+        name: "Adrian Bateman",
+        note: "Until May 2014",
+        w3cid: "42763",
+        company: "Microsoft Corporation",
+        companyURL: "https://www.microsoft.com/"
+      }],
+      otherLinks: [{
+        key: "Repository",
+        href: "https://github.com/w3c/encrypted-media/"
+      }],
       emeDefGroupName: "format-registry",
-      emeUnusedGroupNameExcludeList: [
-        "encrypted-media",
-        "eme-references-from-registry",
-      ],
-
+      emeUnusedGroupNameExcludeList: ["encrypted-media", "eme-references-from-registry", ],
       // name of the WG
       wg: "Media Working Group",
-
       // URI of the public WG page
       wgURI: "https://www.w3.org/media-wg/",
-
       // name (without the @w3c.org) of the public mailing to which comments are due
       wgPublicList: "public-media-wg",
-
       // URI of the patent status for this WG, for Rec-track documents
       // !!!! IMPORTANT !!!!
       // This is important for Rec-track documents, do not copy a patent URI from a random
       // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
       // Team Contact.
       wgPatentURI: "https://www.w3.org/2004/01/pp-impl/115198/status",
-
       noIDLIn: true,
-
       scheme: "https",
-
       // Empty definitions for objects declared in the document are here to
       // prevent error messages from being displayed for references to these objects.
       definitionMap: {},
-
-      preProcess: [ encryptedMediaPreProcessor ],
-
+      preProcess: [encryptedMediaPreProcessor],
       // Empty definitions for objects declared in the document are here to
       // prevent error messages from being displayed for references to these objects.
       definitionMap: {},
-
-      postProcess: [ encryptedMediaPostProcessor ],
+      postProcess: [encryptedMediaPostProcessor],
     };
-    </script>
-    <!-- script to register bugs -->
-    <!-- Disabled unless/until it supports GitHub issues.
-    <script src="https://w3c.github.io/webcomponents/assets/scripts/bug-assist.js"></script>
-    <meta name="bug.product" content="HTML WG">
-    <meta name="bug.component" content="Encrypted Media Extensions">
-    -->
+  </script>
+  <style type="text/css">
+    #registry table {
+      border-collapse: collapse;
+      border-style: hidden hidden none hidden;
+    }
 
-    <style type="text/css">
-      #registry table { border-collapse: collapse; border-style: hidden hidden none hidden; }
-      #registry table thead, table tbody { border-bottom: solid; }
-      #registry table tbody th:first-child { border-left: solid; }
-      #registry table tbody th { text-align: left; }
-      #registry table td, table th { border-left: solid; border-right: solid; border-bottom: solid thin; vertical-align: top; padding: 0.2em; }
-    </style>
-  </head>
-  <body>
+    #registry table thead,
+    table tbody {
+      border-bottom: solid;
+    }
 
-    <section id="abstract">
-      <p>This specification defines the <a def-id="initialization-data"></a> formats for use with the <a def-id="eme-spec"></a> [[!ENCRYPTED-MEDIA]].</p>
+    #registry table tbody th:first-child {
+      border-left: solid;
+    }
 
-      <p>Some formats may be extracted from <a def-id="media-data"></a> [[HTML5]] as defined in the <a def-id="stream-registry"></a> [[EME-STREAM-REGISTRY]].
-        All may be provided separately, such as via a manifest or other application data.
-      </p>
-    </section>
+    #registry table tbody th {
+      text-align: left;
+    }
 
-    <section id="sotd">
-    </section>
+    #registry table td,
+    table th {
+      border-left: solid;
+      border-right: solid;
+      border-bottom: solid thin;
+      vertical-align: top;
+      padding: 0.2em;
+    }
 
-    <section id="purpose">
-      <h2>Purpose</h2>
-      <p>This registry is intended to enhance interoperability among implementations and users of encrypted media streams with the
-        <a def-id="eme-spec"></a> (EME) specification [[!ENCRYPTED-MEDIA]]. In particular, this registry provides the means (1) to identify
-        and avoid collisions among initialization data type strings, and (2) to disclose information about initialization data formats accepted by EME
-        implementations to promote interoperability.
-    </section>
+  </style>
+</head>
 
-    <section id="organization">
-      <h2>Organization</h2>
-      <p>The registry maintains a mapping between <a def-id="initialization-data-type"></a> strings and format specifications, which describe the structure and semantics of initialization data.
-        The strings are those used for <code>initDataType</code> values provided by and to <a def-id="eme-spec"></a> [[!ENCRYPTED-MEDIA]] APIs.
-      </p>
-      <p>This registry is not intended to include any information on whether a format is encumbered by intellectual property claims. Implementors and users
-        are advised to seek appropriate legal counsel in this matter if they intend to implement or use a specific format.</p>
-    </section>
+<body>
+  <section id="abstract">
+    <p>This specification defines the <a def-id="initialization-data"></a> formats for use with the
+      <a def-id="eme-spec"></a> [[!ENCRYPTED-MEDIA]].</p>
+    <p>Some formats may be extracted from <a def-id="media-data"></a> [[HTML5]] as defined in the <a
+        def-id="stream-registry"></a> [[EME-STREAM-REGISTRY]]. All may be provided separately, such
+      as via a manifest or other application data. </p>
+  </section>
+  <section id="sotd">
+  </section>
+  <section id="purpose">
+    <h2>Purpose</h2>
+    <p>This registry is intended to enhance interoperability among implementations and users of
+      encrypted media streams with the <a def-id="eme-spec"></a> (EME) specification
+      [[!ENCRYPTED-MEDIA]]. In particular, this registry provides the means (1) to identify and
+      avoid collisions among initialization data type strings, and (2) to disclose information about
+      initialization data formats accepted by EME implementations to promote interoperability.
+  </section>
+  <section id="organization">
+    <h2>Organization</h2>
+    <p>The registry maintains a mapping between <a def-id="initialization-data-type"></a> strings
+      and format specifications, which describe the structure and semantics of initialization data.
+      The strings are those used for <code>initDataType</code> values provided by and to <a
+        def-id="eme-spec"></a> [[!ENCRYPTED-MEDIA]] APIs. </p>
+    <p>This registry is not intended to include any information on whether a format is encumbered by
+      intellectual property claims. Implementors and users are advised to seek appropriate legal
+      counsel in this matter if they intend to implement or use a specific format.</p>
+  </section>
+  <section id="entry-requirements">
+    <h2>Registration Entry Requirements</h2>
+    <ol>
+      <li>
+        <p>Each entry must include a unique <a def-id="initialization-data-type"></a> string.</p>
+      </li>
+      <li>
+        <p>Each entry must include a link that references a publicly available specification. It is
+          RECOMMENDED that such a specification be made available without cost (other than
+          reasonable shipping and handling if not available by online means). </p>
+      </li>
+      <li>
+        <p>Candidate entries must be announced on <a
+            href="mailto:public-media-wg@w3.org">public-media-wg@w3.org</a>(<a
+            href="mailto:public-media-wg-request@w3.org">subscribe</a>, <a
+            href="https://lists.w3.org/Archives/Public/public-media-wg/">archives</a>) so they can
+          be discussed and evaluated for compliance before being added to the registry. </p>
+      </li>
+      <li>
+        <p>Per the <a def-id="eme-spec"></a> specification, entries MUST be fully specified and
+          support common formats such that instances of the format can be processed in a fully
+          specified and compatible way.</p>
+      </li>
+    </ol>
+  </section>
+  <section id="registry">
+    <h2>Registry</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Initialization Data Type</th>
+          <th>Public Specification(s)</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td> cenc </td>
+          <td><a def-id='initdata-registry-cenc'></a> [[!EME-INITDATA-CENC]]</td>
+        </tr>
+        <tr>
+          <td> keyids </td>
+          <td><a def-id="initdata-registry-keyids"></a> [[!EME-INITDATA-KEYIDS]]</td>
+        </tr>
+        <tr>
+          <td> webm </td>
+          <td><a def-id="initdata-registry-webm"></a> [[!EME-INITDATA-WEBM]]</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+</body>
 
-    <section id="entry-requirements">
-      <h2>Registration Entry Requirements</h2>
-      <ol>
-        <li><p>Each entry must include a unique <a def-id="initialization-data-type"></a> string.</p></li>
-        <li>
-          <p>Each entry must include a link that references a publicly available specification.
-            It is RECOMMENDED that such a specification be made available without cost (other than reasonable shipping and handling if not available by online means).
-          </p>
-        </li>
-        <li>
-          <p>Candidate entries must be announced on <a href="mailto:public-media-wg@w3.org">public-media-wg@w3.org</a>(<a href="mailto:public-media-wg-request@w3.org">subscribe</a>,
-            <a href="https://lists.w3.org/Archives/Public/public-media-wg/">archives</a>) so they can be discussed and evaluated for compliance before being added to the registry.
-          </p>
-        </li>
-        <li><p>Per the <a def-id="eme-spec"></a> specification, entries MUST be fully specified and support common formats such that instances of the format can be processed in a fully specified and compatible way.</p></li>
-      </ol>
-    </section>
-
-    <section id="registry">
-      <h2>Registry</h2>
-      <table>
-        <thead>
-          <tr>
-            <th>Initialization Data Type</th>
-            <th>Public Specification(s)</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              cenc
-            </td>
-            <td><a def-id='initdata-registry-cenc'></a> [[!EME-INITDATA-CENC]]</td>
-          </tr>
-          <tr>
-            <td>
-              keyids
-            </td>
-            <td><a def-id="initdata-registry-keyids"></a> [[!EME-INITDATA-KEYIDS]]</td>
-          </tr>
-          <tr>
-            <td>
-              webm
-            </td>
-            <td><a def-id="initdata-registry-webm"></a> [[!EME-INITDATA-WEBM]]</td>
-          </tr>
-        </tbody>
-      </table>
-    </section>
-  </body>
 </html>

--- a/format-registry/initdata/keyids-respec.html
+++ b/format-registry/initdata/keyids-respec.html
@@ -1,118 +1,116 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <title>"keyids" Initialization Data Format</title>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
-    <script src="../../encrypted-media.js" class="remove"></script>
-    <script class="remove">
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <title>"keyids" Initialization Data Format</title>
+  <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
+  <script src="../../encrypted-media.js" class="remove"></script>
+  <script class="remove">
     var respecConfig = {
       // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
       specStatus: "ED",
-
       // the specification's short name, as in https://www.w3.org/TR/short-name/
       shortName: "eme-initdata-keyids",
-
       // if there a publicly available Editor's Draft, this is the link
       edDraftURI: "https://w3c.github.io/encrypted-media/format-registry/initdata/keyids.html",
-
       // if this is a LCWD, uncomment and set the end of its review period
       // lcEnd: "2009-08-05",
-
       // editors, add as many as you like
       // only "name" is required
-      editors: [
-        { name: "Joey Parrish", w3cid: "105371",
-          company: "Google Inc.", companyURL: "https://www.google.com/" },
-        { name: "Greg Freedman",
-          company: "Netflix Inc.", companyURL: "https://www.netflix.com/" },
-      ],
-
-      formerEditors: [
-        { name: "Mark Watson", note: "Until September 2019", w3cid: "46379",
-          company: "Netflix Inc.", companyURL: "https://www.netflix.com/" },
-        { name: "David Dorwin", note: "Until September 2017", w3cid: "52505",
-          company: "Google Inc.", companyURL: "https://www.google.com/" },
-        { name: "Jerry Smith", note: "Until September 2017", w3cid: "60176",
-          company: "Microsoft Corporation", companyURL: "https://www.microsoft.com/" },
-        { name: "Adrian Bateman", note: "Until May 2014", w3cid: "42763",
-          company: "Microsoft Corporation", companyURL: "https://www.microsoft.com/" },
-      ],
-
-      otherLinks: [
-        { key: "Repository", href: "https://github.com/w3c/encrypted-media/" },
-      ],
-
+      editors: [{
+        name: "Joey Parrish",
+        w3cid: "105371",
+        company: "Google Inc.",
+        companyURL: "https://www.google.com/"
+      }, {
+        name: "Greg Freedman",
+        company: "Netflix Inc.",
+        companyURL: "https://www.netflix.com/"
+      }],
+      formerEditors: [{
+        name: "Mark Watson",
+        note: "Until September 2019",
+        w3cid: "46379",
+        company: "Netflix Inc.",
+        companyURL: "https://www.netflix.com/"
+      }, {
+        name: "David Dorwin",
+        note: "Until September 2017",
+        w3cid: "52505",
+        company: "Google Inc.",
+        companyURL: "https://www.google.com/"
+      }, {
+        name: "Jerry Smith",
+        note: "Until September 2017",
+        w3cid: "60176",
+        company: "Microsoft Corporation",
+        companyURL: "https://www.microsoft.com/"
+      }, {
+        name: "Adrian Bateman",
+        note: "Until May 2014",
+        w3cid: "42763",
+        company: "Microsoft Corporation",
+        companyURL: "https://www.microsoft.com/"
+      }],
+      otherLinks: [{
+        key: "Repository",
+        href: "https://github.com/w3c/encrypted-media/"
+      }],
       emeDefGroupName: "keyids-format",
-      emeUnusedGroupNameExcludeList: [
-        "encrypted-media",
-        "eme-references-from-registry",
-      ],
-
+      emeUnusedGroupNameExcludeList: ["encrypted-media", "eme-references-from-registry", ],
       // name of the WG
       wg: "Media Working Group",
-
       // URI of the public WG page
       wgURI: "https://www.w3.org/media-wg/",
-
       // name (without the @w3c.org) of the public mailing to which comments are due
       wgPublicList: "public-media-wg",
-
       // URI of the patent status for this WG, for Rec-track documents
       // !!!! IMPORTANT !!!!
       // This is important for Rec-track documents, do not copy a patent URI from a random
       // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
       // Team Contact.
       wgPatentURI: "https://www.w3.org/2004/01/pp-impl/115198/status",
-
       noIDLIn: true,
-
       scheme: "https",
-
-      preProcess: [ encryptedMediaPreProcessor ],
-
+      preProcess: [encryptedMediaPreProcessor],
       // Empty definitions for objects declared in the document are here to
       // prevent error messages from being displayed for references to these objects.
       definitionMap: {},
-
-      postProcess: [ encryptedMediaPostProcessor ],
+      postProcess: [encryptedMediaPostProcessor],
     };
-    </script>
-    <!-- script to register bugs -->
-    <!-- Disabled unless/until it supports GitHub issues.
-    <script src="https://w3c.github.io/webcomponents/assets/scripts/bug-assist.js"></script>
-    <meta name="bug.product" content="HTML WG">
-    <meta name="bug.component" content="Encrypted Media Extensions">
-    -->
+  </script>
+</head>
 
-  </head>
-  <body>
-    <section id="abstract">
-      <p>This specification defines the <code>"keyids"</code> <a def-id="initialization-data"></a> format for use with the <a def-id="eme-spec"></a> [[!ENCRYPTED-MEDIA]].</p>
-      <p class="note">It defines a stream format-independent format for specifying a list of <a def-id="key-id"></a>(s).
-      This type can be used by applications to directly provide information necessary to generate a license request without using media data or constructing container-specific formats.
-      </p>
-    </section>
-
-    <section id="sotd">
-    </section>
-
-    <section id="format">
-      <h2>Format</h2>
-      <p>The format is a JSON object, encoded in UTF-8 as specified in the Encoding specification [[!encoding]], containing the following member:</p>
-      <dl>
-        <dt>"kids"</dt>
-        <dd>An array of <a def-id="key-id"></a>(s). Each element of the array is the base64url encoding of the octet sequence containing the key ID value.</dd>
-      </dl>
-
-      <p class="note">See <a def-id="using-base64url"></a>.</p>
-      <p class="note">Applications may encode the JSON string using the <a def-id="interface-textencoder"></a> [[encoding]]</p>
-    </section>
-
-    <section class="informative">
-      <h2>Example</h2>
-      <p>The following example will generate a license request for two <a def-id="key-id"></a>(s). (Line breaks are for readability only.)</p>
-        <pre class="example">
+<body>
+  <section id="abstract">
+    <p>This specification defines the <code>"keyids"</code> <a def-id="initialization-data"></a>
+      format for use with the <a def-id="eme-spec"></a> [[!ENCRYPTED-MEDIA]].</p>
+    <p class="note">It defines a stream format-independent format for specifying a list of <a
+        def-id="key-id"></a>(s). This type can be used by applications to directly provide
+      information necessary to generate a license request without using media data or constructing
+      container-specific formats. </p>
+  </section>
+  <section id="sotd">
+  </section>
+  <section id="format">
+    <h2>Format</h2>
+    <p>The format is a JSON object, encoded in UTF-8 as specified in the Encoding specification
+      [[!encoding]], containing the following member:</p>
+    <dl>
+      <dt>"kids"</dt>
+      <dd>An array of <a def-id="key-id"></a>(s). Each element of the array is the base64url
+        encoding of the octet sequence containing the key ID value.</dd>
+    </dl>
+    <p class="note">See <a def-id="using-base64url"></a>.</p>
+    <p class="note">Applications may encode the JSON string using the <a
+        def-id="interface-textencoder"></a> [[encoding]]</p>
+  </section>
+  <section class="informative">
+    <h2>Example</h2>
+    <p>The following example will generate a license request for two <a def-id="key-id"></a>(s).
+      (Line breaks are for readability only.)</p>
+    <pre class="example">
 {
   "kids":
     [
@@ -120,7 +118,7 @@
      "0DdtU9od-Bh5L3xbv0Xf_A"
     ],
 }</pre>
-    </section>
+  </section>
+</body>
 
-  </body>
 </html>

--- a/format-registry/initdata/webm-respec.html
+++ b/format-registry/initdata/webm-respec.html
@@ -1,86 +1,86 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <title>"webm" Initialization Data Format</title>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
-    <script src="../../encrypted-media.js" class="remove"></script>
-    <script class="remove">
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <title>"webm" Initialization Data Format</title>
+  <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
+  <script src="../../encrypted-media.js" class="remove"></script>
+  <script class="remove">
     var respecConfig = {
       // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
       specStatus: "ED",
-
       // the specification's short name, as in https://www.w3.org/TR/short-name/
       shortName: "eme-initdata-webm",
-
       // if there a publicly available Editor's Draft, this is the link
       edDraftURI: "https://w3c.github.io/encrypted-media/format-registry/initdata/webm.html",
-
       // if this is a LCWD, uncomment and set the end of its review period
       // lcEnd: "2009-08-05",
-
       // editors, add as many as you like
       // only "name" is required
-      editors: [
-        { name: "Joey Parrish", w3cid: "105371",
-          company: "Google Inc.", companyURL: "https://www.google.com/" },
-        { name: "Greg Freedman",
-          company: "Netflix Inc.", companyURL: "https://www.netflix.com/" },
-      ],
-
-      formerEditors: [
-        { name: "Mark Watson", note: "Until September 2019", w3cid: "46379",
-          company: "Netflix Inc.", companyURL: "https://www.netflix.com/" },
-        { name: "David Dorwin", note: "Until September 2017", w3cid: "52505",
-          company: "Google Inc.", companyURL: "https://www.google.com/" },
-        { name: "Jerry Smith", note: "Until September 2017", w3cid: "60176",
-          company: "Microsoft Corporation", companyURL: "https://www.microsoft.com/" },
-        { name: "Adrian Bateman", note: "Until May 2014", w3cid: "42763",
-          company: "Microsoft Corporation", companyURL: "https://www.microsoft.com/" },
-      ],
-
-      otherLinks: [
-        { key: "Repository", href: "https://github.com/w3c/encrypted-media/" },
-      ],
-
+      editors: [{
+        name: "Joey Parrish",
+        w3cid: "105371",
+        company: "Google Inc.",
+        companyURL: "https://www.google.com/"
+      }, {
+        name: "Greg Freedman",
+        company: "Netflix Inc.",
+        companyURL: "https://www.netflix.com/"
+      }],
+      formerEditors: [{
+        name: "Mark Watson",
+        note: "Until September 2019",
+        w3cid: "46379",
+        company: "Netflix Inc.",
+        companyURL: "https://www.netflix.com/"
+      }, {
+        name: "David Dorwin",
+        note: "Until September 2017",
+        w3cid: "52505",
+        company: "Google Inc.",
+        companyURL: "https://www.google.com/"
+      }, {
+        name: "Jerry Smith",
+        note: "Until September 2017",
+        w3cid: "60176",
+        company: "Microsoft Corporation",
+        companyURL: "https://www.microsoft.com/"
+      }, {
+        name: "Adrian Bateman",
+        note: "Until May 2014",
+        w3cid: "42763",
+        company: "Microsoft Corporation",
+        companyURL: "https://www.microsoft.com/"
+      }],
+      otherLinks: [{
+        key: "Repository",
+        href: "https://github.com/w3c/encrypted-media/"
+      }],
       emeDefGroupName: "webm-format",
-      emeUnusedGroupNameExcludeList: [
-        "encrypted-media",
-        "eme-references-from-registry",
-      ],
-
+      emeUnusedGroupNameExcludeList: ["encrypted-media", "eme-references-from-registry", ],
       // name of the WG
       wg: "Media Working Group",
-
       // URI of the public WG page
       wgURI: "https://www.w3.org/media-wg/",
-
       // name (without the @w3c.org) of the public mailing to which comments are due
       wgPublicList: "public-media-wg",
-
       // URI of the patent status for this WG, for Rec-track documents
       // !!!! IMPORTANT !!!!
       // This is important for Rec-track documents, do not copy a patent URI from a random
       // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
       // Team Contact.
       wgPatentURI: "https://www.w3.org/2004/01/pp-impl/115198/status",
-
       noIDLIn: true,
-
       scheme: "https",
-
       // Empty definitions for objects declared in the document are here to
       // prevent error messages from being displayed for references to these objects.
       definitionMap: {},
-
-      preProcess: [ encryptedMediaPreProcessor ],
-
+      preProcess: [encryptedMediaPreProcessor],
       // Empty definitions for objects declared in the document are here to
       // prevent error messages from being displayed for references to these objects.
       definitionMap: {},
-
-      postProcess: [ encryptedMediaPostProcessor ],
-
+      postProcess: [encryptedMediaPostProcessor],
       localBiblio: {
         "WebM-Encryption": {
           title: "WebM Encryption",
@@ -91,28 +91,23 @@
         },
       },
     };
-    </script>
-    <!-- script to register bugs -->
-    <!-- Disabled unless/until it supports GitHub issues.
-    <script src="https://w3c.github.io/webcomponents/assets/scripts/bug-assist.js"></script>
-    <meta name="bug.product" content="HTML WG">
-    <meta name="bug.component" content="Encrypted Media Extensions">
-    -->
+  </script>
+</head>
 
-  </head>
-  <body>
-    <section id="abstract">
-      <p>This specification defines the <code>"webm"</code> <a def-id="initialization-data"></a> format for use with the <a def-id="eme-spec"></a> [[!ENCRYPTED-MEDIA]].
-        This format is commonly used with the <a def-id="stream-registry-webm"></a> [[EME-STREAM-REGISTRY]].
-      </p>
-    </section>
+<body>
+  <section id="abstract">
+    <p>This specification defines the <code>"webm"</code> <a def-id="initialization-data"></a>
+      format for use with the <a def-id="eme-spec"></a> [[!ENCRYPTED-MEDIA]]. This format is
+      commonly used with the <a def-id="stream-registry-webm"></a> [[EME-STREAM-REGISTRY]]. </p>
+  </section>
+  <section id="sotd">
+  </section>
+  <section id="format">
+    <h2>Format</h2>
+    <p>The format is a single <a def-id="key-id"></a> of one or more bytes, as defined by the <a
+        href="https://matroska.org/technical/specs/index.html#ContentEncKeyID">ContentEncKeyID</a>
+      [[!Matroska]] element and [[!WebM-Encryption]].</p>
+  </section>
+</body>
 
-    <section id="sotd">
-    </section>
-
-    <section id="format">
-      <h2>Format</h2>
-      <p>The format is a single <a def-id="key-id"></a> of one or more bytes, as defined by the <a href="https://matroska.org/technical/specs/index.html#ContentEncKeyID">ContentEncKeyID</a> [[!Matroska]] element and [[!WebM-Encryption]].</p>
-    </section>
-  </body>
 </html>

--- a/format-registry/stream/index-respec.html
+++ b/format-registry/stream/index-respec.html
@@ -1,173 +1,197 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <title>Encrypted Media Extensions Stream Format Registry</title>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
-    <script src="../../encrypted-media.js" class="remove"></script>
-    <script class="remove">
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <title>Encrypted Media Extensions Stream Format Registry</title>
+  <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
+  <script src="../../encrypted-media.js" class="remove"></script>
+  <script class="remove">
     var respecConfig = {
       // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
       specStatus: "ED",
-
       // the specification's short name, as in https://www.w3.org/TR/short-name/
       shortName: "eme-stream-registry",
-
       // if there a publicly available Editor's Draft, this is the link
       edDraftURI: "https://w3c.github.io/encrypted-media/format-registry/stream/",
-
       // if this is a LCWD, uncomment and set the end of its review period
       // lcEnd: "2009-08-05",
-
       // editors, add as many as you like
       // only "name" is required
-      editors: [
-        { name: "Joey Parrish", w3cid: "105371",
-          company: "Google Inc.", companyURL: "https://www.google.com/" },
-        { name: "Greg Freedman",
-          company: "Netflix Inc.", companyURL: "https://www.netflix.com/" },
-      ],
-
-      formerEditors: [
-        { name: "Mark Watson", note: "Until September 2019", w3cid: "46379",
-          company: "Netflix Inc.", companyURL: "https://www.netflix.com/" },
-        { name: "David Dorwin", note: "Until September 2017", w3cid: "52505",
-          company: "Google Inc.", companyURL: "https://www.google.com/" },
-        { name: "Jerry Smith", note: "Until September 2017", w3cid: "60176",
-          company: "Microsoft Corporation", companyURL: "https://www.microsoft.com/" },
-        { name: "Adrian Bateman", note: "Until May 2014", w3cid: "42763",
-          company: "Microsoft Corporation", companyURL: "https://www.microsoft.com/" },
-      ],
-
-      otherLinks: [
-        { key: "Repository", href: "https://github.com/w3c/encrypted-media/" },
-      ],
-
+      editors: [{
+        name: "Joey Parrish",
+        w3cid: "105371",
+        company: "Google Inc.",
+        companyURL: "https://www.google.com/"
+      }, {
+        name: "Greg Freedman",
+        company: "Netflix Inc.",
+        companyURL: "https://www.netflix.com/"
+      }],
+      formerEditors: [{
+        name: "Mark Watson",
+        note: "Until September 2019",
+        w3cid: "46379",
+        company: "Netflix Inc.",
+        companyURL: "https://www.netflix.com/"
+      }, {
+        name: "David Dorwin",
+        note: "Until September 2017",
+        w3cid: "52505",
+        company: "Google Inc.",
+        companyURL: "https://www.google.com/"
+      }, {
+        name: "Jerry Smith",
+        note: "Until September 2017",
+        w3cid: "60176",
+        company: "Microsoft Corporation",
+        companyURL: "https://www.microsoft.com/"
+      }, {
+        name: "Adrian Bateman",
+        note: "Until May 2014",
+        w3cid: "42763",
+        company: "Microsoft Corporation",
+        companyURL: "https://www.microsoft.com/"
+      }],
+      otherLinks: [{
+        key: "Repository",
+        href: "https://github.com/w3c/encrypted-media/"
+      }],
       emeDefGroupName: "format-registry",
-      emeUnusedGroupNameExcludeList: [
-        "encrypted-media",
-        "eme-references-from-registry",
-      ],
-
+      emeUnusedGroupNameExcludeList: ["encrypted-media", "eme-references-from-registry", ],
       // name of the WG
       wg: "Media Working Group",
-
       // URI of the public WG page
       wgURI: "https://www.w3.org/media-wg/",
-
       // name (without the @w3c.org) of the public mailing to which comments are due
       wgPublicList: "public-media-wg",
-
       // URI of the patent status for this WG, for Rec-track documents
       // !!!! IMPORTANT !!!!
       // This is important for Rec-track documents, do not copy a patent URI from a random
       // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
       // Team Contact.
       wgPatentURI: "https://www.w3.org/2004/01/pp-impl/115198/status",
-
       noIDLIn: true,
-
       scheme: "https",
-
       // Empty definitions for objects declared in the document are here to
       // prevent error messages from being displayed for references to these objects.
       definitionMap: {},
-
-      preProcess: [ encryptedMediaPreProcessor ],
-
+      preProcess: [encryptedMediaPreProcessor],
       // Empty definitions for objects declared in the document are here to
       // prevent error messages from being displayed for references to these objects.
       definitionMap: {},
-
-      postProcess: [ encryptedMediaPostProcessor ],
+      postProcess: [encryptedMediaPostProcessor],
     };
-    </script>
-    <!-- script to register bugs -->
-    <!-- Disabled unless/until it supports GitHub issues.
-    <script src="https://w3c.github.io/webcomponents/assets/scripts/bug-assist.js"></script>
-    <meta name="bug.product" content="HTML WG">
-    <meta name="bug.component" content="Encrypted Media Extensions">
-    -->
+  </script>
+  <style type="text/css">
+    #registry table {
+      border-collapse: collapse;
+      border-style: hidden hidden none hidden;
+    }
 
-    <style type="text/css">
-      #registry table { border-collapse: collapse; border-style: hidden hidden none hidden; }
-      #registry table thead, table tbody { border-bottom: solid; }
-      #registry table tbody th:first-child { border-left: solid; }
-      #registry table tbody th { text-align: left; }
-      #registry table td, table th { border-left: solid; border-right: solid; border-bottom: solid thin; vertical-align: top; padding: 0.2em; }
-    </style>
-  </head>
-  <body>
+    #registry table thead,
+    table tbody {
+      border-bottom: solid;
+    }
 
-    <section id="abstract">
-      <p>This specification defines the stream formats for use with the <a def-id="eme-spec"></a> [[!ENCRYPTED-MEDIA]].</p>
-    </section>
+    #registry table tbody th:first-child {
+      border-left: solid;
+    }
 
-    <section id="sotd">
-    </section>
+    #registry table tbody th {
+      text-align: left;
+    }
 
-    <section id="purpose">
-      <h2>Purpose</h2>
-      <p>This registry is intended to enhance interoperability among implementations and users of encrypted media streams with the
-        <a def-id="eme-spec"></a> (EME) specification [[!ENCRYPTED-MEDIA]]. In particular, this registry provides the means (1) to identify
-        and avoid collisions among content type strings, and (2) to disclose information about encrypted data formats accepted by EME
-        implementations to promote interoperability.
-    </section>
+    #registry table td,
+    table th {
+      border-left: solid;
+      border-right: solid;
+      border-bottom: solid thin;
+      vertical-align: top;
+      padding: 0.2em;
+    }
 
-    <section id="organization">
-      <h2>Organization</h2>
-      <p>The registry maintains a mapping between content type strings and encryption format specifications, which describe the structure, semantics, and processing of the formats.
-        The strings are those used for the media type/subtype pairs in <code>contentType</code> values provided to <a def-id="eme-spec"></a> [[!ENCRYPTED-MEDIA]] APIs.
-      </p>
-      <p>This registry is not intended to include any information on whether a stream format is encumbered by intellectual property claims. Implementors and users
-        are advised to seek appropriate legal counsel in this matter if they intend to implement or use a specific stream format.</p>
-    </section>
+  </style>
+</head>
 
-    <section id="entry-requirements">
-      <h2>Registration Entry Requirements</h2>
-      <ol>
-        <li><p>Each entry must include a unique <a def-id="initialization-data-type"></a> string.</p></li>
-        <li>
-          <p>Each entry must include a link that references a publicly available specification.
-            It is RECOMMENDED that such a specification be made available without cost (other than reasonable shipping and handling if not available by online means).
-          </p>
-        </li>
-        <li>
-          <p>Candidate entries must be announced on <a href="mailto:public-media-wg@w3.org">public-media-wg@w3.org</a>(<a href="mailto:public-media-wg-request@w3.org">subscribe</a>,
-            <a href="https://lists.w3.org/Archives/Public/public-media-wg/">archives</a>) so they can be discussed and evaluated for compliance before being added to the registry.
-          </p>
-        </li>
-        <li><p>Per the <a def-id="eme-spec"></a> specification, the media container for a stream format MUST NOT be encrypted.</p></li>
-        <li><p>Per the <a def-id="eme-spec"></a> specification, entries MUST be fully specified and support "common encryption" such that the content can decrypted in a fully specified and compatible way when a key or keys are provided.</p></li>
-      </ol>
-    </section>
+<body>
+  <section id="abstract">
+    <p>This specification defines the stream formats for use with the <a def-id="eme-spec"></a>
+      [[!ENCRYPTED-MEDIA]].</p>
+  </section>
+  <section id="sotd">
+  </section>
+  <section id="purpose">
+    <h2>Purpose</h2>
+    <p>This registry is intended to enhance interoperability among implementations and users of
+      encrypted media streams with the <a def-id="eme-spec"></a> (EME) specification
+      [[!ENCRYPTED-MEDIA]]. In particular, this registry provides the means (1) to identify and
+      avoid collisions among content type strings, and (2) to disclose information about encrypted
+      data formats accepted by EME implementations to promote interoperability.
+  </section>
+  <section id="organization">
+    <h2>Organization</h2>
+    <p>The registry maintains a mapping between content type strings and encryption format
+      specifications, which describe the structure, semantics, and processing of the formats. The
+      strings are those used for the media type/subtype pairs in <code>contentType</code> values
+      provided to <a def-id="eme-spec"></a> [[!ENCRYPTED-MEDIA]] APIs. </p>
+    <p>This registry is not intended to include any information on whether a stream format is
+      encumbered by intellectual property claims. Implementors and users are advised to seek
+      appropriate legal counsel in this matter if they intend to implement or use a specific stream
+      format.</p>
+  </section>
+  <section id="entry-requirements">
+    <h2>Registration Entry Requirements</h2>
+    <ol>
+      <li>
+        <p>Each entry must include a unique <a def-id="initialization-data-type"></a> string.</p>
+      </li>
+      <li>
+        <p>Each entry must include a link that references a publicly available specification. It is
+          RECOMMENDED that such a specification be made available without cost (other than
+          reasonable shipping and handling if not available by online means). </p>
+      </li>
+      <li>
+        <p>Candidate entries must be announced on <a
+            href="mailto:public-media-wg@w3.org">public-media-wg@w3.org</a>(<a
+            href="mailto:public-media-wg-request@w3.org">subscribe</a>, <a
+            href="https://lists.w3.org/Archives/Public/public-media-wg/">archives</a>) so they can
+          be discussed and evaluated for compliance before being added to the registry. </p>
+      </li>
+      <li>
+        <p>Per the <a def-id="eme-spec"></a> specification, the media container for a stream format
+          MUST NOT be encrypted.</p>
+      </li>
+      <li>
+        <p>Per the <a def-id="eme-spec"></a> specification, entries MUST be fully specified and
+          support "common encryption" such that the content can decrypted in a fully specified and
+          compatible way when a key or keys are provided.</p>
+      </li>
+    </ol>
+  </section>
+  <section id="registry">
+    <h2>Registry</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>MIME type/subtype</th>
+          <th>Public Specification(s)</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td> audio/mp4
+            <br />video/mp4 </td>
+          <td><a def-id="stream-registry-mp4"></a> [[!EME-STREAM-MP4]]</td>
+        </tr>
+        <tr>
+          <td> audio/webm
+            <br />video/webm </td>
+          <td><a def-id="stream-registry-webm"></a> [[!EME-STREAM-WEBM]]</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+</body>
 
-    <section id="registry">
-      <h2>Registry</h2>
-      <table>
-        <thead>
-          <tr>
-            <th>MIME type/subtype</th>
-            <th>Public Specification(s)</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              audio/mp4
-              <br/>video/mp4
-            </td>
-            <td><a def-id="stream-registry-mp4"></a> [[!EME-STREAM-MP4]]</td>
-          </tr>
-          <tr>
-            <td>
-              audio/webm
-              <br/>video/webm
-            </td>
-            <td><a def-id="stream-registry-webm"></a> [[!EME-STREAM-WEBM]]</td>
-          </tr>
-        </tbody>
-      </table>
-    </section>
-  </body>
 </html>

--- a/format-registry/stream/mp4-respec.html
+++ b/format-registry/stream/mp4-respec.html
@@ -1,86 +1,87 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <title>ISO Common Encryption Protection Scheme for ISO Base Media File Format Stream Format</title>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
-    <script src="../../encrypted-media.js" class="remove"></script>
-    <script class="remove">
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <title>ISO Common Encryption Protection Scheme for ISO Base Media File Format Stream Format
+  </title>
+  <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
+  <script src="../../encrypted-media.js" class="remove"></script>
+  <script class="remove">
     var respecConfig = {
       // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
       specStatus: "ED",
-
       // the specification's short name, as in https://www.w3.org/TR/short-name/
       shortName: "eme-stream-mp4",
-
       // if there a publicly available Editor's Draft, this is the link
       edDraftURI: "https://w3c.github.io/encrypted-media/format-registry/stream/mp4.html",
-
       // if this is a LCWD, uncomment and set the end of its review period
       // lcEnd: "2009-08-05",
-
       // editors, add as many as you like
       // only "name" is required
-      editors: [
-        { name: "Joey Parrish", w3cid: "105371",
-          company: "Google Inc.", companyURL: "https://www.google.com/" },
-        { name: "Greg Freedman",
-          company: "Netflix Inc.", companyURL: "https://www.netflix.com/" },
-      ],
-
-      formerEditors: [
-        { name: "Mark Watson", note: "Until September 2019", w3cid: "46379",
-          company: "Netflix Inc.", companyURL: "https://www.netflix.com/" },
-        { name: "David Dorwin", note: "Until September 2017", w3cid: "52505",
-          company: "Google Inc.", companyURL: "https://www.google.com/" },
-        { name: "Jerry Smith", note: "Until September 2017", w3cid: "60176",
-          company: "Microsoft Corporation", companyURL: "https://www.microsoft.com/" },
-        { name: "Adrian Bateman", note: "Until May 2014", w3cid: "42763",
-          company: "Microsoft Corporation", companyURL: "https://www.microsoft.com/" },
-      ],
-
-      otherLinks: [
-        { key: "Repository", href: "https://github.com/w3c/encrypted-media/" },
-      ],
-
+      editors: [{
+        name: "Joey Parrish",
+        w3cid: "105371",
+        company: "Google Inc.",
+        companyURL: "https://www.google.com/"
+      }, {
+        name: "Greg Freedman",
+        company: "Netflix Inc.",
+        companyURL: "https://www.netflix.com/"
+      }],
+      formerEditors: [{
+        name: "Mark Watson",
+        note: "Until September 2019",
+        w3cid: "46379",
+        company: "Netflix Inc.",
+        companyURL: "https://www.netflix.com/"
+      }, {
+        name: "David Dorwin",
+        note: "Until September 2017",
+        w3cid: "52505",
+        company: "Google Inc.",
+        companyURL: "https://www.google.com/"
+      }, {
+        name: "Jerry Smith",
+        note: "Until September 2017",
+        w3cid: "60176",
+        company: "Microsoft Corporation",
+        companyURL: "https://www.microsoft.com/"
+      }, {
+        name: "Adrian Bateman",
+        note: "Until May 2014",
+        w3cid: "42763",
+        company: "Microsoft Corporation",
+        companyURL: "https://www.microsoft.com/"
+      }],
+      otherLinks: [{
+        key: "Repository",
+        href: "https://github.com/w3c/encrypted-media/"
+      }],
       emeDefGroupName: "mp4-stream-format",
-      emeUnusedGroupNameExcludeList: [
-        "encrypted-media",
-        "eme-references-from-registry",
-      ],
-
+      emeUnusedGroupNameExcludeList: ["encrypted-media", "eme-references-from-registry", ],
       // name of the WG
       wg: "Media Working Group",
-
       // URI of the public WG page
       wgURI: "https://www.w3.org/media-wg/",
-
       // name (without the @w3c.org) of the public mailing to which comments are due
       wgPublicList: "public-media-wg",
-
       // URI of the patent status for this WG, for Rec-track documents
       // !!!! IMPORTANT !!!!
       // This is important for Rec-track documents, do not copy a patent URI from a random
       // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
       // Team Contact.
       wgPatentURI: "https://www.w3.org/2004/01/pp-impl/115198/status",
-
       noIDLIn: true,
-
       scheme: "https",
-
       // Empty definitions for objects declared in the document are here to
       // prevent error messages from being displayed for references to these objects.
       definitionMap: {},
-
-      preProcess: [ encryptedMediaPreProcessor ],
-
+      preProcess: [encryptedMediaPreProcessor],
       // Empty definitions for objects declared in the document are here to
       // prevent error messages from being displayed for references to these objects.
       definitionMap: {},
-
-      postProcess: [ encryptedMediaPostProcessor ],
-
+      postProcess: [encryptedMediaPostProcessor],
       localBiblio: {
         "CENC": {
           title: "ISO/IEC 23001-7:2016, Information technology — MPEG systems technologies — Part 7: Common encryption in ISO Base Media File Format files",
@@ -90,121 +91,78 @@
         },
       },
     };
-    </script>
-    <!-- script to register bugs -->
-    <!-- Disabled unless/until it supports GitHub issues.
-    <script src="https://w3c.github.io/webcomponents/assets/scripts/bug-assist.js"></script>
-    <meta name="bug.product" content="HTML WG">
-    <meta name="bug.component" content="Encrypted Media Extensions">
-    -->
+  </script>
+</head>
 
-  </head>
-  <body>
-    <!-- TODO: Use styles for ISO boxes like the MSE registry. -->
-    <section id="abstract">
-      <p>
-        This specification defines the stream format for using ISO Base Media
-        File Format [[!ISOBMFF]] content that uses the ISO Common Encryption
-        protection schemes [[!CENC]] with the <a def-id="eme-spec"></a>
-        [[!ENCRYPTED-MEDIA]].
-      </p>
-      <p class="note">
-        Although the ISO Base Media File Format [[!ISOBMFF]] associated with
-        this format's MIME type/subtype strings supports multiple protection
-        schemes, when used with Encrypted Media Extensions, these strings refer
-        specifically to content encrypted and packaged using the 'cenc' or
-        'cbcs' protection schemes, as defined by section 4.2 of [[!CENC]].
-      </p>
-    </section>
+<body>
+  <!-- TODO: Use styles for ISO boxes like the MSE registry. -->
+  <section id="abstract">
+    <p> This specification defines the stream format for using ISO Base Media File Format
+      [[!ISOBMFF]] content that uses the ISO Common Encryption protection schemes [[!CENC]] with the
+      <a def-id="eme-spec"></a> [[!ENCRYPTED-MEDIA]]. </p>
+    <p class="note"> Although the ISO Base Media File Format [[!ISOBMFF]] associated with this
+      format's MIME type/subtype strings supports multiple protection schemes, when used with
+      Encrypted Media Extensions, these strings refer specifically to content encrypted and packaged
+      using the 'cenc' or 'cbcs' protection schemes, as defined by section 4.2 of [[!CENC]]. </p>
+  </section>
+  <section id="sotd">
+  </section>
+  <section id="stream-format">
+    <h2>Stream Format</h2>
+    <p> ISO Base Media File Format [[!ISOBMFF]] content that is encrypted using the ISO Common
+      Encryption protection schemes [[!CENC]] SHALL be encrypted at the sample level with either the
+      'cenc' (AES-128 CTR) or 'cbcs' (AES-128 CBC) encryption schemes, as defined in section 4.2 of
+      [[!CENC]]. These protection methods enabls multiple Key Systems to decrypt the same media
+      content. </p>
+    <p> Each key is identified by a <a def-id="key-id"></a> and each encrypted sample is associated
+      with the key ID of the key needed to decrypt it. This association is signaled either through
+      the specification of a default key ID in the track encryption box ('tenc') or by assigning the
+      sample to a Sample Group, the definition of which specifies a key ID. Streams may contain a
+      mixture of encrypted and unencrypted samples. </p>
+  </section>
+  <section id="detect-format">
+    <h2>Detection</h2>
+    <p> For a stream determined to be in the ISO Base Media File Format [[!ISOBMFF]], the ISO Common
+      Encryption protection schemes may be detected as follows. </p>
+    <p> Protection scheme signaling conforms with [[!ISOBMFF]]. When protection has been applied,
+      the stream type will be transformed to 'encv' for video or 'enca' for audio, with a Protection
+      Scheme Information Box ('sinf') added to the sample entry in the Sample Description Box
+      ('stsd'). The Protection Scheme Information Box ('sinf') will contain a Scheme Type Box
+      ('schm') with a scheme_type field set to a value of <code>'cenc'</code> or <code>'cbcs'</code>
+      . [[!CENC]] </p>
+  </section>
+  <section id="detect-encrypted-blocks">
+    <h2>Detecting Encrypted Blocks</h2>
+    <p> For the purposes of the <a def-id="encrypted-block-encountered-algorithm"></a>, encrypted
+      blocks are identified as follows. </p>
+    <p> The encrypted block is a sample. Determining whether a sample is encrypted depends on the
+      corresponding Track Encryption Box ('tenc') and the sample group with grouping type 'seig'
+      (CencSampleEncryption group), if any, associated with the sample. The default encryption state
+      of a sample is defined by the IsEncrypted flag in the associated track encryption box
+      ('tenc'). This default state may be modified by the IsEncrypted flag in the
+      SampleGroupDescriptionBox ('sgpd'), pointed to by an index in the SampleToGroupBox ('sbgp').
+    </p>
+    <p> Samples can be partially encrypted, specified by subsample information referenced by
+      SampleAuxiliaryInformationSizesBox ('saiz') and SampleAuxiliaryInformationOffsetsBox ('saio')
+      boxes. </p>
+    <p>For complete information, see [[!CENC]].</p>
+  </section>
+  <section id="init-data">
+    <h2>Initialization Data Extraction</h2>
+    <p> Streams may contain one or more Protection System Specific Header ('pssh') boxes [[!CENC]],
+      each for a unique SystemID, at each location where a 'pssh' box is necessary. Content using
+      this stream format SHOULD include a box containing the <a def-id="cenc-common-system"></a>.
+    </p>
+    <p>
+      <a def-id="initialization-data"></a> is always one or more concatenated 'pssh' boxes as
+      defined by the <a def-id="initdata-registry-cenc"></a> [[!EME-INITDATA-REGISTRY]]. </p>
+    <p> Each time one or more 'pssh' boxes are encountered, the <a
+        def-id="initdata-encountered-algorithm"></a> algorithm SHALL be invoked with <var title="">
+        initDataType</var> = <code>"<a def-id="initdata-registry-cenc">cenc</a>"</code>
+      [[!EME-INITDATA-REGISTRY]] and <var title="">initData</var> = the 'pssh' box(es). Multiple
+      'pssh' boxes MUST be provided together if and only if they appear directly next to each other
+      in the stream. </p>
+  </section>
+</body>
 
-    <section id="sotd">
-    </section>
-
-    <section id="stream-format">
-      <h2>Stream Format</h2>
-      <p>
-        ISO Base Media File Format [[!ISOBMFF]] content that is encrypted using
-        the ISO Common Encryption protection schemes [[!CENC]] SHALL be
-        encrypted at the sample level with either the 'cenc' (AES-128 CTR) or
-        'cbcs' (AES-128 CBC) encryption schemes, as defined in section 4.2 of
-        [[!CENC]].  These protection methods enabls multiple Key Systems to
-        decrypt the same media content.
-      </p>
-      <p>
-        Each key is identified by a <a def-id="key-id"></a> and each encrypted
-        sample is associated with the key ID of the key needed to decrypt it.
-        This association is signaled either through the specification of a
-        default key ID in the track encryption box ('tenc') or by assigning the
-        sample to a Sample Group, the definition of which specifies a key ID.
-        Streams may contain a mixture of encrypted and unencrypted samples.
-      </p>
-    </section>
-
-    <section id="detect-format">
-      <h2>Detection</h2>
-      <p>
-        For a stream determined to be in the ISO Base Media File Format
-        [[!ISOBMFF]], the ISO Common Encryption protection schemes may be
-        detected as follows.
-      </p>
-      <p>
-        Protection scheme signaling conforms with [[!ISOBMFF]]. When protection
-        has been applied, the stream type will be transformed to 'encv' for
-        video or 'enca' for audio, with a Protection Scheme Information Box
-        ('sinf') added to the sample entry in the Sample Description Box
-        ('stsd'). The Protection Scheme Information Box ('sinf') will contain a
-        Scheme Type Box ('schm') with a scheme_type field set to a value of
-        <code>'cenc'</code> or <code>'cbcs'</code>. [[!CENC]]
-      </p>
-    </section>
-
-    <section id="detect-encrypted-blocks">
-      <h2>Detecting Encrypted Blocks</h2>
-      <p>
-        For the purposes of the <a
-        def-id="encrypted-block-encountered-algorithm"></a>, encrypted blocks
-        are identified as follows.
-      </p>
-      <p>
-        The encrypted block is a sample. Determining whether a sample is
-        encrypted depends on the corresponding Track Encryption Box ('tenc') and
-        the sample group with grouping type 'seig' (CencSampleEncryption group),
-        if any, associated with the sample.  The default encryption state of a
-        sample is defined by the IsEncrypted flag in the associated track
-        encryption box ('tenc'). This default state may be modified by the
-        IsEncrypted flag in the SampleGroupDescriptionBox ('sgpd'), pointed to
-        by an index in the SampleToGroupBox ('sbgp').
-      </p>
-      <p>
-        Samples can be partially encrypted, specified by subsample information
-        referenced by SampleAuxiliaryInformationSizesBox ('saiz') and
-        SampleAuxiliaryInformationOffsetsBox ('saio') boxes.
-      </p>
-      <p>For complete information, see [[!CENC]].</p>
-    </section>
-
-    <section id="init-data">
-      <h2>Initialization Data Extraction</h2>
-      <p>
-        Streams may contain one or more Protection System Specific Header
-        ('pssh') boxes [[!CENC]], each for a unique SystemID, at each location
-        where a 'pssh' box is necessary.  Content using this stream format
-        SHOULD include a box containing the <a def-id="cenc-common-system"></a>.
-      </p>
-      <p>
-        <a def-id="initialization-data"></a> is always one or more concatenated
-        'pssh' boxes as defined by the <a def-id="initdata-registry-cenc"></a>
-        [[!EME-INITDATA-REGISTRY]].
-      </p>
-      <p>
-        Each time one or more 'pssh' boxes are encountered, the <a
-        def-id="initdata-encountered-algorithm"></a> algorithm SHALL be invoked
-        with <var title="">initDataType</var> = <code>"<a
-        def-id="initdata-registry-cenc">cenc</a>"</code>
-        [[!EME-INITDATA-REGISTRY]] and <var title="">initData</var> = the 'pssh'
-        box(es).  Multiple 'pssh' boxes MUST be provided together if and only if
-        they appear directly next to each other in the stream.
-      </p>
-    </section>
-  </body>
 </html>

--- a/format-registry/stream/webm-respec.html
+++ b/format-registry/stream/webm-respec.html
@@ -1,86 +1,86 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <title>WebM Stream Format</title>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
-    <script src="../../encrypted-media.js" class="remove"></script>
-    <script class="remove">
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <title>WebM Stream Format</title>
+  <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
+  <script src="../../encrypted-media.js" class="remove"></script>
+  <script class="remove">
     var respecConfig = {
       // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
       specStatus: "ED",
-
       // the specification's short name, as in https://www.w3.org/TR/short-name/
       shortName: "eme-stream-webm",
-
       // if there a publicly available Editor's Draft, this is the link
       edDraftURI: "https://w3c.github.io/encrypted-media/format-registry/stream/webm.html",
-
       // if this is a LCWD, uncomment and set the end of its review period
       // lcEnd: "2009-08-05",
-
       // editors, add as many as you like
       // only "name" is required
-      editors: [
-        { name: "Joey Parrish", w3cid: "105371",
-          company: "Google Inc.", companyURL: "https://www.google.com/" },
-        { name: "Greg Freedman",
-          company: "Netflix Inc.", companyURL: "https://www.netflix.com/" },
-      ],
-
-      formerEditors: [
-        { name: "Mark Watson", note: "Until September 2019", w3cid: "46379",
-          company: "Netflix Inc.", companyURL: "https://www.netflix.com/" },
-        { name: "David Dorwin", note: "Until September 2017", w3cid: "52505",
-          company: "Google Inc.", companyURL: "https://www.google.com/" },
-        { name: "Jerry Smith", note: "Until September 2017", w3cid: "60176",
-          company: "Microsoft Corporation", companyURL: "https://www.microsoft.com/" },
-        { name: "Adrian Bateman", note: "Until May 2014", w3cid: "42763",
-          company: "Microsoft Corporation", companyURL: "https://www.microsoft.com/" },
-      ],
-
-      otherLinks: [
-        { key: "Repository", href: "https://github.com/w3c/encrypted-media/" },
-      ],
-
+      editors: [{
+        name: "Joey Parrish",
+        w3cid: "105371",
+        company: "Google Inc.",
+        companyURL: "https://www.google.com/"
+      }, {
+        name: "Greg Freedman",
+        company: "Netflix Inc.",
+        companyURL: "https://www.netflix.com/"
+      }],
+      formerEditors: [{
+        name: "Mark Watson",
+        note: "Until September 2019",
+        w3cid: "46379",
+        company: "Netflix Inc.",
+        companyURL: "https://www.netflix.com/"
+      }, {
+        name: "David Dorwin",
+        note: "Until September 2017",
+        w3cid: "52505",
+        company: "Google Inc.",
+        companyURL: "https://www.google.com/"
+      }, {
+        name: "Jerry Smith",
+        note: "Until September 2017",
+        w3cid: "60176",
+        company: "Microsoft Corporation",
+        companyURL: "https://www.microsoft.com/"
+      }, {
+        name: "Adrian Bateman",
+        note: "Until May 2014",
+        w3cid: "42763",
+        company: "Microsoft Corporation",
+        companyURL: "https://www.microsoft.com/"
+      }],
+      otherLinks: [{
+        key: "Repository",
+        href: "https://github.com/w3c/encrypted-media/"
+      }],
       emeDefGroupName: "webm-stream-format",
-      emeUnusedGroupNameExcludeList: [
-        "encrypted-media",
-        "eme-references-from-registry",
-      ],
-
+      emeUnusedGroupNameExcludeList: ["encrypted-media", "eme-references-from-registry", ],
       // name of the WG
       wg: "Media Working Group",
-
       // URI of the public WG page
       wgURI: "https://www.w3.org/media-wg/",
-
       // name (without the @w3c.org) of the public mailing to which comments are due
       wgPublicList: "public-media-wg",
-
       // URI of the patent status for this WG, for Rec-track documents
       // !!!! IMPORTANT !!!!
       // This is important for Rec-track documents, do not copy a patent URI from a random
       // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
       // Team Contact.
       wgPatentURI: "https://www.w3.org/2004/01/pp-impl/115198/status",
-
       noIDLIn: true,
-
       scheme: "https",
-
       // Empty definitions for objects declared in the document are here to
       // prevent error messages from being displayed for references to these objects.
       definitionMap: {},
-
-      preProcess: [ encryptedMediaPreProcessor ],
-
+      preProcess: [encryptedMediaPreProcessor],
       // Empty definitions for objects declared in the document are here to
       // prevent error messages from being displayed for references to these objects.
       definitionMap: {},
-
-      postProcess: [ encryptedMediaPostProcessor ],
-
+      postProcess: [encryptedMediaPostProcessor],
       localBiblio: {
         "WebM-Encryption": {
           title: "WebM Encryption",
@@ -91,48 +91,57 @@
         },
       },
     };
-    </script>
-    <!-- script to register bugs -->
-    <!-- Disabled unless/until it supports GitHub issues.
-    <script src="https://w3c.github.io/webcomponents/assets/scripts/bug-assist.js"></script>
-    <meta name="bug.product" content="HTML WG">
-    <meta name="bug.component" content="Encrypted Media Extensions">
-    -->
+  </script>
+</head>
 
-  </head>
-  <body>
-    <section id="abstract">
-      <p>This specification defines the stream format for using WebM [[!WebM]] content with the <a def-id="eme-spec"></a> [[!ENCRYPTED-MEDIA]].</p>
-    </section>
+<body>
+  <section id="abstract">
+    <p>This specification defines the stream format for using WebM [[!WebM]] content with the <a
+        def-id="eme-spec"></a> [[!ENCRYPTED-MEDIA]].</p>
+  </section>
+  <section id="sotd">
+  </section>
+  <section id="stream-format">
+    <h2>Stream Format</h2>
+    <p>Encrypted WebM streams [[!WebM-Encryption]] are encrypted at the block level with AES-128 CTR
+      encryption. The container SHALL include appropriate values within the <a
+        href="https://matroska.org/technical/specs/index.html#ContentEncryption">ContentEncryption</a>
+      [[!Matroska]] element. </p>
+    <p>WebM streams may be partially encrypted, both at the <a
+        href="https://matroska.org/technical/specs/index.html#LevelTrack">Track</a> level and the
+      block level. In the former case, a subset of Tracks in the stream have a <a
+        href="https://matroska.org/technical/specs/index.html#ContentEncryption">ContentEncryption</a>
+      element. In the latter case, a subset of the blocks within a Track containing a <a
+        href="https://matroska.org/technical/specs/index.html#ContentEncryption">ContentEncryption</a>
+      element are marked as encrypted. </p>
+  </section>
+  <section id="detect-format">
+    <h2>Detection</h2>
+    <p>For a stream determined to be in the WebM format [[!WebM]], when a <a
+        href="https://matroska.org/technical/specs/index.html#LevelTrack">Track</a> [[!Matroska]] is
+      parsed, the presence of a <a
+        href="https://matroska.org/technical/specs/index.html#ContentEncKeyID">ContentEncKeyID</a>
+      element indicates that blocks in the track may be encrypted.</p>
+  </section>
+  <section id="detect-encrypted-blocks">
+    <h2>Detecting Encrypted Blocks</h2>
+    <p>For the purposes of the <a def-id="encrypted-block-encountered-algorithm"></a>, encrypted
+      blocks are those marked encrypted by the <a
+        href="https://www.webmproject.org/docs/webm-encryption/#46-signal-byte-format">Signal
+        Byte.</a> [[!WebM-Encryption]]</p>
+  </section>
+  <section id="init-data">
+    <h2>Initialization Data Extraction</h2>
+    <p><a def-id="initialization-data"></a> is always a single <a def-id="key-id"></a>, as defined
+      by the <a def-id="initdata-registry-webm"></a> [[!EME-INITDATA-REGISTRY]].</p>
+    <p>Each time a <a
+        href="https://matroska.org/technical/specs/index.html#ContentEncKeyID">ContentEncKeyID</a>
+      [[!Matroska]] element is encountered in a <a
+        href="https://matroska.org/technical/specs/index.html#LevelTrack">Track</a>, the <a
+        def-id="initdata-encountered-algorithm"></a> algorithm SHALL be invoked with <var title="">
+        initDataType</var> = <code>"<a def-id="initdata-registry-webm">webm</a>"</code>
+      [[!EME-INITDATA-REGISTRY]] and <var title="">initData</var> = the value in that element.</p>
+  </section>
+</body>
 
-    <section id="sotd">
-    </section>
-
-    <section id="stream-format">
-      <h2>Stream Format</h2>
-      <p>Encrypted WebM streams [[!WebM-Encryption]] are encrypted at the block level with AES-128 CTR encryption.
-      The container SHALL include appropriate values within the <a href="https://matroska.org/technical/specs/index.html#ContentEncryption">ContentEncryption</a> [[!Matroska]] element.
-      </p>
-      <p>WebM streams may be partially encrypted, both at the <a href="https://matroska.org/technical/specs/index.html#LevelTrack">Track</a> level and the block level.
-      In the former case, a subset of Tracks in the stream have a <a href="https://matroska.org/technical/specs/index.html#ContentEncryption">ContentEncryption</a> element.
-      In the latter case, a subset of the blocks within a Track containing a <a href="https://matroska.org/technical/specs/index.html#ContentEncryption">ContentEncryption</a> element are marked as encrypted.
-      </p>
-    </section>
-
-    <section id="detect-format">
-      <h2>Detection</h2>
-      <p>For a stream determined to be in the WebM format [[!WebM]], when a <a href="https://matroska.org/technical/specs/index.html#LevelTrack">Track</a> [[!Matroska]] is parsed, the presence of a <a href="https://matroska.org/technical/specs/index.html#ContentEncKeyID">ContentEncKeyID</a> element indicates that blocks in the track may be encrypted.</p>
-    </section>
-
-    <section id="detect-encrypted-blocks">
-      <h2>Detecting Encrypted Blocks</h2>
-      <p>For the purposes of the <a def-id="encrypted-block-encountered-algorithm"></a>, encrypted blocks are those marked encrypted by the <a href="https://www.webmproject.org/docs/webm-encryption/#46-signal-byte-format">Signal Byte.</a> [[!WebM-Encryption]]</p>
-    </section>
-
-    <section id="init-data">
-      <h2>Initialization Data Extraction</h2>
-      <p><a def-id="initialization-data"></a> is always a single <a def-id="key-id"></a>, as defined by the <a def-id="initdata-registry-webm"></a> [[!EME-INITDATA-REGISTRY]].</p>
-      <p>Each time a <a href="https://matroska.org/technical/specs/index.html#ContentEncKeyID">ContentEncKeyID</a> [[!Matroska]] element is encountered in a <a href="https://matroska.org/technical/specs/index.html#LevelTrack">Track</a>, the <a def-id="initdata-encountered-algorithm"></a> algorithm SHALL be invoked with <var title="">initDataType</var> = <code>"<a def-id="initdata-registry-webm">webm</a>"</code> [[!EME-INITDATA-REGISTRY]] and <var title="">initData</var> = the value in that element.</p>
-    </section>
-  </body>
 </html>

--- a/html-formatter.sh
+++ b/html-formatter.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if ! which html-beautify >/dev/null; then
+  echo "This uses html-beautify, which you don't seem to have." 1>&2
+  echo "You can install it via:" 1>&2
+  echo "  sudo npm install -g js-beautify" 1>&2
+  exit 1
+fi
+
+html-beautify -r $(find -name '*-respec.html')
+echo "All respec HTML formatted with html-beautify." 1>&2


### PR DESCRIPTION
This should make the spec source easier to read and maintain.

Formatting is based on jsbeautify's html-beautify tool.  Just run
`./html-formatter.sh` after changes to respec files.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/joeyparrish/encrypted-media/pull/463.html" title="Last updated on Dec 20, 2019, 9:53 PM UTC (acc115d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/463/29db5e9...joeyparrish:acc115d.html" title="Last updated on Dec 20, 2019, 9:53 PM UTC (acc115d)">Diff</a>