### PR TITLE
Specify QuotaExceededError return from generateRequest

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -1876,7 +1876,8 @@ The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows:
                 <li>
                   <p><a def-id="Queue-a-task"></a> to run the following steps:</p>
                   <ol>
-                    <li><p>If any of the preceding steps failed, reject <var>promise</var> with <a def-id="new-domexception-named"></a> <a def-id="appropriate-error-name"></a>.</p></li>
+                    <li><p>If any of the preceding steps failed due to a lack of resources, reject <var>promise</var> with <a def-id="QuotaExceededError"></a>.</p></li>
+                    <li><p>If any of the preceding steps failed for any other reason, reject <var>promise</var> with <a def-id="new-domexception-named"></a> <a def-id="appropriate-error-name"></a>.</p></li>
                     <li><p>Set the <a def-id="sessionId"></a> attribute to <var>session id</var>.</p></li>
                     <li><p>Set this object's <var>callable</var> value to true.</p></li>
                     <li><p>Run the <a def-id="queue-message-algorithm"></a> algorithm on the <var>session</var>, providing <var>message type</var> and <var>message</var>.</p>
@@ -2626,7 +2627,8 @@ interface MediaKeyMessageEvent : Event {
             <tr>
               <td><dfn id="dfn-QuotaExceededError"><code>QuotaExceededError</code></dfn></td>
               <td>The MediaKeys object cannot be used with additional HTMLMediaElements.<br>
-                A non-closed session already exists for this sessionId.
+                A non-closed session already exists for this sessionId.<br>
+                There are insufficient resources to create a new session or license request.
               </td>
             </tr>
           </tbody>


### PR DESCRIPTION
This was already possible under the very general specification of
"reject promise with a new DOMException whose name is the appropriate
error name."  However, it is better to explicitly state a common case
where QuotaExceededError should be used.

Closes #483


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 11, 2021, 10:01 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fjoeyparrish%2Fencrypted-media%2F8aec2ec905fa34640a96a89d48325aabdf17218d%2Fencrypted-media-respec.html%3FisPreview%3Dtrue)

```
📡 HTTP Error 429: https://rawcdn.githack.com/joeyparrish/encrypted-media/8aec2ec905fa34640a96a89d48325aabdf17218d/encrypted-media-respec.html
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/encrypted-media%23485.)._
</details>
