### PR TITLE
Fix code highlighting for Example 7

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -4573,7 +4573,7 @@ interface MediaEncryptedEvent : Event {
   var licenseUrl;
   var serverCertificate;
 
-  // Returns a Promise&lt;<a>MediaKeys</a>&gt;.
+  // Returns a Promise&lt;MediaKeys&gt;.
   function createSupportedKeySystem() {
     someSystemOptions = [
      { <a def-id="option-initDataTypes"></a>: ['keyids', 'webm'],

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
     
     <title>Encrypted Media Extensions</title>
     <style id="respec-mainstyle">@keyframes pop{0%{transform:scale(1,1)}25%{transform:scale(1.25,1.25);opacity:.75}100%{transform:scale(1,1)}}.hljs{background:0 0!important}a abbr,h1 abbr,h2 abbr,h3 abbr,h4 abbr,h5 abbr,h6 abbr{border:none}dfn{font-weight:700}a.internalDFN{color:inherit;border-bottom:1px solid #99c;text-decoration:none}a.externalDFN{color:inherit;border-bottom:1px dotted #ccc;text-decoration:none}a.bibref{text-decoration:none}.respec-offending-element:target{animation:pop .25s ease-in-out 0s 1}.respec-offending-element,a[href].respec-offending-element{text-decoration:red wavy underline}@supports not (text-decoration:red wavy underline){.respec-offending-element:not(pre){display:inline-block}.respec-offending-element{background:url(data:image/gif;base64,R0lGODdhBAADAPEAANv///8AAP///wAAACwAAAAABAADAEACBZQjmIAFADs=) bottom repeat-x}}#references :target{background:#eaf3ff;animation:pop .4s ease-in-out 0s 1}cite .bibref{font-style:normal}code{color:#c63501}th code{color:inherit}a[href].orcid{padding-left:4px;padding-right:4px}a[href].orcid>svg{margin-bottom:-2px}.toc a,.tof a{text-decoration:none}a .figno,a .secno{color:#000}ol.tof,ul.tof{list-style:none outside none}.caption{margin-top:.5em;font-style:italic}table.simple{border-spacing:0;border-collapse:collapse;border-bottom:3px solid #005a9c}.simple th{background:#005a9c;color:#fff;padding:3px 5px;text-align:left}.simple th a{color:#fff;padding:3px 5px;text-align:left}.simple th[scope=row]{background:inherit;color:inherit;border-top:1px solid #ddd}.simple td{padding:3px 10px;border-top:1px solid #ddd}.simple tr:nth-child(even){background:#f0f6ff}.section dd>p:first-child{margin-top:0}.section dd>p:last-child{margin-bottom:0}.section dd{margin-bottom:1em}.section dl.attrs dd,.section dl.eldef dd{margin-bottom:0}#issue-summary>ul,.respec-dfn-list{column-count:2}#issue-summary li,.respec-dfn-list li{list-style:none}details.respec-tests-details{margin-left:1em;display:inline-block;vertical-align:top}details.respec-tests-details>*{padding-right:2em}details.respec-tests-details[open]{z-index:999999;position:absolute;border:thin solid #cad3e2;border-radius:.3em;background-color:#fff;padding-bottom:.5em}details.respec-tests-details[open]>summary{border-bottom:thin solid #cad3e2;padding-left:1em;margin-bottom:1em;line-height:2em}details.respec-tests-details>ul{width:100%;margin-top:-.3em}details.respec-tests-details>li{padding-left:1em}a[href].self-link:hover{opacity:1;text-decoration:none;background-color:transparent}h2,h3,h4,h5,h6{position:relative}aside.example .marker>a.self-link{color:inherit}h2>a.self-link,h3>a.self-link,h4>a.self-link,h5>a.self-link,h6>a.self-link{border:none;color:inherit;font-size:83%;height:2em;left:-1.6em;opacity:.5;position:absolute;text-align:center;text-decoration:none;top:0;transition:opacity .2s;width:2em}h2>a.self-link::before,h3>a.self-link::before,h4>a.self-link::before,h5>a.self-link::before,h6>a.self-link::before{content:"§";display:block}@media (max-width:767px){dd{margin-left:0}h2>a.self-link,h3>a.self-link,h4>a.self-link,h5>a.self-link,h6>a.self-link{left:auto;top:auto}}@media print{.removeOnSave{display:none}}</style>
-    
+
     
     
     
@@ -211,15 +211,15 @@
       "publisher": "W3C"
     }
   },
-  "publishISODate": "2020-09-09T00:00:00.000Z",
-  "generatedSubtitle": "Editor's Draft 09 September 2020"
+  "publishISODate": "2020-12-22T00:00:00.000Z",
+  "generatedSubtitle": "Editor's Draft 22 December 2020"
 }</script><link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED"></head>
   <body data-cite="WebIDL HTML" class="h-entry"><div class="head">
     <a class="logo" href="https://www.w3.org/"><img alt="W3C" width="72" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C"></a> <h1 id="title" class="title">Encrypted Media Extensions</h1>
     
     <h2>
       W3C Editor's Draft
-      <time class="dt-published" datetime="2020-09-09">09 September 2020</time>
+      <time class="dt-published" datetime="2020-12-22">22 December 2020</time>
     </h2>
     <dl>
       <dt>This version:</dt><dd>
@@ -337,7 +337,7 @@
   </p><p>
                   This document is governed by the
                   <a id="w3c_process_revision" href="https://www.w3.org/2019/Process-20190301/">1 March 2019 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
-                </p></section><nav id="toc"><h2 class="introductory" id="table-of-contents">Table of Contents</h2><ol class="toc"><li class="tocline"><a class="tocxref" href="#introduction"><bdi class="secno">1. </bdi>Introduction</a></li><li class="tocline"><a class="tocxref" href="#definitions"><bdi class="secno">2. </bdi>Definitions</a></li><li class="tocline"><a class="tocxref" href="#obtaining-access-to-key-systems"><bdi class="secno">3. </bdi>Obtaining Access to Key Systems</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#feature-policy-integration"><bdi class="secno">3.1 </bdi>Feature Policy Integration</a></li><li class="tocline"><a class="tocxref" href="#navigator-extension-requestmediakeysystemaccess"><bdi class="secno">3.2 </bdi><span data-dfn-type="dfn" data-idl="interface" data-title="Navigator" data-dfn-for=""><code>Navigator</code></span> Extension: <code>requestMediaKeySystemAccess()</code></a><ol class="toc"><li class="tocline"><a class="tocxref" href="#algorithms"><bdi class="secno">3.2.1 </bdi>Algorithms</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#get-supported-configuration"><bdi class="secno">3.2.1.1 </bdi>Get Supported Configuration</a></li><li class="tocline"><a class="tocxref" href="#get-supported-configuration-and-consent"><bdi class="secno">3.2.1.2 </bdi>Get Supported Configuration and Consent</a></li><li class="tocline"><a class="tocxref" href="#get-supported-capabilities-for-audio-video-type"><bdi class="secno">3.2.1.3 </bdi>Get Supported Capabilities for Audio/Video Type</a></li><li class="tocline"><a class="tocxref" href="#get-consent-status"><bdi class="secno">3.2.1.4 </bdi>Get Consent Status</a></li></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#mediakeysystemconfiguration-dictionary"><bdi class="secno">3.3 </bdi><span class="formerLink" data-link-type="idl"><code>MediaKeySystemConfiguration</code></span> dictionary</a></li><li class="tocline"><a class="tocxref" href="#mediakeysystemmediacapability-dictionary"><bdi class="secno">3.4 </bdi><span data-dfn-type="dictionary" data-export="" data-idl="dictionary" data-title="MediaKeySystemMediaCapability" data-dfn-for=""><code>MediaKeySystemMediaCapability</code></span> dictionary</a></li></ol></li><li class="tocline"><a class="tocxref" href="#mediakeysystemaccess-interface"><bdi class="secno">4. </bdi><span data-dfn-type="interface" data-export="" data-idl="interface" data-title="MediaKeySystemAccess" data-dfn-for=""><code>MediaKeySystemAccess</code></span> Interface</a></li><li class="tocline"><a class="tocxref" href="#mediakeys-interface"><bdi class="secno">5. </bdi><span data-dfn-type="interface" data-export="" data-idl="interface" data-title="MediaKeys" data-dfn-for=""><code>MediaKeys</code></span> Interface</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#algorithms-0"><bdi class="secno">5.1 </bdi>Algorithms</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#is-persistent-session-type"><bdi class="secno">5.1.1 </bdi>Is persistent session type?</a></li><li class="tocline"><a class="tocxref" href="#cdm-unavailable"><bdi class="secno">5.1.2 </bdi>CDM Unavailable</a></li></ol></li><li class="tocline"><a class="tocxref" href="#media-keys-storage"><bdi class="secno">5.2 </bdi>Storage and Persistence</a></li></ol></li><li class="tocline"><a class="tocxref" href="#mediakeysession-interface"><bdi class="secno">6. </bdi><span data-dfn-type="interface" data-export="" data-idl="interface" data-title="MediaKeySession" data-dfn-for=""><code>MediaKeySession</code></span> Interface</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#mediakeystatusmap-interface"><bdi class="secno">6.1 </bdi><span data-dfn-type="interface" data-export="" data-idl="interface" data-title="MediaKeyStatusMap" data-dfn-for=""><code>MediaKeyStatusMap</code></span> Interface</a></li><li class="tocline"><a class="tocxref" href="#mediakeymessageevent"><bdi class="secno">6.2 </bdi><span class="formerLink" data-link-type="idl"><code>MediaKeyMessageEvent</code></span></a><ol class="toc"><li class="tocline"><a class="tocxref" href="#mediakeymessageeventinit"><bdi class="secno">6.2.1 </bdi><span data-dfn-type="dictionary" data-export="" data-idl="dictionary" data-title="MediaKeyMessageEventInit" data-dfn-for=""><code>MediaKeyMessageEventInit</code></span></a></li></ol></li><li class="tocline"><a class="tocxref" href="#mediakeysession-events"><bdi class="secno">6.3 </bdi>Event Summary</a></li><li class="tocline"><a class="tocxref" href="#mediakeysession-algorithms"><bdi class="secno">6.4 </bdi>Algorithms</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#queue-message"><bdi class="secno">6.4.1 </bdi>Queue a "message" Event</a></li><li class="tocline"><a class="tocxref" href="#update-key-statuses"><bdi class="secno">6.4.2 </bdi>Update Key Statuses</a></li><li class="tocline"><a class="tocxref" href="#update-expiration"><bdi class="secno">6.4.3 </bdi>Update Expiration</a></li><li class="tocline"><a class="tocxref" href="#session-closed"><bdi class="secno">6.4.4 </bdi>Session Closed</a></li><li class="tocline"><a class="tocxref" href="#media-key-session-destroyed"><bdi class="secno">6.4.5 </bdi>MediaKeySession Destroyed</a></li><li class="tocline"><a class="tocxref" href="#monitor-cdm"><bdi class="secno">6.4.6 </bdi>Monitor for CDM State Changes</a></li></ol></li><li class="tocline"><a class="tocxref" href="#exceptions"><bdi class="secno">6.5 </bdi>Exceptions</a></li><li class="tocline"><a class="tocxref" href="#session-storage"><bdi class="secno">6.6 </bdi>Session Storage and Persistence</a></li></ol></li><li class="tocline"><a class="tocxref" href="#htmlmediaelement-extensions"><bdi class="secno">7. </bdi><span data-dfn-type="dfn" data-idl="interface" data-title="HTMLMediaElement" data-dfn-for=""><code>HTMLMediaElement</code></span> Extensions</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#mediaencryptedevent"><bdi class="secno">7.1 </bdi><span class="formerLink" data-link-type="idl"><code>MediaEncryptedEvent</code></span></a><ol class="toc"><li class="tocline"><a class="tocxref" href="#mediaencryptedeventinit"><bdi class="secno">7.1.1 </bdi><span data-dfn-type="dictionary" data-export="" data-idl="dictionary" data-title="MediaEncryptedEventInit" data-dfn-for=""><code>MediaEncryptedEventInit</code></span></a></li></ol></li><li class="tocline"><a class="tocxref" href="#htmlmediaelement-events"><bdi class="secno">7.2 </bdi>Event Summary</a></li><li class="tocline"><a class="tocxref" href="#htmlmediaelement-algorithms"><bdi class="secno">7.3 </bdi>Algorithms</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#media-may-contain-encrypted-blocks"><bdi class="secno">7.3.1 </bdi>Media Data May Contain Encrypted Blocks</a></li><li class="tocline"><a class="tocxref" href="#initdata-encountered"><bdi class="secno">7.3.2 </bdi>Initialization Data Encountered</a></li><li class="tocline"><a class="tocxref" href="#encrypted-block-encountered"><bdi class="secno">7.3.3 </bdi>Encrypted Block Encountered</a></li><li class="tocline"><a class="tocxref" href="#attempt-to-decrypt"><bdi class="secno">7.3.4 </bdi>Attempt to Decrypt</a></li><li class="tocline"><a class="tocxref" href="#wait-for-key"><bdi class="secno">7.3.5 </bdi>Wait for Key</a></li><li class="tocline"><a class="tocxref" href="#resume-playback"><bdi class="secno">7.3.6 </bdi>Attempt to Resume Playback If Necessary</a></li></ol></li><li class="tocline"><a class="tocxref" href="#media-element-restrictions"><bdi class="secno">7.4 </bdi>Media Element Restrictions</a></li></ol></li><li class="tocline"><a class="tocxref" href="#implementation-requirements"><bdi class="secno">8. </bdi>Implementation Requirements</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#cdm-constraint-requirements"><bdi class="secno">8.1 </bdi>CDM Constraints</a></li><li class="tocline"><a class="tocxref" href="#messaging-requirements"><bdi class="secno">8.2 </bdi>Messages and Communication</a></li><li class="tocline"><a class="tocxref" href="#persistent-state-requirements"><bdi class="secno">8.3 </bdi>Persistent Data</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#use-origin-specific-key-system-storage"><bdi class="secno">8.3.1 </bdi>Use origin-specific and browsing profile-specific Key System storage</a></li><li class="tocline"><a class="tocxref" href="#allow-persistent-data-cleared"><bdi class="secno">8.3.2 </bdi>Allow Persistent Data to Be Cleared</a></li><li class="tocline"><a class="tocxref" href="#encrypt-or-obfuscate-persistent-data"><bdi class="secno">8.3.3 </bdi>Encrypt or obfuscate Persistent Data</a></li></ol></li><li class="tocline"><a class="tocxref" href="#exposed-value-requirements"><bdi class="secno">8.4 </bdi>Values Exposed to the Application</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#per-origin-per-profile-values"><bdi class="secno">8.4.1 </bdi>Use Per-Origin Per-Profile Values</a></li><li class="tocline"><a class="tocxref" href="#allow-values-to-be-cleared"><bdi class="secno">8.4.2 </bdi>Allow Values to Be Cleared</a></li></ol></li><li class="tocline"><a class="tocxref" href="#identifier-requirements"><bdi class="secno">8.5 </bdi>Identifiers</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#limit-or-avoid-use-of-distinctive-identifiers-and-permanent-identifiers"><bdi class="secno">8.5.1 </bdi>Limit or Avoid use of Distinctive Identifiers and Permanent Identifiers</a></li><li class="tocline"><a class="tocxref" href="#encrypt-identifiers"><bdi class="secno">8.5.2 </bdi>Encrypt Identifiers</a></li><li class="tocline"><a class="tocxref" href="#per-origin-per-profile-identifiers"><bdi class="secno">8.5.3 </bdi>Use Per-Origin Per-Profile Identifiers</a></li><li class="tocline"><a class="tocxref" href="#non-associable-identifiers"><bdi class="secno">8.5.4 </bdi>Use Non-Associable Identifiers</a></li><li class="tocline"><a class="tocxref" href="#allow-identifiers-cleared"><bdi class="secno">8.5.5 </bdi>Allow Identifiers to Be Cleared</a></li></ol></li><li class="tocline"><a class="tocxref" href="#individualization"><bdi class="secno">8.6 </bdi>Individualization</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#direct-individualization"><bdi class="secno">8.6.1 </bdi>Direct Individualization</a></li><li class="tocline"><a class="tocxref" href="#app-assisted-individualization"><bdi class="secno">8.6.2 </bdi>App-Assisted Individualization</a></li></ol></li><li class="tocline"><a class="tocxref" href="#support-multiple-keys"><bdi class="secno">8.7 </bdi>Support Multiple Keys</a></li><li class="tocline"><a class="tocxref" href="#initialization-data-type-support-requirements"><bdi class="secno">8.8 </bdi>Initialization Data Type Support</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#licenses-generated-are-independent-of-content-type"><bdi class="secno">8.8.1 </bdi>Licenses Generated are Independent of Content Type</a></li><li class="tocline"><a class="tocxref" href="#support-extraction-from-media-data"><bdi class="secno">8.8.2 </bdi>Support Extraction From Media Data</a></li></ol></li><li class="tocline"><a class="tocxref" href="#media-requirements"><bdi class="secno">8.9 </bdi>Supported Media</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#unencrypted-container"><bdi class="secno">8.9.1 </bdi>Unencrypted Container</a></li><li class="tocline"><a class="tocxref" href="#interoperably-encrypted"><bdi class="secno">8.9.2 </bdi>Interoperably Encrypted</a></li><li class="tocline"><a class="tocxref" href="#unencrypted-in-band-support-content"><bdi class="secno">8.9.3 </bdi>Unencrypted In-band Support Content</a></li></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#common-key-systems"><bdi class="secno">9. </bdi>Common Key Systems</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#clear-key"><bdi class="secno">9.1 </bdi>Clear Key</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#clear-key-capabilities"><bdi class="secno">9.1.1 </bdi>Capabilities</a></li><li class="tocline"><a class="tocxref" href="#clear-key-behavior"><bdi class="secno">9.1.2 </bdi>Behavior</a></li><li class="tocline"><a class="tocxref" href="#clear-key-request-format"><bdi class="secno">9.1.3 </bdi>License Request Format</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#clear-key-request-format-example"><bdi class="secno">9.1.3.1 </bdi>Example</a></li></ol></li><li class="tocline"><a class="tocxref" href="#clear-key-license-format"><bdi class="secno">9.1.4 </bdi>License Format</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#clear-key-license-format-example"><bdi class="secno">9.1.4.1 </bdi>Example</a></li></ol></li><li class="tocline"><a class="tocxref" href="#clear-key-release-format"><bdi class="secno">9.1.5 </bdi>License Release Format</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#clear-key-release-format-example-1"><bdi class="secno">9.1.5.1 </bdi>Example message reflecting a <span def-id="record-of-license-destruction" class="formerLink"></span></a></li><li class="tocline"><a class="tocxref" href="#clear-key-release-format-example-2"><bdi class="secno">9.1.5.2 </bdi>Example message reflecting a <span def-id="record-of-key-usage" class="formerLink"></span></a></li></ol></li><li class="tocline"><a class="tocxref" href="#clear-key-release-ack-format"><bdi class="secno">9.1.6 </bdi>License Release Acknowledgement Format</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#clear-key-release-ack-format-example"><bdi class="secno">9.1.6.1 </bdi>Example</a></li></ol></li><li class="tocline"><a class="tocxref" href="#using-base64url"><bdi class="secno">9.1.7 </bdi>Using base64url</a></li></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#security"><bdi class="secno">10. </bdi>Security</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#input-data-security"><bdi class="secno">10.1 </bdi>Input Data Attacks and Vulnerabilities</a></li><li class="tocline"><a class="tocxref" href="#cdm-security"><bdi class="secno">10.2 </bdi>CDM Attacks and Vulnerabilities</a></li><li class="tocline"><a class="tocxref" href="#network-attacks"><bdi class="secno">10.3 </bdi>Network Attacks</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#potential-attacks"><bdi class="secno">10.3.1 </bdi>Potential Attacks</a></li><li class="tocline"><a class="tocxref" href="#mitigations"><bdi class="secno">10.3.2 </bdi>Mitigations</a></li></ol></li><li class="tocline"><a class="tocxref" href="#iframe-attacks"><bdi class="secno">10.4 </bdi><code>iframe</code> Attacks</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#potential-attacks-0"><bdi class="secno">10.4.1 </bdi>Potential Attacks</a></li><li class="tocline"><a class="tocxref" href="#mitigations-0"><bdi class="secno">10.4.2 </bdi>Mitigations</a></li></ol></li><li class="tocline"><a class="tocxref" href="#cross-directory-attacks"><bdi class="secno">10.5 </bdi>Cross-Directory Attacks</a></li></ol></li><li class="tocline"><a class="tocxref" href="#privacy"><bdi class="secno">11. </bdi>Privacy</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#privacy-disclosure"><bdi class="secno">11.1 </bdi>Information Disclosed by EME and Key Systems</a></li><li class="tocline"><a class="tocxref" href="#privacy-fingerprinting"><bdi class="secno">11.2 </bdi>Fingerprinting</a></li><li class="tocline"><a class="tocxref" href="#privacy-leakage"><bdi class="secno">11.3 </bdi>Information Leakage</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#concerns"><bdi class="secno">11.3.1 </bdi>Concerns</a></li><li class="tocline"><a class="tocxref" href="#mitigations-1"><bdi class="secno">11.3.2 </bdi>Mitigations</a></li></ol></li><li class="tocline"><a class="tocxref" href="#user-tracking"><bdi class="secno">11.4 </bdi>User Tracking</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#concerns-0"><bdi class="secno">11.4.1 </bdi>Concerns</a></li><li class="tocline"><a class="tocxref" href="#mitigations-2"><bdi class="secno">11.4.2 </bdi>Mitigations</a></li></ol></li><li class="tocline"><a class="tocxref" href="#privacy-storedinfo"><bdi class="secno">11.5 </bdi>Information Stored on User Devices</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#concerns-1"><bdi class="secno">11.5.1 </bdi>Concerns</a></li><li class="tocline"><a class="tocxref" href="#mitigations-3"><bdi class="secno">11.5.2 </bdi>Mitigations</a></li></ol></li><li class="tocline"><a class="tocxref" href="#incomplete-clearing"><bdi class="secno">11.6 </bdi>Incomplete Clearing of Data</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#concerns-2"><bdi class="secno">11.6.1 </bdi>Concerns</a></li><li class="tocline"><a class="tocxref" href="#mitigations-4"><bdi class="secno">11.6.2 </bdi>Mitigations</a></li></ol></li><li class="tocline"><a class="tocxref" href="#private-browsing"><bdi class="secno">11.7 </bdi>Private Browsing Modes</a></li><li class="tocline"><a class="tocxref" href="#privacy-secureorigin"><bdi class="secno">11.8 </bdi>Secure Origin and Transport</a></li></ol></li><li class="tocline"><a class="tocxref" href="#conformance"><bdi class="secno">12. </bdi>Conformance</a></li><li class="tocline"><a class="tocxref" href="#examples"><bdi class="secno">13. </bdi>Examples</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#example-source-and-key-known"><bdi class="secno">13.1 </bdi>Source and Key Known at Page Load (Clear Key)</a></li><li class="tocline"><a class="tocxref" href="#example-selecting-key-system"><bdi class="secno">13.2 </bdi>Selecting a Supported Key System and Using Initialization Data from the "encrypted" Event</a></li><li class="tocline"><a class="tocxref" href="#example-mediakeys-before-source"><bdi class="secno">13.3 </bdi>Create MediaKeys Before Loading Media</a></li><li class="tocline"><a class="tocxref" href="#example-using-all-events"><bdi class="secno">13.4 </bdi>Using All Events</a></li><li class="tocline"><a class="tocxref" href="#example-stored-license"><bdi class="secno">13.5 </bdi>Stored License</a></li></ol></li><li class="tocline"><a class="tocxref" href="#acknowledgements"><bdi class="secno">14. </bdi>Acknowledgments</a></li><li class="tocline"><a class="tocxref" href="#references"><bdi class="secno">A. </bdi>References</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#normative-references"><bdi class="secno">A.1 </bdi>
+                </p></section><nav id="toc"><h2 class="introductory" id="table-of-contents">Table of Contents</h2><ol class="toc"><li class="tocline"><a class="tocxref" href="#introduction"><bdi class="secno">1. </bdi>Introduction</a></li><li class="tocline"><a class="tocxref" href="#definitions"><bdi class="secno">2. </bdi>Definitions</a></li><li class="tocline"><a class="tocxref" href="#obtaining-access-to-key-systems"><bdi class="secno">3. </bdi>Obtaining Access to Key Systems</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#permissions-policy-integration"><bdi class="secno">3.1 </bdi>Permissions Policy Integration</a></li><li class="tocline"><a class="tocxref" href="#navigator-extension-requestmediakeysystemaccess"><bdi class="secno">3.2 </bdi><span data-dfn-type="dfn" data-idl="interface" data-title="Navigator" data-dfn-for=""><code>Navigator</code></span> Extension: <code>requestMediaKeySystemAccess()</code></a><ol class="toc"><li class="tocline"><a class="tocxref" href="#algorithms"><bdi class="secno">3.2.1 </bdi>Algorithms</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#get-supported-configuration"><bdi class="secno">3.2.1.1 </bdi>Get Supported Configuration</a></li><li class="tocline"><a class="tocxref" href="#get-supported-configuration-and-consent"><bdi class="secno">3.2.1.2 </bdi>Get Supported Configuration and Consent</a></li><li class="tocline"><a class="tocxref" href="#get-supported-capabilities-for-audio-video-type"><bdi class="secno">3.2.1.3 </bdi>Get Supported Capabilities for Audio/Video Type</a></li><li class="tocline"><a class="tocxref" href="#get-consent-status"><bdi class="secno">3.2.1.4 </bdi>Get Consent Status</a></li></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#mediakeysystemconfiguration-dictionary"><bdi class="secno">3.3 </bdi><span class="formerLink" data-link-type="idl"><code>MediaKeySystemConfiguration</code></span> dictionary</a></li><li class="tocline"><a class="tocxref" href="#mediakeysystemmediacapability-dictionary"><bdi class="secno">3.4 </bdi><span data-dfn-type="dictionary" data-export="" data-idl="dictionary" data-title="MediaKeySystemMediaCapability" data-dfn-for=""><code>MediaKeySystemMediaCapability</code></span> dictionary</a></li></ol></li><li class="tocline"><a class="tocxref" href="#mediakeysystemaccess-interface"><bdi class="secno">4. </bdi><span data-dfn-type="interface" data-export="" data-idl="interface" data-title="MediaKeySystemAccess" data-dfn-for=""><code>MediaKeySystemAccess</code></span> Interface</a></li><li class="tocline"><a class="tocxref" href="#mediakeys-interface"><bdi class="secno">5. </bdi><span data-dfn-type="interface" data-export="" data-idl="interface" data-title="MediaKeys" data-dfn-for=""><code>MediaKeys</code></span> Interface</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#algorithms-0"><bdi class="secno">5.1 </bdi>Algorithms</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#is-persistent-session-type"><bdi class="secno">5.1.1 </bdi>Is persistent session type?</a></li><li class="tocline"><a class="tocxref" href="#cdm-unavailable"><bdi class="secno">5.1.2 </bdi>CDM Unavailable</a></li></ol></li><li class="tocline"><a class="tocxref" href="#media-keys-storage"><bdi class="secno">5.2 </bdi>Storage and Persistence</a></li></ol></li><li class="tocline"><a class="tocxref" href="#mediakeysession-interface"><bdi class="secno">6. </bdi><span data-dfn-type="interface" data-export="" data-idl="interface" data-title="MediaKeySession" data-dfn-for=""><code>MediaKeySession</code></span> Interface</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#mediakeystatusmap-interface"><bdi class="secno">6.1 </bdi><span data-dfn-type="interface" data-export="" data-idl="interface" data-title="MediaKeyStatusMap" data-dfn-for=""><code>MediaKeyStatusMap</code></span> Interface</a></li><li class="tocline"><a class="tocxref" href="#mediakeymessageevent"><bdi class="secno">6.2 </bdi><span class="formerLink" data-link-type="idl"><code>MediaKeyMessageEvent</code></span></a><ol class="toc"><li class="tocline"><a class="tocxref" href="#mediakeymessageeventinit"><bdi class="secno">6.2.1 </bdi><span data-dfn-type="dictionary" data-export="" data-idl="dictionary" data-title="MediaKeyMessageEventInit" data-dfn-for=""><code>MediaKeyMessageEventInit</code></span></a></li></ol></li><li class="tocline"><a class="tocxref" href="#mediakeysession-events"><bdi class="secno">6.3 </bdi>Event Summary</a></li><li class="tocline"><a class="tocxref" href="#mediakeysession-algorithms"><bdi class="secno">6.4 </bdi>Algorithms</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#queue-message"><bdi class="secno">6.4.1 </bdi>Queue a "message" Event</a></li><li class="tocline"><a class="tocxref" href="#update-key-statuses"><bdi class="secno">6.4.2 </bdi>Update Key Statuses</a></li><li class="tocline"><a class="tocxref" href="#update-expiration"><bdi class="secno">6.4.3 </bdi>Update Expiration</a></li><li class="tocline"><a class="tocxref" href="#session-closed"><bdi class="secno">6.4.4 </bdi>Session Closed</a></li><li class="tocline"><a class="tocxref" href="#media-key-session-destroyed"><bdi class="secno">6.4.5 </bdi>MediaKeySession Destroyed</a></li><li class="tocline"><a class="tocxref" href="#monitor-cdm"><bdi class="secno">6.4.6 </bdi>Monitor for CDM State Changes</a></li></ol></li><li class="tocline"><a class="tocxref" href="#exceptions"><bdi class="secno">6.5 </bdi>Exceptions</a></li><li class="tocline"><a class="tocxref" href="#session-storage"><bdi class="secno">6.6 </bdi>Session Storage and Persistence</a></li></ol></li><li class="tocline"><a class="tocxref" href="#htmlmediaelement-extensions"><bdi class="secno">7. </bdi><span data-dfn-type="dfn" data-idl="interface" data-title="HTMLMediaElement" data-dfn-for=""><code>HTMLMediaElement</code></span> Extensions</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#mediaencryptedevent"><bdi class="secno">7.1 </bdi><span class="formerLink" data-link-type="idl"><code>MediaEncryptedEvent</code></span></a><ol class="toc"><li class="tocline"><a class="tocxref" href="#mediaencryptedeventinit"><bdi class="secno">7.1.1 </bdi><span data-dfn-type="dictionary" data-export="" data-idl="dictionary" data-title="MediaEncryptedEventInit" data-dfn-for=""><code>MediaEncryptedEventInit</code></span></a></li></ol></li><li class="tocline"><a class="tocxref" href="#htmlmediaelement-events"><bdi class="secno">7.2 </bdi>Event Summary</a></li><li class="tocline"><a class="tocxref" href="#htmlmediaelement-algorithms"><bdi class="secno">7.3 </bdi>Algorithms</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#media-may-contain-encrypted-blocks"><bdi class="secno">7.3.1 </bdi>Media Data May Contain Encrypted Blocks</a></li><li class="tocline"><a class="tocxref" href="#initdata-encountered"><bdi class="secno">7.3.2 </bdi>Initialization Data Encountered</a></li><li class="tocline"><a class="tocxref" href="#encrypted-block-encountered"><bdi class="secno">7.3.3 </bdi>Encrypted Block Encountered</a></li><li class="tocline"><a class="tocxref" href="#attempt-to-decrypt"><bdi class="secno">7.3.4 </bdi>Attempt to Decrypt</a></li><li class="tocline"><a class="tocxref" href="#wait-for-key"><bdi class="secno">7.3.5 </bdi>Wait for Key</a></li><li class="tocline"><a class="tocxref" href="#resume-playback"><bdi class="secno">7.3.6 </bdi>Attempt to Resume Playback If Necessary</a></li></ol></li><li class="tocline"><a class="tocxref" href="#media-element-restrictions"><bdi class="secno">7.4 </bdi>Media Element Restrictions</a></li></ol></li><li class="tocline"><a class="tocxref" href="#implementation-requirements"><bdi class="secno">8. </bdi>Implementation Requirements</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#cdm-constraint-requirements"><bdi class="secno">8.1 </bdi>CDM Constraints</a></li><li class="tocline"><a class="tocxref" href="#messaging-requirements"><bdi class="secno">8.2 </bdi>Messages and Communication</a></li><li class="tocline"><a class="tocxref" href="#persistent-state-requirements"><bdi class="secno">8.3 </bdi>Persistent Data</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#use-origin-specific-key-system-storage"><bdi class="secno">8.3.1 </bdi>Use origin-specific and browsing profile-specific Key System storage</a></li><li class="tocline"><a class="tocxref" href="#allow-persistent-data-cleared"><bdi class="secno">8.3.2 </bdi>Allow Persistent Data to Be Cleared</a></li><li class="tocline"><a class="tocxref" href="#encrypt-or-obfuscate-persistent-data"><bdi class="secno">8.3.3 </bdi>Encrypt or obfuscate Persistent Data</a></li></ol></li><li class="tocline"><a class="tocxref" href="#exposed-value-requirements"><bdi class="secno">8.4 </bdi>Values Exposed to the Application</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#per-origin-per-profile-values"><bdi class="secno">8.4.1 </bdi>Use Per-Origin Per-Profile Values</a></li><li class="tocline"><a class="tocxref" href="#allow-values-to-be-cleared"><bdi class="secno">8.4.2 </bdi>Allow Values to Be Cleared</a></li></ol></li><li class="tocline"><a class="tocxref" href="#identifier-requirements"><bdi class="secno">8.5 </bdi>Identifiers</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#limit-or-avoid-use-of-distinctive-identifiers-and-permanent-identifiers"><bdi class="secno">8.5.1 </bdi>Limit or Avoid use of Distinctive Identifiers and Permanent Identifiers</a></li><li class="tocline"><a class="tocxref" href="#encrypt-identifiers"><bdi class="secno">8.5.2 </bdi>Encrypt Identifiers</a></li><li class="tocline"><a class="tocxref" href="#per-origin-per-profile-identifiers"><bdi class="secno">8.5.3 </bdi>Use Per-Origin Per-Profile Identifiers</a></li><li class="tocline"><a class="tocxref" href="#non-associable-identifiers"><bdi class="secno">8.5.4 </bdi>Use Non-Associable Identifiers</a></li><li class="tocline"><a class="tocxref" href="#allow-identifiers-cleared"><bdi class="secno">8.5.5 </bdi>Allow Identifiers to Be Cleared</a></li></ol></li><li class="tocline"><a class="tocxref" href="#individualization"><bdi class="secno">8.6 </bdi>Individualization</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#direct-individualization"><bdi class="secno">8.6.1 </bdi>Direct Individualization</a></li><li class="tocline"><a class="tocxref" href="#app-assisted-individualization"><bdi class="secno">8.6.2 </bdi>App-Assisted Individualization</a></li></ol></li><li class="tocline"><a class="tocxref" href="#support-multiple-keys"><bdi class="secno">8.7 </bdi>Support Multiple Keys</a></li><li class="tocline"><a class="tocxref" href="#initialization-data-type-support-requirements"><bdi class="secno">8.8 </bdi>Initialization Data Type Support</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#licenses-generated-are-independent-of-content-type"><bdi class="secno">8.8.1 </bdi>Licenses Generated are Independent of Content Type</a></li><li class="tocline"><a class="tocxref" href="#support-extraction-from-media-data"><bdi class="secno">8.8.2 </bdi>Support Extraction From Media Data</a></li></ol></li><li class="tocline"><a class="tocxref" href="#media-requirements"><bdi class="secno">8.9 </bdi>Supported Media</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#unencrypted-container"><bdi class="secno">8.9.1 </bdi>Unencrypted Container</a></li><li class="tocline"><a class="tocxref" href="#interoperably-encrypted"><bdi class="secno">8.9.2 </bdi>Interoperably Encrypted</a></li><li class="tocline"><a class="tocxref" href="#unencrypted-in-band-support-content"><bdi class="secno">8.9.3 </bdi>Unencrypted In-band Support Content</a></li></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#common-key-systems"><bdi class="secno">9. </bdi>Common Key Systems</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#clear-key"><bdi class="secno">9.1 </bdi>Clear Key</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#clear-key-capabilities"><bdi class="secno">9.1.1 </bdi>Capabilities</a></li><li class="tocline"><a class="tocxref" href="#clear-key-behavior"><bdi class="secno">9.1.2 </bdi>Behavior</a></li><li class="tocline"><a class="tocxref" href="#clear-key-request-format"><bdi class="secno">9.1.3 </bdi>License Request Format</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#clear-key-request-format-example"><bdi class="secno">9.1.3.1 </bdi>Example</a></li></ol></li><li class="tocline"><a class="tocxref" href="#clear-key-license-format"><bdi class="secno">9.1.4 </bdi>License Format</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#clear-key-license-format-example"><bdi class="secno">9.1.4.1 </bdi>Example</a></li></ol></li><li class="tocline"><a class="tocxref" href="#clear-key-release-format"><bdi class="secno">9.1.5 </bdi>License Release Format</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#clear-key-release-format-example-1"><bdi class="secno">9.1.5.1 </bdi>Example message reflecting a <span def-id="record-of-license-destruction" class="formerLink"></span></a></li><li class="tocline"><a class="tocxref" href="#clear-key-release-format-example-2"><bdi class="secno">9.1.5.2 </bdi>Example message reflecting a <span def-id="record-of-key-usage" class="formerLink"></span></a></li></ol></li><li class="tocline"><a class="tocxref" href="#clear-key-release-ack-format"><bdi class="secno">9.1.6 </bdi>License Release Acknowledgement Format</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#clear-key-release-ack-format-example"><bdi class="secno">9.1.6.1 </bdi>Example</a></li></ol></li><li class="tocline"><a class="tocxref" href="#using-base64url"><bdi class="secno">9.1.7 </bdi>Using base64url</a></li></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#security"><bdi class="secno">10. </bdi>Security</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#input-data-security"><bdi class="secno">10.1 </bdi>Input Data Attacks and Vulnerabilities</a></li><li class="tocline"><a class="tocxref" href="#cdm-security"><bdi class="secno">10.2 </bdi>CDM Attacks and Vulnerabilities</a></li><li class="tocline"><a class="tocxref" href="#network-attacks"><bdi class="secno">10.3 </bdi>Network Attacks</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#potential-attacks"><bdi class="secno">10.3.1 </bdi>Potential Attacks</a></li><li class="tocline"><a class="tocxref" href="#mitigations"><bdi class="secno">10.3.2 </bdi>Mitigations</a></li></ol></li><li class="tocline"><a class="tocxref" href="#iframe-attacks"><bdi class="secno">10.4 </bdi><code>iframe</code> Attacks</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#potential-attacks-0"><bdi class="secno">10.4.1 </bdi>Potential Attacks</a></li><li class="tocline"><a class="tocxref" href="#mitigations-0"><bdi class="secno">10.4.2 </bdi>Mitigations</a></li></ol></li><li class="tocline"><a class="tocxref" href="#cross-directory-attacks"><bdi class="secno">10.5 </bdi>Cross-Directory Attacks</a></li></ol></li><li class="tocline"><a class="tocxref" href="#privacy"><bdi class="secno">11. </bdi>Privacy</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#privacy-disclosure"><bdi class="secno">11.1 </bdi>Information Disclosed by EME and Key Systems</a></li><li class="tocline"><a class="tocxref" href="#privacy-fingerprinting"><bdi class="secno">11.2 </bdi>Fingerprinting</a></li><li class="tocline"><a class="tocxref" href="#privacy-leakage"><bdi class="secno">11.3 </bdi>Information Leakage</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#concerns"><bdi class="secno">11.3.1 </bdi>Concerns</a></li><li class="tocline"><a class="tocxref" href="#mitigations-1"><bdi class="secno">11.3.2 </bdi>Mitigations</a></li></ol></li><li class="tocline"><a class="tocxref" href="#user-tracking"><bdi class="secno">11.4 </bdi>User Tracking</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#concerns-0"><bdi class="secno">11.4.1 </bdi>Concerns</a></li><li class="tocline"><a class="tocxref" href="#mitigations-2"><bdi class="secno">11.4.2 </bdi>Mitigations</a></li></ol></li><li class="tocline"><a class="tocxref" href="#privacy-storedinfo"><bdi class="secno">11.5 </bdi>Information Stored on User Devices</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#concerns-1"><bdi class="secno">11.5.1 </bdi>Concerns</a></li><li class="tocline"><a class="tocxref" href="#mitigations-3"><bdi class="secno">11.5.2 </bdi>Mitigations</a></li></ol></li><li class="tocline"><a class="tocxref" href="#incomplete-clearing"><bdi class="secno">11.6 </bdi>Incomplete Clearing of Data</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#concerns-2"><bdi class="secno">11.6.1 </bdi>Concerns</a></li><li class="tocline"><a class="tocxref" href="#mitigations-4"><bdi class="secno">11.6.2 </bdi>Mitigations</a></li></ol></li><li class="tocline"><a class="tocxref" href="#private-browsing"><bdi class="secno">11.7 </bdi>Private Browsing Modes</a></li><li class="tocline"><a class="tocxref" href="#privacy-secureorigin"><bdi class="secno">11.8 </bdi>Secure Origin and Transport</a></li></ol></li><li class="tocline"><a class="tocxref" href="#conformance"><bdi class="secno">12. </bdi>Conformance</a></li><li class="tocline"><a class="tocxref" href="#examples"><bdi class="secno">13. </bdi>Examples</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#example-source-and-key-known"><bdi class="secno">13.1 </bdi>Source and Key Known at Page Load (Clear Key)</a></li><li class="tocline"><a class="tocxref" href="#example-selecting-key-system"><bdi class="secno">13.2 </bdi>Selecting a Supported Key System and Using Initialization Data from the "encrypted" Event</a></li><li class="tocline"><a class="tocxref" href="#example-mediakeys-before-source"><bdi class="secno">13.3 </bdi>Create MediaKeys Before Loading Media</a></li><li class="tocline"><a class="tocxref" href="#example-using-all-events"><bdi class="secno">13.4 </bdi>Using All Events</a></li><li class="tocline"><a class="tocxref" href="#example-stored-license"><bdi class="secno">13.5 </bdi>Stored License</a></li></ol></li><li class="tocline"><a class="tocxref" href="#acknowledgements"><bdi class="secno">14. </bdi>Acknowledgments</a></li><li class="tocline"><a class="tocxref" href="#references"><bdi class="secno">A. </bdi>References</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#normative-references"><bdi class="secno">A.1 </bdi>
         Normative references
       </a></li><li class="tocline"><a class="tocxref" href="#informative-references"><bdi class="secno">A.2 </bdi>
         Informative references
@@ -591,7 +591,7 @@
             <li><p>A value in a configuration file or similar semi-permanent data, even if generated on the client</p></li>
             <li><p>Client or other user account values</p></li>
           </ul>
-          
+
           <p>
             A <dfn id="distinctive-permanent-identifier" data-dfn-type="dfn">Distinctive Permanent Identifier</dfn> is a <a href="#permanent-identifier">Permanent Identifier</a> that is <a href="#distinctive-value">distinctive</a>.
           </p>
@@ -621,7 +621,7 @@
               b) <a href="#browsing-profile">browsing profiles</a>,
               or c) browsing sessions even after the user has attempted to protect his or her privacy by clearing browsing data
               or values for which it is not easy for a user to break such association.
-              In particular, a value is a Distinctive Identifier if it is possible for a <a href="#associable-by-entity">central server, such as an individualization server, to associate</a> values across origins, such as because the <a href="#individualization">individualization</a> requests contained a common value, or because values provided in individualization requests are <a href="#associable-by-entity">associable by such server</a> even after attempts to clear browsing data. 
+              In particular, a value is a Distinctive Identifier if it is possible for a <a href="#associable-by-entity">central server, such as an individualization server, to associate</a> values across origins, such as because the <a href="#individualization">individualization</a> requests contained a common value, or because values provided in individualization requests are <a href="#associable-by-entity">associable by such server</a> even after attempts to clear browsing data.
               Possible causes of this include use of <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifier(s)</a> in the individualization process.
             </p>
             <p>
@@ -630,7 +630,7 @@
             </p>
             <p>
               While the instantiation or use of a Distinctive Identifier is triggered by the application's use of the APIs defined in this specification, the identifier need not be provided to the application to trigger conditions related to Distinctive Identifiers.
-              (The <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifier(s)</a> <em class="rfc2119" title="MUST NOT">MUST NOT</em> ever be provided to the application, even in opaque or encrypted form.) 
+              (The <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifier(s)</a> <em class="rfc2119" title="MUST NOT">MUST NOT</em> ever be provided to the application, even in opaque or encrypted form.)
             </p>
           </div></div>
           <div class="note" role="note" id="issue-container-generatedID-16"><div role="heading" class="note-title marker" id="h-note-16" aria-level="3"><span>Note</span></div><p class="">
@@ -660,7 +660,7 @@
                 </li>
               </ul>
               <div class="note" role="note" id="issue-container-generatedID-19"><div role="heading" class="note-title marker" id="h-note-19" aria-level="3"><span>Note</span></div><div class="">
-                <p>Other properties of concern that are normatively prohibited for values exposed to the application include:</p> 
+                <p>Other properties of concern that are normatively prohibited for values exposed to the application include:</p>
                 <ul>
                   <li><p>It is a <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifier</a>.</p></li>
                   <li><p>It is <em>not</em> <a href="#allow-identifiers-cleared">clearable</a>.</p></li>
@@ -762,8 +762,8 @@
 
         <dt id="time">Time</dt>
         <dd>
-          <p>Time <em class="rfc2119" title="MUST">MUST</em> be equivalent to that represented in <a class="external" href="https://tc39.github.io/ecma262/#sec-time-values-and-time-range">ECMAScript <span class="estype">Time Values and Time Range</span></a> [<cite><a class="bibref" data-link-type="biblio" href="#bib-ecma-262" title="ECMAScript Language Specification">ECMA-262</a></cite>]. 
-          </p>    
+          <p>Time <em class="rfc2119" title="MUST">MUST</em> be equivalent to that represented in <a class="external" href="https://tc39.github.io/ecma262/#sec-time-values-and-time-range">ECMAScript <span class="estype">Time Values and Time Range</span></a> [<cite><a class="bibref" data-link-type="biblio" href="#bib-ecma-262" title="ECMAScript Language Specification">ECMA-262</a></cite>].
+          </p>
           <p>Time will equal <code>NaN</code> if no such time exists or if the time is indeterminate.  It should never have the value <code>Infinity</code>.
           </p>
           <div class="note" role="note" id="issue-container-generatedID-23"><div role="heading" class="note-title marker" id="h-note-23" aria-level="3"><span>Note</span></div><p class="">
@@ -810,12 +810,12 @@
       </p>
       <p>The steps of an algorithm are always aborted when rejecting a promise.</p>
 
-      <section id="feature-policy-integration">
-        <h3 id="x3-1-feature-policy-integration"><bdi class="secno">3.1 </bdi>Feature Policy Integration<a class="self-link" aria-label="§" href="#feature-policy-integration"></a></h3>
+      <section id="permissions-policy-integration">
+        <h3 id="x3-1-permissions-policy-integration"><bdi class="secno">3.1 </bdi>Permissions Policy Integration<a class="self-link" aria-label="§" href="#permissions-policy-integration"></a></h3>
         <p>
           <code><a href="#dom-navigator-requestmediakeysystemaccess">requestMediaKeySystemAccess()</a></code> is a <a href="https://www.w3.org/TR/permissions-policy-1/#policy-controlled-feature">policy-controlled feature</a>
           identified by the string <dfn data-dfn-type="dfn" id="dfn-encrypted-media"><code>encrypted-media</code></dfn>.  Its <a href="https://www.w3.org/TR/permissions-policy-1/#default-allowlist">default allowlist</a> is <code>'self'</code>
-          [<cite><a class="bibref" data-link-type="biblio" href="#bib-feature-policy" title="Permissions Policy">FEATURE-POLICY</a></cite>].
+          [<cite><a class="bibref" data-link-type="biblio" href="#bib-permissions-policy" title="Permissions Policy">PERMISSIONS-POLICY</a></cite>].
         </p>
       </section>
 
@@ -843,7 +843,7 @@ partial interface <a class="internalDFN idlID" data-link-type="interface" href="
                 Requiring Secure Contexts is <em>not</em> a replacement for other security- and privacy-related requirements and recommendations.
                 Implementations <em class="rfc2119" title="MUST">MUST</em> meet all related requirements and <em class="rfc2119" title="SHOULD">SHOULD</em> follow related recommendations such that the risks on in an secure context would be similar.
               </p>
-            </div></div> 
+            </div></div>
 
             
           <table class="parameters"><tbody><tr><th>Parameter</th><th>Type</th><th>Nullable</th><th>Optional</th><th>Description</th></tr><tr><td class="prmName">keySystem</td><td class="prmType"><code>DOMString</code></td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td><td class="prmDesc">
@@ -854,9 +854,8 @@ partial interface <a class="internalDFN idlID" data-link-type="interface" href="
               </td></tr></tbody></table><div><em>Return type: </em><code>Promise&lt;MediaKeySystemAccess&gt;</code></div><p>When this method is invoked, the user agent must run the following steps:</p><ol class="method-algorithm">
               
 
-              <li><p>If the <a href="https://www.w3.org/TR/permissions-policy-1/#responsible-document">responsible
-              document</a> is not <a href="https://www.w3.org/TR/permissions-policy-1/#allowed-to-use">allowed to use</a>
-              the <a href="#dfn-encrypted-media" class="internalDFN" data-link-type="dfn"><code><code>encrypted-media</code></code></a> feature, then throw a "<a href="https://heycam.github.io/webidl/#securityerror">SecurityError</a>" <a href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a> and abort these steps.</p></li>
+              <li><p>If the <a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document">responsible
+              document</a> is not <a data-type="dfn" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use">allowed to use</a> the <a href="#dfn-encrypted-media" class="internalDFN" data-link-type="dfn"><code><code>encrypted-media</code></code></a> feature, then throw a "<a href="https://heycam.github.io/webidl/#securityerror">SecurityError</a>" <a href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a> and abort these steps.</p></li>
 
               <li><p>If <var>keySystem</var> is the empty string, return a promise rejected with a newly created <code><a href="#dfn-TypeError">TypeError</a></code>.</p></li>
               <li><p>If <var>supportedConfigurations</var> is empty, return a promise rejected with a newly created <code><a href="#dfn-TypeError">TypeError</a></code>.</p></li>
@@ -1097,7 +1096,7 @@ partial interface <a class="internalDFN idlID" data-link-type="interface" href="
                 </ol>
               </li>
               <li><p>Set the <code><a href="#dom-mediakeysystemconfiguration-sessiontypes">sessionTypes</a></code> member of <var>accumulated configuration</var> to <var>session types</var>.</p></li>
-              
+
               <li>
                 <p>
                   If the <code><a href="#dom-mediakeysystemconfiguration-videocapabilities">videoCapabilities</a></code> and <code><a href="#dom-mediakeysystemconfiguration-audiocapabilities">audioCapabilities</a></code> members in <var>candidate configuration</var>
@@ -1769,7 +1768,7 @@ The <dfn data-dfn-type="enum" data-export="" id="dom-mediakeysrequirement" data-
 };</span></pre><section><h3 id="methods-1">Methods<a class="self-link" aria-label="§" href="#methods-1"></a></h3><dl class="methods" data-dfn-for="MediaKeys" data-link-for="MediaKeys"><dt><dfn data-dfn-type="method" data-export="" id="dom-mediakeys-createsession" data-idl="operation" data-title="createSession" data-dfn-for="MediaKeys" data-type="MediaKeySession" data-lt="createSession()|createSession(, sessionType)" data-local-lt="MediaKeys.createSession|MediaKeys.createSession()|createSession"><code id="createSession">createSession</code></dfn></dt><dd>
           <p>Returns a new <a href="#dom-mediakeysession" class="internalDFN" data-link-type="idl"><code>MediaKeySession</code></a> object.</p>
 
-          
+
 
           
         <table class="parameters"><tbody><tr><th>Parameter</th><th>Type</th><th>Nullable</th><th>Optional</th><th>Description</th></tr><tr><td class="prmName">sessionType</td><td class="prmType"><code>MediaKeySessionType = "temporary"</code></td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptTrue"><span role="img" aria-label="True">✔</span></td><td class="prmDesc">
@@ -1778,7 +1777,7 @@ The <dfn data-dfn-type="enum" data-export="" id="dom-mediakeysrequirement" data-
             <li><p>If this object's <var>supported session types</var> value does not contain <var>sessionType</var>, <a href="https://heycam.github.io/webidl/#dfn-throw">throw</a> [<cite><a class="bibref" data-link-type="biblio" href="#bib-webidl" title="Web IDL">WEBIDL</a></cite>] a <code><a href="#dfn-NotSupportedError">NotSupportedError</a></code>.</p>
               <div class="note" role="note" id="issue-container-generatedID-59"><div role="heading" class="note-title marker" id="h-note-59" aria-level="4"><span>Note</span></div><p class=""><var>sessionType</var> values for which the <a href="#is-persistent-session-type">Is persistent session type?</a> algorithm returns <code>true</code> will fail if this object's <var>persistent state allowed</var> value is <code>false</code>.</p></div>
             </li>
-            <li><p>If the implementation does not support <a href="#dom-mediakeysession" class="internalDFN" data-link-type="idl"><code>MediaKeySession</code></a> operations in the current state, <a href="https://heycam.github.io/webidl/#dfn-throw">throw</a> [<cite><a class="bibref" data-link-type="biblio" href="#bib-webidl" title="Web IDL">WEBIDL</a></cite>] an <code><a href="#dfn-InvalidStateError">InvalidStateError</a></code>.</p> 
+            <li><p>If the implementation does not support <a href="#dom-mediakeysession" class="internalDFN" data-link-type="idl"><code>MediaKeySession</code></a> operations in the current state, <a href="https://heycam.github.io/webidl/#dfn-throw">throw</a> [<cite><a class="bibref" data-link-type="biblio" href="#bib-webidl" title="Web IDL">WEBIDL</a></cite>] an <code><a href="#dfn-InvalidStateError">InvalidStateError</a></code>.</p>
               <div class="note" role="note" id="issue-container-generatedID-60"><div role="heading" class="note-title marker" id="h-note-60" aria-level="4"><span>Note</span></div><p class="">Some implementations are unable to execute <a href="#dom-mediakeysession" class="internalDFN" data-link-type="idl"><code>MediaKeySession</code></a> algorithms until this <a href="#dom-mediakeys" class="internalDFN" data-link-type="idl"><code>MediaKeys</code></a> object is associated with a media element using <code><a href="#dom-htmlmediaelement-setmediakeys">setMediaKeys()</a></code>.
               This step enables applications to detect this uncommon behavior before attempting to perform such operations.
               </p></div>
@@ -1810,7 +1809,7 @@ The <dfn data-dfn-type="enum" data-export="" id="dom-mediakeysrequirement" data-
             It is intended as an optimization, and applications are not required to use it.
           </p></div>
 
-          
+
 
           
         <table class="parameters"><tbody><tr><th>Parameter</th><th>Type</th><th>Nullable</th><th>Optional</th><th>Description</th></tr><tr><td class="prmName">serverCertificate</td><td class="prmType"><code>BufferSource</code></td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td><td class="prmDesc">
@@ -1862,7 +1861,7 @@ The <dfn data-dfn-type="enum" data-export="" id="dom-mediakeysrequirement" data-
             </li>
           </ol>
         </section>
-        
+
         <section id="cdm-unavailable">
           <h4 id="x5-1-2-cdm-unavailable"><bdi class="secno">5.1.2 </bdi>CDM Unavailable<a class="self-link" aria-label="§" href="#cdm-unavailable"></a></h4>
           <p>
@@ -1880,7 +1879,7 @@ The <dfn data-dfn-type="enum" data-export="" id="dom-mediakeysrequirement" data-
       <section id="media-keys-storage">
         <h3 id="x5-2-storage-and-persistence"><bdi class="secno">5.2 </bdi>Storage and Persistence<a class="self-link" aria-label="§" href="#media-keys-storage"></a></h3>
         <p>This section describes general requirements related to storage and persistence.</p>
-        
+
         <p>
           If a <a href="#dom-mediakeys" class="internalDFN" data-link-type="idl"><code>MediaKeys</code></a> object's <var>persistent state allowed</var> value is <code>false</code> then the object's <var>cdm instance</var>
           <em class="rfc2119" title="SHALL NOT">SHALL NOT</em> persist state or access previously persisted state as a result of operations on this object or any sessions that it creates.
@@ -1889,12 +1888,12 @@ The <dfn data-dfn-type="enum" data-export="" id="dom-mediakeysrequirement" data-
           If a <a href="#dom-mediakeys" class="internalDFN" data-link-type="idl"><code>MediaKeys</code></a> object's <var>persistent state allowed</var> value is <code>true</code> then the object's <var>cdm instance</var>
           <em class="rfc2119" title="MAY">MAY</em> persist state or access previously persisted state as a result of operations on this object or any sessions that it creates.
         </p>
-        
+
         <p>Persisted data <em class="rfc2119" title="MUST">MUST</em> always be stored such that only the <a href="https://www.w3.org/TR/html51/browsers.html#concept-cross-origin">origin</a> of this object's <a href="https://www.w3.org/TR/dom/#concept-document">Document</a> can access it.
           In addition, the data <em class="rfc2119" title="MUST">MUST</em> only be accessible by the current <a href="#browsing-profile">browsing profile</a>; other browsing profiles, user agents, and applications <em class="rfc2119" title="MUST NOT">MUST NOT</em> be able to access the stored data.
           See <a href="#privacy-storedinfo">Information Stored on User Devices</a>.
         </p>
-        
+
         <p>See <a href="#security" class="sec-ref">§&nbsp;<bdi class="secno">10. </bdi>Security</a> and <a href="#privacy" class="sec-ref">§&nbsp;<bdi class="secno">11. </bdi>Privacy</a> for additional considerations when supporting persistent storage.</p>
 
       </section>
@@ -1929,7 +1928,7 @@ The <dfn data-dfn-type="enum" data-export="" id="dom-mediakeysrequirement" data-
       <div class="note" role="note" id="issue-container-generatedID-64"><div role="heading" class="note-title marker" id="h-note-64" aria-level="3"><span>Note</span></div><p class="">Closing the key session results in the destruction of any license(s) and key(s) that have not been explicitly stored.</p></div>
       <div class="note" role="note" id="issue-container-generatedID-65"><div role="heading" class="note-title marker" id="h-note-65" aria-level="3"><span>Note</span></div><p class="">
         Exactly when the key session is closed is an implementation detail, and applications <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> rely on specific timing.
-         
+        
         Applications that want to ensure a session is closed before taking some other action <em class="rfc2119" title="SHOULD">SHOULD</em> call <code><a href="#dom-mediakeysession-close">close()</a></code> and wait for the returned promise to be resolved.
       </p></div>
       <p>
@@ -1972,7 +1971,7 @@ The <dfn data-dfn-type="enum" data-export="" id="dom-mediakeysrequirement" data-
             Key IDs <em class="rfc2119" title="MUST NOT">MUST NOT</em> be removed because they became unusable, such as due to expiration. Instead, such keys <em class="rfc2119" title="MUST">MUST</em> be given an appropriate status, such as <code><a href="#idl-def-MediaKeyStatus.expired">"expired"</a></code>.
           </p></div>
           <div class="note" role="note" id="issue-container-generatedID-68"><div role="heading" class="note-title marker" id="h-note-68" aria-level="4"><span>Note</span></div><p class="">
-            Some older platforms may contain Key System implementations that do not expose key IDs, making it impossible to provide a compliant user agent implementation. 
+            Some older platforms may contain Key System implementations that do not expose key IDs, making it impossible to provide a compliant user agent implementation.
             To maximize interoperability, user agent implementations exposing such CDMs <em class="rfc2119" title="SHOULD">SHOULD</em> implement this member as follows:
             Whenever a non-empty list is appropriate, such as when the <a href="#key-session">key session</a> represented by this object may contain <a href="#decryption-key">key(s)</a>, populate the map with a single pair containing
             the one-byte key ID <code>0</code> and the <a href="#dom-mediakeystatus" class="internalDFN" data-link-type="idl"><code>MediaKeyStatus</code></a> most appropriate for the aggregated status of this object.
@@ -1986,7 +1985,7 @@ The <dfn data-dfn-type="enum" data-export="" id="dom-mediakeysrequirement" data-
             A <code><a href="#dom-evt-message">message</a></code> of type <code><a href="#idl-def-MediaKeyMessageType.license-request">"license-request"</a></code> or <code><a href="#idl-def-MediaKeyMessageType.individualization-request">"individualization-request"</a></code> will always be queued if the algorithm succeeds and the promise is resolved.
           </p>
 
-          
+
 
           
         <table class="parameters"><tbody><tr><th>Parameter</th><th>Type</th><th>Nullable</th><th>Optional</th><th>Description</th></tr><tr><td class="prmName">initDataType</td><td class="prmType"><code>DOMString</code></td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td><td class="prmDesc">
@@ -2133,7 +2132,7 @@ The <dfn data-dfn-type="enum" data-export="" id="dom-mediakeysrequirement" data-
           </ol></dd><dt><dfn data-dfn-type="method" data-export="" id="dom-mediakeysession-load" data-idl="operation" data-title="load" data-dfn-for="MediaKeySession" data-type="Promise" data-lt="load()|load(sessionId)" data-local-lt="MediaKeySession.load|MediaKeySession.load()|load"><code id="load">load</code></dfn></dt><dd>
           <p>Loads the data stored for the specified session into this object.</p>
 
-          
+
 
           
         <table class="parameters"><tbody><tr><th>Parameter</th><th>Type</th><th>Nullable</th><th>Optional</th><th>Description</th></tr><tr><td class="prmName">sessionId</td><td class="prmType"><code>DOMString</code></td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td><td class="prmDesc">
@@ -2210,7 +2209,7 @@ The <dfn data-dfn-type="enum" data-export="" id="dom-mediakeysrequirement" data-
           </ol></dd><dt><dfn data-dfn-type="method" data-export="" id="dom-mediakeysession-update" data-idl="operation" data-title="update" data-dfn-for="MediaKeySession" data-type="Promise" data-lt="update()|update(response)" data-local-lt="MediaKeySession.update|MediaKeySession.update()|update"><code id="update">update</code></dfn></dt><dd>
           <p>Provides messages, including licenses, to the CDM.</p>
 
-          
+
 
           
         <table class="parameters"><tbody><tr><th>Parameter</th><th>Type</th><th>Nullable</th><th>Optional</th><th>Description</th></tr><tr><td class="prmName">response</td><td class="prmType"><code>BufferSource</code></td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td><td class="prmDesc">
@@ -2502,11 +2501,11 @@ The <dfn data-dfn-type="enum" data-export="" id="dom-mediakeysrequirement" data-
         <p>The MediaKeyStatusMap object is a read-only map of <a href="#decryption-key-id">key IDs</a> to the current status of the associated key.</p>
         <p>A key's status is independent of whether the key is currently being used and of media data.</p>
         <div class="note" role="note" id="issue-container-generatedID-89"><div role="heading" class="note-title marker" id="h-note-89" aria-level="4"><span>Note</span></div><p class="">For example, if a key has output requirements that cannot currently be met, the key's status should be <code><a href="#idl-def-MediaKeyStatus.output-downscaled">"output-downscaled"</a></code> or <code><a href="#idl-def-MediaKeyStatus.output-restricted">"output-restricted"</a></code>, as appropriate, regardless of whether that key has been or is currently needed to decrypt media data.</p></div>
-        <div><pre class="idl def" id="webidl-427238198"><span class="idlHeader"><a class="self-link" href="#webidl-427238198">WebIDL</a></span><span data-idl="" class="idlInterface" id="idl-def-mediakeystatusmap" data-title="MediaKeyStatusMap">[<span class="extAttr"><a data-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<a data-type="interface" href="https://html.spec.whatwg.org/multipage/window-object.html#window">Window</a></span>, <span class="extAttr"><a data-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a></span>] interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-mediakeystatusmap"><code>MediaKeyStatusMap</code></a> {<span data-idl="" class="idlIterable" id="idl-def-mediakeystatusmap-iterable" data-title="iterable" data-dfn-for="MediaKeyStatusMap">
+        <div><pre class="idl def" id="webidl-366396555"><span class="idlHeader"><a class="self-link" href="#webidl-366396555">WebIDL</a></span><span data-idl="" class="idlInterface" id="idl-def-mediakeystatusmap" data-title="MediaKeyStatusMap">[<span class="extAttr"><a data-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<a data-type="interface" href="https://html.spec.whatwg.org/multipage/window-object.html#window">Window</a></span>, <span class="extAttr"><a data-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a></span>] interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-mediakeystatusmap"><code>MediaKeyStatusMap</code></a> {<span data-idl="" class="idlIterable" id="idl-def-mediakeystatusmap-iterable" data-title="iterable" data-dfn-for="MediaKeyStatusMap">
     <a data-type="dfn" href="https://heycam.github.io/webidl/#dfn-iterable">iterable</a>&lt;<a data-type="typedef" href="https://heycam.github.io/webidl/#BufferSource">BufferSource</a>,<a href="#dom-mediakeystatus" class="internalDFN" data-link-type="idl"><code>MediaKeyStatus</code></a>&gt;;</span><span data-idl="" class="idlAttribute" id="idl-def-mediakeystatusmap-size" data-title="size" data-dfn-for="MediaKeyStatusMap">
     readonly        attribute<span class="idlType"> <a data-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long">unsigned long</a></span> <a class="internalDFN idlName" data-link-type="attribute" href="#dom-mediakeystatusmap-size"><code>size</code></a>;</span><span data-idl="" class="idlMethod" id="idl-def-mediakeystatusmap-has-keyid" data-title="has" data-dfn-for="MediaKeyStatusMap"><span class="idlType">
     <a data-type="interface" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a></span> <a class="internalDFN idlName" data-link-type="method" href="#dom-mediakeystatusmap-has"><code>has</code></a> (<span class="idlType"><a data-type="typedef" href="https://heycam.github.io/webidl/#BufferSource">BufferSource</a></span> <span class="idlParamName">keyId</span>);</span><span data-idl="" class="idlMethod" id="idl-def-mediakeystatusmap-get-keyid" data-title="get" data-dfn-for="MediaKeyStatusMap"><span class="idlType">
-    <a data-type="interface" href="https://heycam.github.io/webidl/#idl-any">any</a></span>     <a class="internalDFN idlName" data-link-type="method" href="#dom-mediakeystatusmap-get"><code>get</code></a> (<span class="idlType"><a data-type="typedef" href="https://heycam.github.io/webidl/#BufferSource">BufferSource</a></span> <span class="idlParamName">keyId</span>);</span>
+    (<a href="#dom-mediakeystatus" class="internalDFN" data-link-type="idl"><code>MediaKeyStatus</code></a> or <a data-type="interface" href="https://heycam.github.io/webidl/#idl-undefined">undefined</a>)</span>     <a class="internalDFN idlName" data-link-type="method" href="#dom-mediakeystatusmap-get"><code>get</code></a> (<span class="idlType"><a data-type="typedef" href="https://heycam.github.io/webidl/#BufferSource">BufferSource</a></span> <span class="idlParamName">keyId</span>);</span>
 };</span></pre>
           <section>
             <h4 id="attributes-1">Attributes<a class="self-link" aria-label="§" href="#attributes-1"></a></h4>
@@ -2522,14 +2521,14 @@ The <dfn data-dfn-type="enum" data-export="" id="dom-mediakeysrequirement" data-
               <dt><dfn data-dfn-type="method" data-export="" id="dom-mediakeystatusmap-has" data-idl="operation" data-title="has" data-dfn-for="MediaKeyStatusMap" data-type="boolean" data-lt="has()|has(keyId)" data-local-lt="MediaKeyStatusMap.has|MediaKeyStatusMap.has()|has"><code id="has">has</code></dfn></dt>
               <dd>
                 <p>Returns <code>true</code> if the status of the key identified by <var>keyId</var> is known.</p>
-            
+
                 <table class="parameters"><tbody><tr><th>Parameter</th><th>Type</th><th>Nullable</th><th>Optional</th><th>Description</th></tr><tr><td class="prmName">keyId</td><td class="prmType"><code>BufferSource</code></td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td><td class="prmDesc">The <a href="#decryption-key-id">key ID</a> of the key.</td></tr></tbody></table>
                 <div><em>Return type: </em><code>boolean</code></div>
               </dd>
-              <dt><dfn data-dfn-type="method" data-export="" id="dom-mediakeystatusmap-get" data-idl="operation" data-title="get" data-dfn-for="MediaKeyStatusMap" data-type="any" data-lt="get()|get(keyId)" data-local-lt="MediaKeyStatusMap.get|MediaKeyStatusMap.get()|get"><code id="get">get</code></dfn></dt>
+              <dt><dfn data-dfn-type="method" data-export="" id="dom-mediakeystatusmap-get" data-idl="operation" data-title="get" data-dfn-for="MediaKeyStatusMap" data-type="MediaKeyStatus|undefined" data-lt="get()|get(keyId)" data-local-lt="MediaKeyStatusMap.get|MediaKeyStatusMap.get()|get"><code id="get">get</code></dfn></dt>
               <dd>
                 <p>Returns the <a href="#dom-mediakeystatus" class="internalDFN" data-link-type="idl"><code>MediaKeyStatus</code></a> of the key identified by <var>keyId</var> or <code>undefined</code> if the status of the key identified by <var>keyId</var> is not known.</p>
-            
+
                 <table class="parameters"><tbody><tr><th>Parameter</th><th>Type</th><th>Nullable</th><th>Optional</th><th>Description</th></tr><tr><td class="prmName">keyId</td><td class="prmType"><code>BufferSource</code></td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td><td class="prmDesc">The <a href="#decryption-key-id">key ID</a> of the key.</td></tr></tbody></table>
                 <div><em>Return type: </em><code>any</code></div>
               </dd>
@@ -2743,7 +2742,7 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-med
             <li><p>Set the <var>session</var>'s <code><a href="#dom-mediakeysession-expiration">expiration</a></code> attribute to <var>expiration time</var> expressed as <a href="#time">time</a>.</p></li>
           </ol>
         </section>
-      
+
         <section id="session-closed">
           <h4 id="x6-4-4-session-closed"><bdi class="secno">6.4.4 </bdi>Session Closed<a class="self-link" aria-label="§" href="#session-closed"></a></h4>
           <p>The Session Closed algorithm updates the <a href="#dom-mediakeysession" class="internalDFN" data-link-type="idl"><code>MediaKeySession</code></a> state after a <a href="#key-session">key session</a> has been closed by the <a href="#cdm">CDM</a>.</p>
@@ -2979,8 +2978,8 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-med
           In other words, <code><a href="#dom-mediakeysession-load">load()</a></code> <em class="rfc2119" title="MUST">MUST</em> fail when there is already a <a href="#dom-mediakeysession" class="internalDFN" data-link-type="idl"><code>MediaKeySession</code></a> representing the session specified by the <var>sessionId</var> parameter, either because the object that created it via <code><a href="#dom-mediakeysession-generaterequest">generateRequest()</a></code> is still active or it has been loaded into another object via <code><a href="#dom-mediakeysession-load">load()</a></code>.
           A session <em class="rfc2119" title="MAY">MAY</em> only be loaded again if all objects that have ever represented it are <a href="#media-key-session-closed">closed</a>.
         </p>
-        <p>An application that creates a session using a type for which the <a href="#is-persistent-session-type">Is persistent session type?</a> algorithm returns <code>true</code> <em class="rfc2119" title="SHOULD">SHOULD</em> 
-          later remove the stored data by first initiating the removal process using <code><a href="#dom-mediakeysession-remove">remove()</a></code> and then ensuring that the removal process, which may involve 
+        <p>An application that creates a session using a type for which the <a href="#is-persistent-session-type">Is persistent session type?</a> algorithm returns <code>true</code> <em class="rfc2119" title="SHOULD">SHOULD</em>
+          later remove the stored data by first initiating the removal process using <code><a href="#dom-mediakeysession-remove">remove()</a></code> and then ensuring that the removal process, which may involve
           message exchange(s), successfully completes. The CDM <em class="rfc2119" title="MAY">MAY</em> also remove sessions as appropriate, but applications <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> rely on this.
         </p>
         <p>See <a href="#security" class="sec-ref">§&nbsp;<bdi class="secno">10. </bdi>Security</a> and <a href="#privacy" class="sec-ref">§&nbsp;<bdi class="secno">11. </bdi>Privacy</a> for additional considerations when supporting persistent storage.</p>
@@ -2989,9 +2988,9 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-med
 
     <section id="htmlmediaelement-extensions">
       <h2 id="x7-htmlmediaelement-extensions"><bdi class="secno">7. </bdi><dfn data-dfn-type="dfn" id="dom-htmlmediaelement" data-idl="interface" data-title="HTMLMediaElement" data-dfn-for=""><code>HTMLMediaElement</code></dfn> Extensions<a class="self-link" aria-label="§" href="#htmlmediaelement-extensions"></a></h2>
+
       
-      
-      
+
       <p>This section specifies additions to and modifications of the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#htmlmediaelement-htmlmediaelement">HTMLMediaElement</a></code> [<cite><a class="bibref" data-link-type="biblio" href="#bib-html" title="HTML Standard">HTML</a></cite>] when the Encrypted Media Extensions are supported.</p>
       <p>The following internal values are added to the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#htmlmediaelement-htmlmediaelement">HTMLMediaElement</a></code>:</p>
       <ul>
@@ -3371,7 +3370,7 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-med
                                     </li>
                                     <li><p>Return to the beginning of this algorithm.</p></li>
                                   </ol>
-                                  
+
                                 </dd>
                               </dl>
                               <div class="note" role="note" id="issue-container-generatedID-119"><div role="heading" class="note-title marker" id="h-note-119" aria-level="5"><span>Note</span></div><p class="">Not all decryption problems (e.g., using the wrong key) will result in a decryption failure. In such cases, no error is fired here but one may be fired during decode.</p></div>
@@ -3438,7 +3437,7 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-med
                 <dd>
                   <p>Set the <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">readyState</a></code> of <var>media element</var> to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_metadata">HAVE_METADATA</a></code>.</p>
                 </dd>
-              </dl>                  
+              </dl>
               <div class="note" role="note" id="issue-container-generatedID-125"><div role="heading" class="note-title marker" id="h-note-125" aria-level="5"><span>Note</span></div><p class="">
                 In other words, if the video frame and audio data for the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#current-position">current playback position</a> have been decoded because they were unencrypted and/or successfully decrypted, set <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">readyState</a></code> to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_current_data">HAVE_CURRENT_DATA</a></code>.
                 Otherwise, including if this was previously the case but the data is no longer available, set <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-readystate">readyState</a></code> to <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dom-htmlmediaelement-have_metadata">HAVE_METADATA</a></code>.
@@ -3510,7 +3509,7 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-med
       <section id="cdm-constraint-requirements">
         <h3 id="x8-1-cdm-constraints"><bdi class="secno">8.1 </bdi>CDM Constraints<a class="self-link" aria-label="§" href="#cdm-constraint-requirements"></a></h3>
         <p>
-          User agent implementers <em class="rfc2119" title="MUST">MUST</em> ensure that CDMs do not access any information, storage or system capabilities that are not reasonably required for playback of protected media using the features of this specification. 
+          User agent implementers <em class="rfc2119" title="MUST">MUST</em> ensure that CDMs do not access any information, storage or system capabilities that are not reasonably required for playback of protected media using the features of this specification.
           Specifically, the CDM <em class="rfc2119" title="SHALL NOT">SHALL NOT</em>:
         </p>
         <ul>
@@ -3536,10 +3535,10 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-med
           </li>
         </ul>
         <p>
-          User Agent implementers may use various techniques to meet the above requirements. For example, a User Agent implementer also implementing their own CDM may include the above as design requirements for that component. 
+          User Agent implementers may use various techniques to meet the above requirements. For example, a User Agent implementer also implementing their own CDM may include the above as design requirements for that component.
           A User Agent implementer making use of a third party CDM may ensure that it executes in a constrained environment (e.g., "sandbox") without access to the prohibited information and components.
         </p>
-      </section>  
+      </section>
 
       <section id="messaging-requirements">
         <h3 id="x8-2-messages-and-communication"><bdi class="secno">8.2 </bdi>Messages and Communication<a class="self-link" aria-label="§" href="#messaging-requirements"></a></h3>
@@ -3551,7 +3550,7 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-med
           This includes all license exchange messages.
         </p>
       </section>
-        
+
       <section id="persistent-state-requirements">
         <h3 id="x8-3-persistent-data"><bdi class="secno">8.3 </bdi>Persistent Data<a class="self-link" aria-label="§" href="#persistent-state-requirements"></a></h3>
         <p>
@@ -3634,7 +3633,7 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-med
           </p>
         </section>
       </section>
-        
+
       <section id="exposed-value-requirements">
         <h3 id="x8-4-values-exposed-to-the-application"><bdi class="secno">8.4 </bdi>Values Exposed to the Application<a class="self-link" aria-label="§" href="#exposed-value-requirements"></a></h3>
         <p>Values exposed to or inferable by, such as via its use by the CDM, the application could be used to identify the client or user, regardless of whether they are designed to be identifiers.
@@ -3675,7 +3674,7 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-med
         <h3 id="x8-5-identifiers"><bdi class="secno">8.5 </bdi>Identifiers<a class="self-link" aria-label="§" href="#identifier-requirements"></a></h3>
         <p>The use of identifiers, especially <a href="#uses-distinctive-identifiers-or-distinctive-permanent-identifiers">Distinctive Identifier(s) or Distinctive Permanent Identifier(s)</a>, by implementations presents a privacy concern.
           This section defines requirements for avoiding or at least mitigating such concerns.
-          The requirements for <a href="#exposed-value-requirements">Values Exposed to the Application</a> also apply to identifiers exposed to the application. 
+          The requirements for <a href="#exposed-value-requirements">Values Exposed to the Application</a> also apply to identifiers exposed to the application.
         </p>
         <div class="note" role="note" id="issue-container-generatedID-128"><div role="heading" class="note-title marker" id="h-note-128" aria-level="4"><span>Note</span></div><div class="">
           <p>In summary:</p>
@@ -3784,7 +3783,7 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-med
           <div class="note" role="note" id="issue-container-generatedID-136"><div role="heading" class="note-title marker" id="h-note-136" aria-level="5"><span>Note</span></div><p class="">
             For all such identifiers, it <em class="rfc2119" title="MUST NOT">MUST NOT</em> be possible for one or more applications, including related license or other servers to achieve such correlation or association.
           </p></div>
-        </section> 
+        </section>
 
         <section id="allow-identifiers-cleared">
           <h4 id="x8-5-5-allow-identifiers-to-be-cleared"><bdi class="secno">8.5.5 </bdi>Allow Identifiers to Be Cleared<a class="self-link" aria-label="§" href="#allow-identifiers-cleared"></a></h4>
@@ -3935,8 +3934,8 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-med
             Thus, encrypting such tracks would prevent them from being widely available for use with accessibility features in user agent implementations.
           </p></div>
           <p>
-            To ensure accessibility information is available in usable form, for implementations that choose to support encrypted in-band support content: a) the CDM <em class="rfc2119" title="MUST">MUST</em> provide the decrypted data to the user agent and 
-            b) the user agent <em class="rfc2119" title="MUST">MUST</em> process it in the same way as equivalent unencrypted support content. For example, to be exposed as <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timed-text-tracks">timed text tracks</a></code> [<cite><a class="bibref" data-link-type="biblio" href="#bib-html" title="HTML Standard">HTML</a></cite>].            
+            To ensure accessibility information is available in usable form, for implementations that choose to support encrypted in-band support content: a) the CDM <em class="rfc2119" title="MUST">MUST</em> provide the decrypted data to the user agent and
+            b) the user agent <em class="rfc2119" title="MUST">MUST</em> process it in the same way as equivalent unencrypted support content. For example, to be exposed as <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#timed-text-tracks">timed text tracks</a></code> [<cite><a class="bibref" data-link-type="biblio" href="#bib-html" title="HTML Standard">HTML</a></cite>].
           </p>
         </section>
       </section>
@@ -3972,7 +3971,7 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-med
             </li>
             <li><p>The <code><a href="#idl-def-MediaKeySessionType.persistent-license">"persistent-license"</a></code> <a href="#dom-mediakeysessiontype" class="internalDFN" data-link-type="idl"><code>MediaKeySessionType</code></a>: Implementations <em class="rfc2119" title="MAY">MAY</em> support this type.</p></li>
             <li><p>The <code><a href="#idl-def-MediaKeySessionType.persistent-usage-record">"persistent-usage-record"</a></code> <a href="#dom-mediakeysessiontype" class="internalDFN" data-link-type="idl"><code>MediaKeySessionType</code></a>: Implementations <em class="rfc2119" title="MAY">MAY</em> support this type.</p></li>
-            
+
             <li><p>The <code><a href="#dom-mediakeys-setservercertificate">setServerCertificate()</a></code> method: Not supported.</p></li>
             <li><p>The <code><a href="#dom-htmlmediaelement-setmediakeys">setMediaKeys()</a></code> method: Implementations <em class="rfc2119" title="MAY">MAY</em> support associating the <a href="#dom-mediakeys" class="internalDFN" data-link-type="idl"><code>MediaKeys</code></a> object with more than one <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#htmlmediaelement-htmlmediaelement">HTMLMediaElement</a></code>.</p></li>
           </ul>
@@ -4435,7 +4434,7 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-med
             <li><p>Content viewed (via stored or in-memory licenses, keys, key IDs, <a href="#record-of-license-destruction">records of license destruction</a>, <a href="#record-of-key-usage">records of key usage</a>, etc.)</p></li>
           </ul>
           <p>This specification presents a specific concern because such information is commonly stored outside the user agent (and associated <a href="#browsing-profile">browsing profile</a> storage), often in the CDM.</p>
-          
+
           <p>Since the content of licenses, <a href="#record-of-license-destruction">records of license destruction</a>, and <a href="#record-of-key-usage">records of key usage</a> are Key System-specific and since key IDs may contain any value, these data items could be abused to store user-identifying information.</p>
 
           <p>Key Systems may access or create persistent or semi-persistent identifier(s) for a device or user of a device.
@@ -4457,12 +4456,12 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-med
           <p>Finally, if any user interface for user control of Key Systems presents data separately from data in HTTP session cookies [<cite><a class="bibref" data-link-type="biblio" href="#bib-cookies" title="HTTP State Management Mechanism">COOKIES</a></cite>] or persistent storage, then users are likely to modify site authorization or delete data in one and not the others.
             This would allow sites to use the various features as redundant backup for each other, defeating a user's attempts to protect his or her privacy.
           </p>
-          
+
           <p>
             In addition to the potential for sites and other third-parties to track users, the user agent implementer, CDM vendor, or device vendor could build a profile of the user's activities or interests, such as sites using the APIs defined in this specification that the user visits.
             Such tracking would undermine the privacy protections provided by the rest of the web platform, especially those related to isolation of origins.
           </p>
-          
+
           <p>
             Identifiers, such as <a href="#distinctive-identifier">Distinctive Identifiers</a>, may be obtained from a server operated or provided by the CDM vendor, such as via an <a href="#individualization">individualization</a> process.
             The process may include providing client identifier(s), including <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifier(s)</a>, to the server.
@@ -4488,7 +4487,7 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-med
             <dt>Do not expose <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifiers</a> to the application</dt>
             <dd>
               <p>
-                Implementations <em class="rfc2119" title="MUST NOT">MUST NOT</em> expose <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifiers</a> to the application or origin. 
+                Implementations <em class="rfc2119" title="MUST NOT">MUST NOT</em> expose <a href="#distinctive-permanent-identifier">Distinctive Permanent Identifiers</a> to the application or origin.
               </p>
             </dd>
 
@@ -4512,7 +4511,7 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-med
             <dd>
               <p>
                 Do not provide <a href="https://www.w3.org/TR/html51/browsers.html#concept-cross-origin">origin(s)</a> or values <a href="#associable">associable</a> with origins to individualization servers or other entities not related to the origin.
-                Follow the requirements and recommendations in the <a href="#individualization">Individualization</a> section if such a process is used by the implementation. 
+                Follow the requirements and recommendations in the <a href="#individualization">Individualization</a> section if such a process is used by the implementation.
               </p>
             </dd>
 
@@ -4662,7 +4661,7 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-med
       </section>
 
     </section>
-    
+
     <section id="conformance"><h2 id="x12-conformance"><bdi class="secno">12. </bdi>Conformance<a class="self-link" aria-label="§" href="#conformance"></a></h2><p>
       As well as sections marked as non-normative, all authoring guidelines, diagrams, examples, and notes in this specification are non-normative. Everything else in this specification is normative.
     </p><p>
@@ -4752,136 +4751,136 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-med
         <div class="example" id="example-7">
         <div class="marker">
     <a class="self-link" href="#example-7">Example<bdi> 7</bdi></a>
-  </div> <pre class="highlight">&lt;script&gt;
-  var licenseUrl;
-  var serverCertificate;
+  </div> <pre class="highlight" aria-busy="false"><code class="hljs xml"><span class="hljs-tag">&lt;<span class="hljs-name">script</span>&gt;</span><span class="javascript">
+  <span class="hljs-keyword">var</span> licenseUrl;
+  <span class="hljs-keyword">var</span> serverCertificate;
 
-  // Returns a Promise&lt;<a href="#dom-mediakeys" class="internalDFN" data-link-type="idl"><code>MediaKeys</code></a>&gt;.
-  function createSupportedKeySystem() {
+  <span class="hljs-comment">// Returns a Promise&lt;MediaKeys&gt;.</span>
+  <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">createSupportedKeySystem</span>(<span class="hljs-params"></span>) </span>{
     someSystemOptions = [
-     { <span>initDataTypes</span>: ['keyids', 'webm'],
-       <span>audioCapabilities</span>: [
-         { <span>contentType</span>: 'audio/webm; codecs="opus"' },
-         { <span>contentType</span>: 'audio/webm; codecs="vorbis"' }
+     { <span class="hljs-attr">initDataTypes</span>: [<span class="hljs-string">'keyids'</span>, <span class="hljs-string">'webm'</span>],
+       <span class="hljs-attr">audioCapabilities</span>: [
+         { <span class="hljs-attr">contentType</span>: <span class="hljs-string">'audio/webm; codecs="opus"'</span> },
+         { <span class="hljs-attr">contentType</span>: <span class="hljs-string">'audio/webm; codecs="vorbis"'</span> }
        ],
-       <span>videoCapabilities</span>: [
-         { <span>contentType</span>: 'video/webm; codecs="vp9"' },
-         { <span>contentType</span>: 'video/webm; codecs="vp8"' }
+       <span class="hljs-attr">videoCapabilities</span>: [
+         { <span class="hljs-attr">contentType</span>: <span class="hljs-string">'video/webm; codecs="vp9"'</span> },
+         { <span class="hljs-attr">contentType</span>: <span class="hljs-string">'video/webm; codecs="vp8"'</span> }
        ]
      }
     ];
     clearKeyOptions = [
-     { <span>initDataTypes</span>: ['keyids', 'webm'],
-       <span>audioCapabilities</span>: [
-         { <span>contentType</span>: 'audio/webm; codecs="opus"' },
-         { <span>contentType</span>: 'audio/webm; codecs="vorbis"' }
+     { <span class="hljs-attr">initDataTypes</span>: [<span class="hljs-string">'keyids'</span>, <span class="hljs-string">'webm'</span>],
+       <span class="hljs-attr">audioCapabilities</span>: [
+         { <span class="hljs-attr">contentType</span>: <span class="hljs-string">'audio/webm; codecs="opus"'</span> },
+         { <span class="hljs-attr">contentType</span>: <span class="hljs-string">'audio/webm; codecs="vorbis"'</span> }
        ],
-       <span>videoCapabilities</span>: [
-         { <span>contentType</span>: 'video/webm; codecs="vp9"',
-           <span>robustness</span>: 'foo' },
-         { <span>contentType</span>: 'video/webm; codecs="vp9"',
-           <span>robustness</span>: 'bar' },
-         { <span>contentType</span>: 'video/webm; codecs="vp8"',
-           <span>robustness</span>: 'bar' },
+       <span class="hljs-attr">videoCapabilities</span>: [
+         { <span class="hljs-attr">contentType</span>: <span class="hljs-string">'video/webm; codecs="vp9"'</span>,
+           <span class="hljs-attr">robustness</span>: <span class="hljs-string">'foo'</span> },
+         { <span class="hljs-attr">contentType</span>: <span class="hljs-string">'video/webm; codecs="vp9"'</span>,
+           <span class="hljs-attr">robustness</span>: <span class="hljs-string">'bar'</span> },
+         { <span class="hljs-attr">contentType</span>: <span class="hljs-string">'video/webm; codecs="vp8"'</span>,
+           <span class="hljs-attr">robustness</span>: <span class="hljs-string">'bar'</span> },
        ]
      }
     ];
 
-    return navigator.<span>requestMediaKeySystemAccess</span>('com.example.somesystem', someSystemOptions).then(
-      function(keySystemAccess) {
-        // Not shown:
-        // 1. Use both attributes of keySystemAccess.<span>getConfiguration()</span>.<span>audioCapabilities</span>[0]
-        //    and both attributes of keySystemAccess.<span>getConfiguration()</span>.<span>videoCapabilities</span>[0]
-        //    to retrieve appropriate stream(s).
-        // 2. Set video.src.
+    <span class="hljs-keyword">return</span> navigator.requestMediaKeySystemAccess(<span class="hljs-string">'com.example.somesystem'</span>, someSystemOptions).then(
+      <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">keySystemAccess</span>) </span>{
+        <span class="hljs-comment">// Not shown:</span>
+        <span class="hljs-comment">// 1. Use both attributes of keySystemAccess.getConfiguration().audioCapabilities[0]</span>
+        <span class="hljs-comment">//    and both attributes of keySystemAccess.getConfiguration().videoCapabilities[0]</span>
+        <span class="hljs-comment">//    to retrieve appropriate stream(s).</span>
+        <span class="hljs-comment">// 2. Set video.src.</span>
 
-        licenseUrl = 'https://license.example.com/getkey';
-        serverCertificate = new Uint8Array([ ... ]);
-        return keySystemAccess.<span>createMediaKeys</span>();
+        licenseUrl = <span class="hljs-string">'https://license.example.com/getkey'</span>;
+        serverCertificate = <span class="hljs-keyword">new</span> <span class="hljs-built_in">Uint8Array</span>([ ... ]);
+        <span class="hljs-keyword">return</span> keySystemAccess.createMediaKeys();
       }
     ).catch(
-      function(error) {
-        // Try the next key system.
-        navigator.<span>requestMediaKeySystemAccess</span>('org.w3.clearkey', clearKeyOptions).then(
-          function(keySystemAccess) {
-            // Not shown:
-            // 1. Use keySystemAccess.<span>getConfiguration()</span>.<span>audioCapabilities</span>[0].<span>contentType</span>
-            //    and keySystemAccess.<span>getConfiguration()</span>.<span>videoCapabilities</span>[0].<span>contentType</span>
-            //    to retrieve appropriate stream(s).
-            // 2. Set video.src.
+      <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">error</span>) </span>{
+        <span class="hljs-comment">// Try the next key system.</span>
+        navigator.requestMediaKeySystemAccess(<span class="hljs-string">'org.w3.clearkey'</span>, clearKeyOptions).then(
+          <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">keySystemAccess</span>) </span>{
+            <span class="hljs-comment">// Not shown:</span>
+            <span class="hljs-comment">// 1. Use keySystemAccess.getConfiguration().audioCapabilities[0].contentType</span>
+            <span class="hljs-comment">//    and keySystemAccess.getConfiguration().videoCapabilities[0].contentType</span>
+            <span class="hljs-comment">//    to retrieve appropriate stream(s).</span>
+            <span class="hljs-comment">// 2. Set video.src.</span>
 
-            licenseUrl = 'https://license.example.com/clearkey/request';
-            return keySystemAccess.<span>createMediaKeys</span>();
+            licenseUrl = <span class="hljs-string">'https://license.example.com/clearkey/request'</span>;
+            <span class="hljs-keyword">return</span> keySystemAccess.createMediaKeys();
           }
         );
       }
     ).catch(
-      console.error.bind(console, 'Unable to instantiate a key system supporting the required combinations')
+      <span class="hljs-built_in">console</span>.error.bind(<span class="hljs-built_in">console</span>, <span class="hljs-string">'Unable to instantiate a key system supporting the required combinations'</span>)
     );
   }
 
-  function handleInitData(event) {
-    var video = event.target;
-    if (video.mediaKeysObject === undefined) {
-      video.mediaKeysObject = null; // Prevent entering this path again.
-      video.pendingSessionData = []; // Will store all initData until the MediaKeys is ready.
+  <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">handleInitData</span>(<span class="hljs-params">event</span>) </span>{
+    <span class="hljs-keyword">var</span> video = event.target;
+    <span class="hljs-keyword">if</span> (video.mediaKeysObject === <span class="hljs-literal">undefined</span>) {
+      video.mediaKeysObject = <span class="hljs-literal">null</span>; <span class="hljs-comment">// Prevent entering this path again.</span>
+      video.pendingSessionData = []; <span class="hljs-comment">// Will store all initData until the MediaKeys is ready.</span>
       createSupportedKeySystem().then(
-        function(createdMediaKeys) {
+        <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">createdMediaKeys</span>) </span>{
           video.mediaKeysObject = createdMediaKeys;
 
-          if (serverCertificate)
-            createdMediaKeys.<span>setServerCertificate</span>(serverCertificate);
+          <span class="hljs-keyword">if</span> (serverCertificate)
+            createdMediaKeys.setServerCertificate(serverCertificate);
 
-          for (var i = 0; i &lt; video.pendingSessionData.length; i++) {
-            var data = video.pendingSessionData[i];
+          <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>; i &lt; video.pendingSessionData.length; i++) {
+            <span class="hljs-keyword">var</span> data = video.pendingSessionData[i];
             makeNewRequest(video.mediaKeysObject, data.initDataType, data.initData);
           }
           video.pendingSessionData = [];
 
-          return video.<span>setMediaKeys</span>(createdMediaKeys);
+          <span class="hljs-keyword">return</span> video.setMediaKeys(createdMediaKeys);
         }
       ).catch(
-        console.error.bind(console, 'Failed to create and initialize a MediaKeys object')
+        <span class="hljs-built_in">console</span>.error.bind(<span class="hljs-built_in">console</span>, <span class="hljs-string">'Failed to create and initialize a MediaKeys object'</span>)
       );
     }
-    addSession(video, event.<span>initDataType</span>, event.<span>initData</span>);
+    addSession(video, event.initDataType, event.initData);
   }
 
-  function addSession(video, initDataType, initData) {
-    if (video.mediaKeysObject) {
+  <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">addSession</span>(<span class="hljs-params">video, initDataType, initData</span>) </span>{
+    <span class="hljs-keyword">if</span> (video.mediaKeysObject) {
       makeNewRequest(video.mediaKeysObject, initDataType, initData);
-    } else {
-      video.pendingSessionData.push({initDataType: initDataType, initData: initData});
+    } <span class="hljs-keyword">else</span> {
+      video.pendingSessionData.push({<span class="hljs-attr">initDataType</span>: initDataType, <span class="hljs-attr">initData</span>: initData});
     }
   }
 
-  function makeNewRequest(mediaKeys, initDataType, initData) {
-    var keySession = mediaKeys.<span>createSession</span>();
-    keySession.addEventListener("<span>message</span>", licenseRequestReady, false);
-    keySession.<span>generateRequest</span>(initDataType, initData).catch(
-      console.error.bind(console, 'Unable to create or initialize key session')
+  <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">makeNewRequest</span>(<span class="hljs-params">mediaKeys, initDataType, initData</span>) </span>{
+    <span class="hljs-keyword">var</span> keySession = mediaKeys.createSession();
+    keySession.addEventListener(<span class="hljs-string">"message"</span>, licenseRequestReady, <span class="hljs-literal">false</span>);
+    keySession.generateRequest(initDataType, initData).catch(
+      <span class="hljs-built_in">console</span>.error.bind(<span class="hljs-built_in">console</span>, <span class="hljs-string">'Unable to create or initialize key session'</span>)
     );
   }
 
-  function licenseRequestReady(event) {
-    var request = event.<span>message</span>;
+  <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">licenseRequestReady</span>(<span class="hljs-params">event</span>) </span>{
+    <span class="hljs-keyword">var</span> request = event.message;
 
-    var xmlhttp = new XMLHttpRequest();
+    <span class="hljs-keyword">var</span> xmlhttp = <span class="hljs-keyword">new</span> XMLHttpRequest();
     xmlhttp.keySession = event.target;
-    xmlhttp.open("POST", licenseUrl);
-    xmlhttp.onreadystatechange = function() {
-      if (xmlhttp.readyState == 4) {
-        var license = new Uint8Array(xmlhttp.response);
-        xmlhttp.keySession.<span>update</span>(license).catch(
-          console.error.bind(console, 'update() failed')
+    xmlhttp.open(<span class="hljs-string">"POST"</span>, licenseUrl);
+    xmlhttp.onreadystatechange = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
+      <span class="hljs-keyword">if</span> (xmlhttp.readyState == <span class="hljs-number">4</span>) {
+        <span class="hljs-keyword">var</span> license = <span class="hljs-keyword">new</span> <span class="hljs-built_in">Uint8Array</span>(xmlhttp.response);
+        xmlhttp.keySession.update(license).catch(
+          <span class="hljs-built_in">console</span>.error.bind(<span class="hljs-built_in">console</span>, <span class="hljs-string">'update() failed'</span>)
         );
       }
     }
     xmlhttp.send(request);
   }
-&lt;/script&gt;
+</span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span>
 
-&lt;video autoplay <span>onencrypted</span>='handleInitData(event)'&gt;&lt;/video&gt;</pre>
+<span class="hljs-tag">&lt;<span class="hljs-name">video</span> <span class="hljs-attr">autoplay</span> <span class="hljs-attr">onencrypted</span>=<span class="hljs-string">'handleInitData(event)'</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">video</span>&gt;</span></code></pre>
       </div>
       </section>
 
@@ -5131,7 +5130,7 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-med
 
     <section id="acknowledgements">
       <h2 id="x14-acknowledgments"><bdi class="secno">14. </bdi>Acknowledgments<a class="self-link" aria-label="§" href="#acknowledgements"></a></h2>
-      The editors would like to thank Aaron Colwell, Alex Russell, Anne van Kesteren, Bob Lund, Boris Zbarsky, Chris Pearce, David Singer, Domenic Denicola, Frank Galligan, Glenn Adams, Henri Sivonen, Jer Noble, Joe Steele, Joey Parrish, John Simmons, Mark Vickers, Pavel Pergamenshchik, Philip Jägenstedt, Pierre Lemieux, Robert O'Callahan, Ryan Sleevi, Steve Heffernan, Steven Robertson, Theresa O'Connor, Thomás Inskip, Travis Leithead, and Xiaohan Wang for their contributions to this specification.  Thank you also to the many others who contributed to the specification, including through their participation on the mailing list and in the issues. 
+      The editors would like to thank Aaron Colwell, Alex Russell, Anne van Kesteren, Bob Lund, Boris Zbarsky, Chris Pearce, David Singer, Domenic Denicola, Frank Galligan, Glenn Adams, Henri Sivonen, Jer Noble, Joe Steele, Joey Parrish, John Simmons, Mark Vickers, Pavel Pergamenshchik, Philip Jägenstedt, Pierre Lemieux, Robert O'Callahan, Ryan Sleevi, Steve Heffernan, Steven Robertson, Theresa O'Connor, Thomás Inskip, Travis Leithead, and Xiaohan Wang for their contributions to this specification.  Thank you also to the many others who contributed to the specification, including through their participation on the mailing list and in the issues.
     </section>
 
 
@@ -5140,7 +5139,7 @@ interface <a class="internalDFN idlID" data-link-type="interface" href="#dom-med
         Normative references
       <a class="self-link" aria-label="§" href="#normative-references"></a></h3>
     <dl class="bibliography">
-      <dt id="bib-cookies">[COOKIES]</dt><dd><a href="https://httpwg.org/specs/rfc6265.html"><cite>HTTP State Management Mechanism</cite></a>. A. Barth.  IETF. April 2011. Proposed Standard. URL: <a href="https://httpwg.org/specs/rfc6265.html">https://httpwg.org/specs/rfc6265.html</a></dd><dt id="bib-dom">[DOM]</dt><dd><a href="https://dom.spec.whatwg.org/"><cite>DOM Standard</cite></a>. Anne van Kesteren.  WHATWG. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a></dd><dt id="bib-ecma-262">[ECMA-262]</dt><dd><a href="https://tc39.es/ecma262/"><cite>ECMAScript Language Specification</cite></a>.  Ecma International. URL: <a href="https://tc39.es/ecma262/">https://tc39.es/ecma262/</a></dd><dt id="bib-eme-initdata-keyids">[EME-INITDATA-KEYIDS]</dt><dd><a href="format-registry/initdata/keyids.html"><cite>"keyids" Initialization Data Format</cite></a>. David Dorwin; Adrian Bateman; Mark Watson; Jerry Smith.  W3C. URL: <a href="format-registry/initdata/keyids.html">format-registry/initdata/keyids.html</a></dd><dt id="bib-eme-initdata-registry">[EME-INITDATA-REGISTRY]</dt><dd><a href="format-registry/initdata/index.html"><cite>Encrypted Media Extensions Initialization Data Format Registry</cite></a>. David Dorwin; Adrian Bateman; Mark Watson.  W3C. URL: <a href="format-registry/initdata/index.html">format-registry/initdata/index.html</a></dd><dt id="bib-encoding">[ENCODING]</dt><dd><a href="https://encoding.spec.whatwg.org/"><cite>Encoding Standard</cite></a>. Anne van Kesteren.  WHATWG. Living Standard. URL: <a href="https://encoding.spec.whatwg.org/">https://encoding.spec.whatwg.org/</a></dd><dt id="bib-feature-policy">[FEATURE-POLICY]</dt><dd><a href="https://www.w3.org/TR/permissions-policy-1/"><cite>Permissions Policy</cite></a>. Ian Clelland.  W3C. 16 July 2020. W3C Working Draft. URL: <a href="https://www.w3.org/TR/permissions-policy-1/">https://www.w3.org/TR/permissions-policy-1/</a></dd><dt id="bib-html">[HTML]</dt><dd><a href="https://html.spec.whatwg.org/multipage/"><cite>HTML Standard</cite></a>. Anne van Kesteren; Domenic Denicola; Ian Hickson; Philip Jägenstedt; Simon Pieters.  WHATWG. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a></dd><dt id="bib-mixed-content">[MIXED-CONTENT]</dt><dd><a href="https://www.w3.org/TR/mixed-content/"><cite>Mixed Content</cite></a>. Mike West.  W3C. 2 August 2016. W3C Candidate Recommendation. URL: <a href="https://www.w3.org/TR/mixed-content/">https://www.w3.org/TR/mixed-content/</a></dd><dt id="bib-rfc2119">[RFC2119]</dt><dd><a href="https://tools.ietf.org/html/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. S. Bradner.  IETF. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a></dd><dt id="bib-rfc6381">[RFC6381]</dt><dd><a href="https://tools.ietf.org/html/rfc6381"><cite>The 'Codecs' and 'Profiles' Parameters for "Bucket" Media Types</cite></a>. R. Gellens; D. Singer; P. Frojdh.  IETF. August 2011. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc6381">https://tools.ietf.org/html/rfc6381</a></dd><dt id="bib-rfc7517">[RFC7517]</dt><dd><a href="https://tools.ietf.org/html/rfc7517"><cite>JSON Web Key (JWK)</cite></a>. M. Jones.  IETF. May 2015. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7517">https://tools.ietf.org/html/rfc7517</a></dd><dt id="bib-rfc8174">[RFC8174]</dt><dd><a href="https://tools.ietf.org/html/rfc8174"><cite>Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words</cite></a>. B. Leiba.  IETF. May 2017. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc8174">https://tools.ietf.org/html/rfc8174</a></dd><dt id="bib-webidl">[WEBIDL]</dt><dd><a href="https://heycam.github.io/webidl/"><cite>Web IDL</cite></a>. Boris Zbarsky.  W3C. 15 December 2016. W3C Editor's Draft. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a></dd>
+      <dt id="bib-cookies">[COOKIES]</dt><dd><a href="https://httpwg.org/specs/rfc6265.html"><cite>HTTP State Management Mechanism</cite></a>. A. Barth.  IETF. April 2011. Proposed Standard. URL: <a href="https://httpwg.org/specs/rfc6265.html">https://httpwg.org/specs/rfc6265.html</a></dd><dt id="bib-dom">[DOM]</dt><dd><a href="https://dom.spec.whatwg.org/"><cite>DOM Standard</cite></a>. Anne van Kesteren.  WHATWG. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a></dd><dt id="bib-ecma-262">[ECMA-262]</dt><dd><a href="https://tc39.es/ecma262/"><cite>ECMAScript Language Specification</cite></a>.  Ecma International. URL: <a href="https://tc39.es/ecma262/">https://tc39.es/ecma262/</a></dd><dt id="bib-eme-initdata-keyids">[EME-INITDATA-KEYIDS]</dt><dd><a href="format-registry/initdata/keyids.html"><cite>"keyids" Initialization Data Format</cite></a>. David Dorwin; Adrian Bateman; Mark Watson; Jerry Smith.  W3C. URL: <a href="format-registry/initdata/keyids.html">format-registry/initdata/keyids.html</a></dd><dt id="bib-eme-initdata-registry">[EME-INITDATA-REGISTRY]</dt><dd><a href="format-registry/initdata/index.html"><cite>Encrypted Media Extensions Initialization Data Format Registry</cite></a>. David Dorwin; Adrian Bateman; Mark Watson.  W3C. URL: <a href="format-registry/initdata/index.html">format-registry/initdata/index.html</a></dd><dt id="bib-encoding">[ENCODING]</dt><dd><a href="https://encoding.spec.whatwg.org/"><cite>Encoding Standard</cite></a>. Anne van Kesteren.  WHATWG. Living Standard. URL: <a href="https://encoding.spec.whatwg.org/">https://encoding.spec.whatwg.org/</a></dd><dt id="bib-html">[HTML]</dt><dd><a href="https://html.spec.whatwg.org/multipage/"><cite>HTML Standard</cite></a>. Anne van Kesteren; Domenic Denicola; Ian Hickson; Philip Jägenstedt; Simon Pieters.  WHATWG. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a></dd><dt id="bib-mixed-content">[MIXED-CONTENT]</dt><dd><a href="https://www.w3.org/TR/mixed-content/"><cite>Mixed Content</cite></a>. Mike West.  W3C. 2 August 2016. W3C Candidate Recommendation. URL: <a href="https://www.w3.org/TR/mixed-content/">https://www.w3.org/TR/mixed-content/</a></dd><dt id="bib-permissions-policy">[PERMISSIONS-POLICY]</dt><dd><a href="https://www.w3.org/TR/permissions-policy-1/"><cite>Permissions Policy</cite></a>. Ian Clelland.  W3C. 16 July 2020. W3C Working Draft. URL: <a href="https://www.w3.org/TR/permissions-policy-1/">https://www.w3.org/TR/permissions-policy-1/</a></dd><dt id="bib-rfc2119">[RFC2119]</dt><dd><a href="https://tools.ietf.org/html/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. S. Bradner.  IETF. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a></dd><dt id="bib-rfc6381">[RFC6381]</dt><dd><a href="https://tools.ietf.org/html/rfc6381"><cite>The 'Codecs' and 'Profiles' Parameters for "Bucket" Media Types</cite></a>. R. Gellens; D. Singer; P. Frojdh.  IETF. August 2011. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc6381">https://tools.ietf.org/html/rfc6381</a></dd><dt id="bib-rfc7517">[RFC7517]</dt><dd><a href="https://tools.ietf.org/html/rfc7517"><cite>JSON Web Key (JWK)</cite></a>. M. Jones.  IETF. May 2015. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7517">https://tools.ietf.org/html/rfc7517</a></dd><dt id="bib-rfc8174">[RFC8174]</dt><dd><a href="https://tools.ietf.org/html/rfc8174"><cite>Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words</cite></a>. B. Leiba.  IETF. May 2017. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc8174">https://tools.ietf.org/html/rfc8174</a></dd><dt id="bib-webidl">[WEBIDL]</dt><dd><a href="https://heycam.github.io/webidl/"><cite>Web IDL</cite></a>. Boris Zbarsky.  W3C. 15 December 2016. W3C Editor's Draft. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a></dd>
     </dl></section><section id="informative-references">
       <h3 id="a-2-informative-references"><bdi class="secno">A.2 </bdi>
         Informative references


### PR DESCRIPTION
An `<a>` is breaking the whole syntax highlight for that code block. This fixes it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/saschanaz/encrypted-media/pull/478.html" title="Last updated on Dec 22, 2020, 11:16 PM UTC (c5c021e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/478/c9e116f...saschanaz:c5c021e.html" title="Last updated on Dec 22, 2020, 11:16 PM UTC (c5c021e)">Diff</a>