### PR TITLE
Broken references in Encrypted Media Extensions

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -674,7 +674,7 @@ partial interface Navigator {
               Otherwise, it is resolved with a new <a>MediaKeySystemAccess</a> object.
             </p>
             <div class="note">
-              <p>This method is only exposed to <a href="https://www.w3.org/TR/secure-contexts/#secure-context">secure contexts</a> [[SECURE-CONTEXTS]] as indicated by the <code>[SecureContext]</code> IDL attribute.</p>
+              <p>This method is only exposed to <a href="https://www.w3.org/TR/secure-contexts/">secure contexts</a> [[SECURE-CONTEXTS]] as indicated by the <code>[SecureContext]</code> IDL attribute.</p>
               <p>
                 Requiring Secure Contexts is <em>not</em> a replacement for other security- and privacy-related requirements and recommendations.
                 Implementations MUST meet all related requirements and SHOULD follow related recommendations such that the risks on in an secure context would be similar.

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -674,7 +674,7 @@ partial interface Navigator {
               Otherwise, it is resolved with a new <a>MediaKeySystemAccess</a> object.
             </p>
             <div class="note">
-              <p>This method is only exposed to <a href="https://www.w3.org/TR/secure-contexts/">secure contexts</a> [[SECURE-CONTEXTS]] as indicated by the <code>[SecureContext]</code> IDL attribute.</p>
+              <p>This method is only exposed to [=secure contexts=] as indicated by the <code>[SecureContext]</code> IDL attribute.</p>
               <p>
                 Requiring Secure Contexts is <em>not</em> a replacement for other security- and privacy-related requirements and recommendations.
                 Implementations MUST meet all related requirements and SHOULD follow related recommendations such that the risks on in an secure context would be similar.

--- a/encrypted-media.js
+++ b/encrypted-media.js
@@ -1,8 +1,8 @@
 (function() {
   var EME_spec_url = "https://www.w3.org/TR/encrypted-media/";
-  var HTML_spec_url = "https://www.w3.org/TR/html51/semantics-embedded-content.html";
-  var DOM_spec_url = "https://www.w3.org/TR/dom/";
-  var IDL_spec_url = "https://www.w3.org/TR/WebIDL-1/";
+  var HTML_spec_url = "https://html.spec.whatwg.org/multipage/media.html";
+  var DOM_spec_url = "https://dom.spec.whatwg.org/";
+  var IDL_spec_url = "https://webidl.spec.whatwg.org/";
 
   function url_helper(doc, url) {
     if (url[0] == "#" && doc.emeDefGroupName != window.respecConfig.emeDefGroupName) {
@@ -32,19 +32,19 @@
   }
 
   function encodingapi_helper(doc, df, id, text) {
-    link_helper(doc, df, 'https://www.w3.org/TR/encoding/#' + id, text);
+    link_helper(doc, df, 'https://encoding.spec.whatwg.org/#' + id, text);
   }
 
   function webappapis_helper(doc, df, id, text) {
-    link_helper(doc, df, 'https://www.w3.org/TR/html51/webappapis.html#' + id, text);
+    link_helper(doc, df, 'https://html.spec.whatwg.org/multipage/webappapis.html#' + id, text);
   }
 
   function infrastructure_helper(doc, df, id, text) {
-    link_helper(doc, df, 'https://www.w3.org/TR/html51/infrastructure.html#' + id, text);
+    link_helper(doc, df, 'https://html.spec.whatwg.org/multipage/infrastructure.html#' + id, text);
   }
 
   function browsers_helper(doc, df, id, text) {
-    link_helper(doc, df, 'https://www.w3.org/TR/html51/browsers.html#' + id, text);
+    link_helper(doc, df, 'https://html.spec.whatwg.org/multipage/browsers.html#' + id, text);
   }
 
   function mixedcontent_helper(doc, df, id, text) {
@@ -408,8 +408,6 @@
           var prefix = is_registry_file ? "../../" : "";
           EME_spec_url = prefix + file;
           groupBaseURLs[x] = EME_spec_url;
-          // Refer to the Web IDL Editor’s Draft from Editor’s Drafts of this spec.
-          IDL_spec_url = "https://webidl.spec.whatwg.org/";
       }
     }
 

--- a/encrypted-media.js
+++ b/encrypted-media.js
@@ -409,7 +409,7 @@
           EME_spec_url = prefix + file;
           groupBaseURLs[x] = EME_spec_url;
           // Refer to the Web IDL Editor’s Draft from Editor’s Drafts of this spec.
-          IDL_spec_url = "https://www.w3.org/TR/WebIDL-1/";
+          IDL_spec_url = "https://webidl.spec.whatwg.org/";
       }
     }
 

--- a/encrypted-media.js
+++ b/encrypted-media.js
@@ -324,8 +324,8 @@
     'new-domexception-named': { func: new_domexception_helper, fragment: '', },
     'domexception': { func: domexception_helper, fragment: '', },
     'domexception-names': { func: webidl_helper, fragment: 'idl-DOMException-error-names', link_text: '', },
-    'present-dictionary-member': { func: webidl_helper, fragment: 'dfn-present', link_text: 'present', },
-    'not-present-dictionary-member': { func: webidl_helper, fragment: 'dfn-present', link_text: 'not present', },
+    'present-dictionary-member': { func: webidl_helper, fragment: 'map-exists', link_text: 'present', },
+    'not-present-dictionary-member': { func: webidl_helper, fragment: 'map-exists', link_text: 'not present', },
     'simple-exception': { func: webidl_helper, fragment: 'dfn-simple-exception', link_text: 'simple exception', },
     'throw': { func: webidl_helper, fragment: 'dfn-throw', link_text: 'throw', },
 
@@ -409,7 +409,7 @@
           EME_spec_url = prefix + file;
           groupBaseURLs[x] = EME_spec_url;
           // Refer to the Web IDL Editor’s Draft from Editor’s Drafts of this spec.
-          IDL_spec_url = "https://heycam.github.io/webidl/";
+          IDL_spec_url = "https://www.w3.org/TR/WebIDL-1/";
       }
     }
 


### PR DESCRIPTION
Fixing non-existing anchors

Closes #502


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gregwfreedman/encrypted-media/pull/505.html" title="Last updated on Jul 19, 2023, 10:47 PM UTC (859a7c9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/505/9e777de...gregwfreedman:859a7c9.html" title="Last updated on Jul 19, 2023, 10:47 PM UTC (859a7c9)">Diff</a>