### PR TITLE
Fix Clear Key behavior on "persistent-usage-record" session

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -3854,7 +3854,7 @@ interface MediaEncryptedEvent : Event {
             </li>
             <li>
               <p>
-                For sessions of type <a def-id="persistent-usage-record-session"></a>, in the <a def-id="remove"></a> and <a def-id="load"></a> algorithms, the <var>message</var> reflecting
+                For sessions of type <a def-id="persistent-usage-record-session"></a>, in the <a def-id="remove"></a> algorithm, the <var>message</var> reflecting
                 the object's <var>record of key usage</var> is a JSON object encoded in UTF-8 as described in <a href="#clear-key-release-format">License Release Format</a>.
               </p>
             </li>


### PR DESCRIPTION
The message reflecting the object's record of key usage should only be
generated on remove(), not on load().

Fixes #469


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/xhwang-chromium/encrypted-media/pull/471.html" title="Last updated on Jul 17, 2020, 7:03 PM UTC (b7df33c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/471/29db5e9...xhwang-chromium:b7df33c.html" title="Last updated on Jul 17, 2020, 7:03 PM UTC (b7df33c)">Diff</a>