### PR TITLE
Add "usable-in-future" to MediaKeyStatus

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -2402,6 +2402,7 @@ The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows:
     "released",
     "output-restricted",
     "output-downscaled",
+    "usable-in-future",
     "status-pending",
     "internal-error"
 };</pre>
@@ -2430,6 +2431,9 @@ The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows:
             with the key.<br>
             Support for downscaling is OPTIONAL.
             Applications SHOULD NOT rely on downscaling to ensure uninterrupted playback when output requirements cannot be met.
+          </td></tr><tr><td><dfn><code id="idl-def-MediaKeyStatus.usable-in-future">usable-in-future</code></dfn></td><td>
+            The key is not yet <a def-id="usable-for-decryption"></a> because the start time is in the future.
+            The key will become usable when its start time is reached.
           </td></tr><tr><td><dfn><code id="idl-def-MediaKeyStatus.status-pending">status-pending</code></dfn></td><td>
             The status of the key is not yet known and is being determined.
             The status will be updated with the actual status when it has been determined.


### PR DESCRIPTION
Fixes #451


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/xhwang-chromium/encrypted-media/pull/475.html" title="Last updated on Sep 9, 2020, 12:51 AM UTC (a67b33f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/475/26b1719...xhwang-chromium:a67b33f.html" title="Last updated on Sep 9, 2020, 12:51 AM UTC (a67b33f)">Diff</a>