### PR TITLE
Rename Feature Policy to Permissions Policy

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -645,13 +645,13 @@
       <p>The steps of an algorithm are always aborted when rejecting a promise.</p>
 
       <section>
-        <h3>Feature Policy Integration</h3>
+        <h3>Permissions Policy Integration</h3>
         <p>
           <a def-id="requestMediaKeySystemAccess"></a> is a <a
-          data-cite="!FEATURE-POLICY#policy-controlled-feature">policy-controlled feature</a>
+          data-cite="!PERMISSIONS-POLICY#policy-controlled-feature">policy-controlled feature</a>
           identified by the string <dfn><code>encrypted-media</code></dfn>.  Its <a
-          data-cite="!FEATURE-POLICY#default-allowlist">default allowlist</a> is <code>'self'</code>
-          [[!FEATURE-POLICY]].
+          data-cite="!PERMISSIONS-POLICY#default-allowlist">default allowlist</a> is <code>'self'</code>
+          [[!PERMISSIONS-POLICY]].
         </p>
       </section>
 
@@ -684,9 +684,8 @@ partial interface Navigator {
             <ol class="method-algorithm">
               <!-- TODO: Convert all parameters to use <code>. -->
 
-              <li><p>If the <a data-cite="!FEATURE-POLICY#responsible-document">responsible
-              document</a> is not <a data-cite="!FEATURE-POLICY#allowed-to-use">allowed to use</a>
-              the <a><code>encrypted-media</code></a> feature, then throw a "<a
+              <li><p>If the <a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document">responsible
+              document</a> is not <a>allowed to use</a> the <a><code>encrypted-media</code></a> feature, then throw a "<a
               data-cite="!WEBIDL#securityerror">SecurityError</a>" <a
               data-cite="!WEBIDL#dfn-DOMException">DOMException</a> and abort these steps.</p></li>
 


### PR DESCRIPTION
Feature Policy has been renamed, and the spec has moved. This change
updates the integration to point to the new locations, and to use the
new name.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/clelland/encrypted-media/pull/476.html" title="Last updated on Oct 20, 2020, 2:12 PM UTC (195769e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/476/72679ab...clelland:195769e.html" title="Last updated on Oct 20, 2020, 2:12 PM UTC (195769e)">Diff</a>