### PR TITLE
Add reason for session close

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -1389,7 +1389,7 @@ The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows:
               </div>
               <div class="note">
                 <p>
-                  NOTE: The empty string is distinct from null or not present,
+                  The empty string is distinct from null or not present,
                   and so would be treated as an unrecognized encryption scheme.
                 </p>
               </div>
@@ -1669,7 +1669,7 @@ The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows:
           <p>The following step is run:</p>
           <ol>
             <li>
-              <p>For each <a>MediaKeySession</a> created by the <var>media keys</var> that is not <a def-id="media-key-session-closed"></a>, <a def-id="queue-a-task"></a> to run the <a def-id="session-closed-algorithm"></a> algorithm on the session.</p>
+              <p>For each <a>MediaKeySession</a> created by the <var>media keys</var> that is not <a def-id="media-key-session-closed"></a>, <a def-id="queue-a-task"></a> to run the <a def-id="session-closed-algorithm"></a> algorithm on the session with reason <a def-id="reason-cdm-unavailable"></a>.</p>
             </li>
           </ol>
         </section>
@@ -1732,13 +1732,50 @@ The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows:
       <p>For methods that return a promise, all errors are reported asynchronously by rejecting the returned Promise. This includes [[WEBIDL]] type mapping errors.</p>
       <p>The following steps of an algorithm are always aborted when rejecting a promise.</p>
 
+<div><pre class="idl">enum MediaKeySessionClosedReason {
+    "unknown",
+    "closed-by-application",
+    "persistent-license-released",
+    "cdm-unavailable",
+    "hardware-context-reset",
+    "resource-evicted"
+};</pre>
+<p>
+The <dfn>MediaKeySessionClosedReason</dfn> enumeration is defined as follows:
+</p>
+<table class="simple" data-dfn-for="MediaKeySessionClosedReason" data-link-for="MediaKeySessionClosedReason"><tbody><tr><th colspan="2">Enumeration description</th></tr><tr><td><dfn><code id="idl-def-MediaKeySessionClosedReason.unknown">unknown</code></dfn></td><td>
+            The session was closed for a reason not covered by any other value.
+          </td></tr><tr><td><dfn><code id="idl-def-MediaKeySessionClosedReason.closed-by-application">closed-by-application</code></dfn></td><td>
+            The session was closed by the application calling the <a def-id="close"></a> method of the session explicitly.
+          </td></tr><tr><td><dfn><code id="idl-def-MediaKeySessionClosedReason.persistent-license-released">persistent-license-released</code></dfn></td><td>
+            The session was closed because the CDM received a <a def-id="record-of-license-destruction"></a> acknowledgement.
+          </td></tr><tr><td><dfn><code id="idl-def-MediaKeySessionClosedReason.cdm-unavailable">cdm-unavailable</code></dfn></td><td>
+            The session was closed because the CDM became unavailable and the <a def-id="cdm-unavailable-algorithm"></a> algorithm was run.
+          </td></tr><tr><td><dfn><code id="idl-def-MediaKeySessionClosedReason.hardware-context-reset">hardware-context-reset</code></dfn></td><td>
+            The session was closed because the CDM's original hardware context was reset.  This could occur for many reasons, including device hibernation, monitor configuration change.
+            <div class="note">
+              <p>
+                This could occur for many reasons, including device hibernation, monitor configuration change, etc.
+                The exact reasons for a hardware context reset are implementation-dependent.
+              </p>
+            </div>
+          </td></tr><tr><td><dfn><code id="idl-def-MediaKeySessionClosedReason.resource-evicted">resource-evicted</code></dfn></td><td>
+            The session was closed because the system needed to reclaim resources to allow the creation of other sessions.
+            <div class="note">
+              <p>
+                This would imply that the application is running into a device-specific limit on session resources.
+                If the closed session is still needed for some reason, the application developer should consider some strategy to reduce the number of sessions needed or proactively close unneeded sessions.
+              </p>
+            </div>
+          </td></tr></tbody></table></div>
+
       <div><pre class="idl">[Exposed=Window, SecureContext] interface MediaKeySession : EventTarget {
-    readonly        attribute DOMString           sessionId;
-    readonly        attribute unrestricted double expiration;
-    readonly        attribute Promise&lt;undefined&gt;       closed;
-    readonly        attribute MediaKeyStatusMap   keyStatuses;
-                    attribute EventHandler        onkeystatuseschange;
-                    attribute EventHandler        onmessage;
+    readonly        attribute DOMString                            sessionId;
+    readonly        attribute unrestricted double                  expiration;
+    readonly        attribute Promise&lt;MediaKeySessionClosedReason&gt; closed;
+    readonly        attribute MediaKeyStatusMap                    keyStatuses;
+                    attribute EventHandler                         onkeystatuseschange;
+                    attribute EventHandler                         onmessage;
     Promise&lt;undefined&gt;    generateRequest (DOMString initDataType, BufferSource initData);
     Promise&lt;boolean&gt; load (DOMString sessionId);
     Promise&lt;undefined&gt;    update (BufferSource response);
@@ -1750,7 +1787,7 @@ The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows:
         </dd><dt><dfn><code>expiration</code></dfn> of type <span class="idlAttrType">{{unrestricted double}}</span>, readonly       </dt><dd>
           <p>The <a def-id="expiration-time"></a> for all key(s) in the session, or <code>NaN</code> if no such time exists or if the license explicitly never expires, as determined by the CDM.</p>
           <p class="note">This value MAY change during the session lifetime, such as when an action triggers the start of a window.</p>
-        </dd><dt><dfn><code>closed</code></dfn> of type <span class="idlAttrType">Promise&lt;{{undefined}}&gt;</span>, readonly       </dt><dd>
+        </dd><dt><dfn><code>closed</code></dfn> of type <span class="idlAttrType">Promise&lt;{{MediaKeySessionClosedReason}}&gt;</span>, readonly       </dt><dd>
           <p>Signals when the object becomes <a def-id="media-key-session-closed"></a> as a result of the <a def-id="session-closed-algorithm"></a> algorithm being run.
           This promise can only be fulfilled and is never rejected.</p>
         </dd><dt><dfn><code>keyStatuses</code></dfn> of type <span class="idlAttrType"><a>MediaKeyStatusMap</a></span>, readonly       </dt><dd>
@@ -2061,7 +2098,7 @@ The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows:
                       <dl class="switch">
                         <dt>If <var>session closed</var> is true:</dt>
                         <dd>
-                          <p>Run the <a def-id="session-closed-algorithm"></a> algorithm on this object.</p>
+                          <p>Run the <a def-id="session-closed-algorithm"></a> algorithm on this object with reason <a def-id="reason-persistent-license-released"></a>.</p>
                         </dd>
                         <dt>Otherwise:</dt>
                         <dd>
@@ -2105,7 +2142,7 @@ The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows:
               It MUST NOT contain executable code.
             </td></tr></tbody></table><div><em>Return type: </em><code>Promise&lt;undefined&gt;</code></div></dd><dt><dfn><code>close</code></dfn></dt><dd>
           <p>Indicates that the application no longer needs the session and the CDM should release any resources associated with the session and close it. Persisted data should not be released or cleared.</p>
-          <p class="note">The returned promise is resolved when the request has been processed, and the <a def-id="closed"></a> attribute promise is resolved when the session is closed.</p>
+          <p class="note">The returned promise is resolved when the request has been processed, and the <a def-id="closed"></a> attribute promise is resolved with <a def-id="reason-closed-by-application"></a> when the session is closed.</p>
 
           <ol class="method-algorithm">
             <li><p>If this object's <var>closing or closed</var> value is true, return a resolved promise.</p></li>
@@ -2122,7 +2159,7 @@ The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows:
                 <li>
                   <p><a def-id="Queue-a-task"></a> to run the following steps:</p>
                   <ol>
-                    <li><p>Run the <a def-id="session-closed-algorithm"></a> algorithm on this object.</p></li>
+                    <li><p>Run the <a def-id="session-closed-algorithm"></a> algorithm on this object with reason <a def-id="reason-closed-by-application"></a>.</p></li>
                     <li>
                       <p>Resolve <var>promise</var>.</p>
                       <p class="note">Since promise handlers are queued as microtasks, these will be executed ahead of any events queued by the preceding steps.</p>
@@ -2468,7 +2505,10 @@ interface MediaKeyMessageEvent : Event {
 
         <section id="session-closed">
           <h4>Session Closed</h4>
-          <p>The Session Closed algorithm updates the <a>MediaKeySession</a> state after a <a href="#key-session">key session</a> has been closed by the <a def-id="cdm"></a>.</p>
+          <p>
+            The Session Closed algorithm updates the <a>MediaKeySession</a> state after a <a href="#key-session">key session</a> has been closed by the <a def-id="cdm"></a>.
+            Requests to run this algorithm include a target <a>MediaKeySession</a> object and a <a>MediaKeySessionClosedReason</a>.
+          </p>
           <p class="note">The algorithm is always run in a task.</p>
           <p>
             When a session is closed, the license(s) and key(s) associated with it are no longer available to
@@ -2496,7 +2536,7 @@ interface MediaKeyMessageEvent : Event {
             <li><p>Set the <var>session</var>'s <var>closing or closed</var> value to true.</p></li>
             <li><p>Run the <a def-id="update-key-statuses-algorithm"></a> algorithm on the <var>session</var>, providing an empty sequence.</p></li>
             <li><p>Run the <a def-id="update-expiration-algorithm"></a> algorithm on the <var>session</var>, providing <code>NaN</code>.</p></li>
-            <li><p>Resolve <var>promise</var>.</p></li>
+            <li><p>Resolve <var>promise</var> with the provided reason.</p></li>
           </ol>
         </section>
         <section id="monitor-cdm">
@@ -2572,12 +2612,12 @@ interface MediaKeyMessageEvent : Event {
             </li>
             <li>
               <p>
-                If <var>cdm</var> has closed <var>session</var>, <a def-id="queue-a-task"></a> to run the <a def-id="session-closed-algorithm"></a> algorithm on <var>session</var>.
+                If <var>cdm</var> has closed <var>session</var>, <a def-id="queue-a-task"></a> to run the <a def-id="session-closed-algorithm"></a> algorithm on <var>session</var> with an appropriate <a>MediaKeySessionClosedReason</a> value.
               </p>
             </li>
             <li>
               <p>
-                If <var>cdm</var> had become unavailable, <a def-id="queue-a-task"></a> to run the <a def-id="session-closed-algorithm"></a> algorithm on <var>session</var>.
+                If <var>cdm</var> has become unavailable, <a def-id="queue-a-task"></a> to run the <a def-id="cdm-unavailable-algorithm"></a> algorithm.
               </p>
             </li>
           </ol>
@@ -4537,7 +4577,9 @@ interface MediaEncryptedEvent : Event {
     keySession.addEventListener('<a def-id="message"></a>', handleMessage, false);
     keySession.addEventListener('<a def-id="keystatuseschange"></a>', handlekeyStatusesChange, false);
     keySession.<a def-id="closed"></a>.then(
-      console.log.bind(console, 'Session closed')
+      function(reason) {
+        console.log('Session', this.<a def-id="sessionId"></a>, 'closed, reason', reason);
+      }.bind(keySession)
     );
     keySession.<a def-id="generateRequest-call"></a>(initDataType, initData).catch(
       console.error.bind(console, 'Unable to create or initialize key session')
@@ -4629,8 +4671,8 @@ interface MediaEncryptedEvent : Event {
     var keySession = mediaKeys.<a def-id="createSession-call"></a>(<a def-id="persistent-license-session"></a>);
     keySession.addEventListener('<a def-id="message"></a>', handleMessage, false);
     keySession.<a def-id="closed"></a>.then(
-      function() {
-        console.log('Session ' + this.<a def-id="sessionId"></a> + ' closed');
+      function(reason) {
+        console.log('Session', this.<a def-id="sessionId"></a>, 'closed, reason', reason);
       }.bind(keySession)
     );
     keySession.<a def-id="generateRequest-call"></a>(initDataType, initData).then(
@@ -4647,7 +4689,9 @@ interface MediaEncryptedEvent : Event {
     var keySession = mediaKeys.<a def-id="createSession-call"></a>(<a def-id="persistent-license-session"></a>);
     keySession.addEventListener('<a def-id="message"></a>', handleMessage, false);
     keySession.<a def-id="closed"></a>.then(
-      console.log.bind(console, 'Session closed')
+      function(reason) {
+        console.log('Session', this.<a def-id="sessionId"></a>, 'closed, reason', reason);
+      }.bind(keySession)
     );
     keySession.<a def-id="load-call"></a>(sessionId).then(
       function(loaded) {

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -1744,22 +1744,18 @@ The <dfn>MediaKeySessionClosedReason</dfn> enumeration is defined as follows:
 </p>
 <table class="simple" data-dfn-for="MediaKeySessionClosedReason" data-link-for="MediaKeySessionClosedReason"><tbody><tr><th colspan="2">Enumeration description</th></tr><tr><td><dfn><code id="idl-def-MediaKeySessionClosedReason.unknown">internal-error</code></dfn></td><td>
             The session was closed because of an unrecoverable error in the CDM.
-            <div class="note">
-              <p>
-                When this occurs, applications SHOULD NOT expect to be able to create new sessions on this <a>MediaKeys</a> instance.
-              </p>
-            </div>
+            When this occurs, applications MUST NOT create new sessions on this <a>MediaKeys</a> instance.
           </td></tr><tr><td><dfn><code id="idl-def-MediaKeySessionClosedReason.closed-by-application">closed-by-application</code></dfn></td><td>
             The session was closed by the application calling the <a def-id="close"></a> method of the session explicitly.
           </td></tr><tr><td><dfn><code id="idl-def-MediaKeySessionClosedReason.release-acknowledged">release-acknowledged</code></dfn></td><td>
             The session was closed because the CDM received a <a def-id="record-of-license-destruction"></a> acknowledgement.
           </td></tr><tr><td><dfn><code id="idl-def-MediaKeySessionClosedReason.hardware-context-reset">hardware-context-reset</code></dfn></td><td>
             The session was closed because the CDM's original hardware context was reset.
+            When this occurs, the User Agent MUST allow the application to create new sessions on this <a>MediaKeys</a> instance.
             <div class="note">
               <p>
                 This could occur for many reasons, including device hibernation, monitor configuration change, etc.
                 The exact reasons for a hardware context reset are implementation-dependent.
-                When this occurs, applications SHOULD expect to be able to create new sessions on this <a>MediaKeys</a> instance.
               </p>
             </div>
           </td></tr><tr><td><dfn><code id="idl-def-MediaKeySessionClosedReason.resource-evicted">resource-evicted</code></dfn></td><td>
@@ -1767,7 +1763,7 @@ The <dfn>MediaKeySessionClosedReason</dfn> enumeration is defined as follows:
             <div class="note">
               <p>
                 This would imply that the application is running into a device-specific limit on session resources.
-                If the closed session is still needed for some reason, the application developer SHOULD consider some strategy to reduce the number of sessions needed or proactively close unneeded sessions.
+                If the closed session is still needed for some reason, the application developer should consider some strategy to reduce the number of sessions needed or proactively close unneeded sessions.
               </p>
             </div>
           </td></tr></tbody></table></div>

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -1669,7 +1669,7 @@ The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows:
           <p>The following step is run:</p>
           <ol>
             <li>
-              <p>For each <a>MediaKeySession</a> created by the <var>media keys</var> that is not <a def-id="media-key-session-closed"></a>, <a def-id="queue-a-task"></a> to run the <a def-id="session-closed-algorithm"></a> algorithm on the session with reason <a def-id="reason-cdm-unavailable"></a>.</p>
+              <p>For each <a>MediaKeySession</a> created by the <var>media keys</var> that is not <a def-id="media-key-session-closed"></a>, <a def-id="queue-a-task"></a> to run the <a def-id="session-closed-algorithm"></a> algorithm on the session with reason <a def-id="reason-internal-error"></a>.</p>
             </li>
           </ol>
         </section>
@@ -1733,30 +1733,33 @@ The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows:
       <p>The following steps of an algorithm are always aborted when rejecting a promise.</p>
 
 <div><pre class="idl">enum MediaKeySessionClosedReason {
-    "unknown",
+    "internal-error",
     "closed-by-application",
-    "persistent-license-released",
-    "cdm-unavailable",
+    "release-acknowledged",
     "hardware-context-reset",
     "resource-evicted"
 };</pre>
 <p>
 The <dfn>MediaKeySessionClosedReason</dfn> enumeration is defined as follows:
 </p>
-<table class="simple" data-dfn-for="MediaKeySessionClosedReason" data-link-for="MediaKeySessionClosedReason"><tbody><tr><th colspan="2">Enumeration description</th></tr><tr><td><dfn><code id="idl-def-MediaKeySessionClosedReason.unknown">unknown</code></dfn></td><td>
-            The session was closed for a reason not covered by any other value.
+<table class="simple" data-dfn-for="MediaKeySessionClosedReason" data-link-for="MediaKeySessionClosedReason"><tbody><tr><th colspan="2">Enumeration description</th></tr><tr><td><dfn><code id="idl-def-MediaKeySessionClosedReason.unknown">internal-error</code></dfn></td><td>
+            The session was closed because of an unrecoverable error in the CDM.
+            <div class="note">
+              <p>
+                When this occurs, applications should not expect to be able to create new sessions on this <a>MediaKeys</a> instance.
+              </p>
+            </div>
           </td></tr><tr><td><dfn><code id="idl-def-MediaKeySessionClosedReason.closed-by-application">closed-by-application</code></dfn></td><td>
             The session was closed by the application calling the <a def-id="close"></a> method of the session explicitly.
-          </td></tr><tr><td><dfn><code id="idl-def-MediaKeySessionClosedReason.persistent-license-released">persistent-license-released</code></dfn></td><td>
+          </td></tr><tr><td><dfn><code id="idl-def-MediaKeySessionClosedReason.release-acknowledged">release-acknowledged</code></dfn></td><td>
             The session was closed because the CDM received a <a def-id="record-of-license-destruction"></a> acknowledgement.
-          </td></tr><tr><td><dfn><code id="idl-def-MediaKeySessionClosedReason.cdm-unavailable">cdm-unavailable</code></dfn></td><td>
-            The session was closed because the CDM became unavailable and the <a def-id="cdm-unavailable-algorithm"></a> algorithm was run.
           </td></tr><tr><td><dfn><code id="idl-def-MediaKeySessionClosedReason.hardware-context-reset">hardware-context-reset</code></dfn></td><td>
-            The session was closed because the CDM's original hardware context was reset.  This could occur for many reasons, including device hibernation, monitor configuration change.
+            The session was closed because the CDM's original hardware context was reset.
             <div class="note">
               <p>
                 This could occur for many reasons, including device hibernation, monitor configuration change, etc.
                 The exact reasons for a hardware context reset are implementation-dependent.
+                When this occurs, applications should expect to be able to create new sessions on this <a>MediaKeys</a> instance.
               </p>
             </div>
           </td></tr><tr><td><dfn><code id="idl-def-MediaKeySessionClosedReason.resource-evicted">resource-evicted</code></dfn></td><td>
@@ -2098,7 +2101,7 @@ The <dfn>MediaKeySessionClosedReason</dfn> enumeration is defined as follows:
                       <dl class="switch">
                         <dt>If <var>session closed</var> is true:</dt>
                         <dd>
-                          <p>Run the <a def-id="session-closed-algorithm"></a> algorithm on this object with reason <a def-id="reason-persistent-license-released"></a>.</p>
+                          <p>Run the <a def-id="session-closed-algorithm"></a> algorithm on this object with reason <a def-id="reason-release-acknowledged"></a>.</p>
                         </dd>
                         <dt>Otherwise:</dt>
                         <dd>

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -1746,7 +1746,7 @@ The <dfn>MediaKeySessionClosedReason</dfn> enumeration is defined as follows:
             The session was closed because of an unrecoverable error in the CDM.
             <div class="note">
               <p>
-                When this occurs, applications should not expect to be able to create new sessions on this <a>MediaKeys</a> instance.
+                When this occurs, applications SHOULD NOT expect to be able to create new sessions on this <a>MediaKeys</a> instance.
               </p>
             </div>
           </td></tr><tr><td><dfn><code id="idl-def-MediaKeySessionClosedReason.closed-by-application">closed-by-application</code></dfn></td><td>
@@ -1759,7 +1759,7 @@ The <dfn>MediaKeySessionClosedReason</dfn> enumeration is defined as follows:
               <p>
                 This could occur for many reasons, including device hibernation, monitor configuration change, etc.
                 The exact reasons for a hardware context reset are implementation-dependent.
-                When this occurs, applications should expect to be able to create new sessions on this <a>MediaKeys</a> instance.
+                When this occurs, applications SHOULD expect to be able to create new sessions on this <a>MediaKeys</a> instance.
               </p>
             </div>
           </td></tr><tr><td><dfn><code id="idl-def-MediaKeySessionClosedReason.resource-evicted">resource-evicted</code></dfn></td><td>
@@ -1767,7 +1767,7 @@ The <dfn>MediaKeySessionClosedReason</dfn> enumeration is defined as follows:
             <div class="note">
               <p>
                 This would imply that the application is running into a device-specific limit on session resources.
-                If the closed session is still needed for some reason, the application developer should consider some strategy to reduce the number of sessions needed or proactively close unneeded sessions.
+                If the closed session is still needed for some reason, the application developer SHOULD consider some strategy to reduce the number of sessions needed or proactively close unneeded sessions.
               </p>
             </div>
           </td></tr></tbody></table></div>

--- a/encrypted-media.js
+++ b/encrypted-media.js
@@ -221,10 +221,9 @@
 
     'statusmap-size': { func: idlref_helper, fragment: 'dom-mediakeystatusmap-size', link_text: 'size',  },
 
-    'reason-unknown': { func: idlref_helper, fragment: 'dom-mediakeysessionclosedreason-unknown', link_text: '"unknown"',  },
+    'reason-internal-error': { func: idlref_helper, fragment: 'dom-mediakeysessionclosedreason-internal-error', link_text: '"internal-error"',  },
     'reason-closed-by-application': { func: idlref_helper, fragment: 'dom-mediakeysessionclosedreason-closed-by-application', link_text: '"closed-by-application"',  },
-    'reason-persistent-license-released': { func: idlref_helper, fragment: 'dom-mediakeysessionclosedreason-persistent-license-released', link_text: '"persistent-license-released"',  },
-    'reason-cdm-unavailable': { func: idlref_helper, fragment: 'dom-mediakeysessionclosedreason-cdm-unavailable', link_text: '"cdm-unavailable"',  },
+    'reason-release-acknowledged': { func: idlref_helper, fragment: 'dom-mediakeysessionclosedreason-release-acknowledged', link_text: '"release-acknowledged"',  },
     'reason-hardware-context-reset': { func: idlref_helper, fragment: 'dom-mediakeysessionclosedreason-hardware-context-reset', link_text: '"hardware-context-reset"',  },
     'reason-resource-evicted': { func: idlref_helper, fragment: 'dom-mediakeysessionclosedreason-resource-evicted', link_text: '"resource-evicted"',  },
 

--- a/encrypted-media.js
+++ b/encrypted-media.js
@@ -221,6 +221,13 @@
 
     'statusmap-size': { func: idlref_helper, fragment: 'dom-mediakeystatusmap-size', link_text: 'size',  },
 
+    'reason-unknown': { func: idlref_helper, fragment: 'dom-mediakeysessionclosedreason-unknown', link_text: '"unknown"',  },
+    'reason-closed-by-application': { func: idlref_helper, fragment: 'dom-mediakeysessionclosedreason-closed-by-application', link_text: '"closed-by-application"',  },
+    'reason-persistent-license-released': { func: idlref_helper, fragment: 'dom-mediakeysessionclosedreason-persistent-license-released', link_text: '"persistent-license-released"',  },
+    'reason-cdm-unavailable': { func: idlref_helper, fragment: 'dom-mediakeysessionclosedreason-cdm-unavailable', link_text: '"cdm-unavailable"',  },
+    'reason-hardware-context-reset': { func: idlref_helper, fragment: 'dom-mediakeysessionclosedreason-hardware-context-reset', link_text: '"hardware-context-reset"',  },
+    'reason-resource-evicted': { func: idlref_helper, fragment: 'dom-mediakeysessionclosedreason-resource-evicted', link_text: '"resource-evicted"',  },
+
     'sessionId': { func: idlref_helper, fragment: 'dom-mediakeysession-sessionid', link_text: 'sessionId',  },
     'expiration': { func: idlref_helper, fragment: 'dom-mediakeysession-expiration', link_text: 'expiration',  },
     'closed': { func: idlref_helper, fragment: 'dom-mediakeysession-closed', link_text: 'closed',  },


### PR DESCRIPTION
This adds a `MediaKeySessionCloseReason` enum, values of which are
used to resolve the `closed` `Promise` on `MediaKeySession`.  This
gives applications additional information about the reasons for a
session closure, which should help applications make better decisions
when a session is closed by the CDM.

Closes #473


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/joeyparrish/encrypted-media/pull/487.html" title="Last updated on Jun 24, 2021, 7:55 PM UTC (8617192)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/487/4c84c08...joeyparrish:8617192.html" title="Last updated on Jun 24, 2021, 7:55 PM UTC (8617192)">Diff</a>