### PR TITLE
Add draft HDCP version registry

### DIFF
--- a/.github/workflows/generate-respec-html.yml
+++ b/.github/workflows/generate-respec-html.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Generate HTML
         run: |
           npx respec2html encrypted-media-respec.html -o build/index.html
+          npx respec2html hdcp-version-registry-respec.html -o hdcp-version-registry.html
           npx respec2html format-registry/initdata/cenc-respec.html -o build/format-registry/initdata/cenc.html
           npx respec2html format-registry/initdata/index-respec.html -o build/format-registry/initdata/index.html
           npx respec2html format-registry/initdata/keyids-respec.html -o build/format-registry/initdata/keyids.html

--- a/hdcp-version-registry-respec.html
+++ b/hdcp-version-registry-respec.html
@@ -19,30 +19,101 @@
       group: "media",
       localBiblio: {
         "HDCP-1.0": {
-          "title": "High-bandwidth Digital Content Protection System, Revision 1.0",
-          "publisher": "Digital Content Protection LLC",
-          "date": "17 Feburary 2000"
+          title: "High-bandwidth Digital Content Protection System, Revision 1.0",
+          publisher: "Digital Content Protection LLC",
+          date: "17 Feburary 2000",
+          href: "https://www.digital-cp.com/sites/default/files/specifications/HDCP10.pdf"
         },
         "HDCP-1.1": {
-          "title": "High-bandwidth Digital Content Protection System, Revision 1.1",
-          "publisher": "Digital Content Protection LLC",
-          "date": "9 June 2003"
+          title: "High-bandwidth Digital Content Protection System, Revision 1.1",
+          publisher: "Digital Content Protection LLC",
+          date: "9 June 2003",
+          href: "https://www.digital-cp.com/sites/default/files/specifications/HDCPSpecificationRev1_1.pdf"
         },
         "HDCP-1.2": {
-          "title": "High-bandwidth Digital Content Protection System, Revision 1.2",
-          "publisher": "Digital Content Protection LLC",
-          "date": "13 June 2006"
+          title: "High-bandwidth Digital Content Protection System, Revision 1.2",
+          publisher: "Digital Content Protection LLC",
+          date: "13 June 2006",
+          href: "https://www.digital-cp.com/sites/default/files/specifications/HDCP_Specification_Rev1_2.pdf"
         },
         "HDCP-1.3": {
-          "title": "High-bandwidth Digital Content Protection System, Revision 1.3",
-          "publisher": "Digital Content Protection LLC",
-          "date": "21 December 2006"
+          title: "High-bandwidth Digital Content Protection System, Revision 1.3",
+          publisher: "Digital Content Protection LLC",
+          date: "21 December 2006",
+          href: "https://www.digital-cp.com/sites/default/files/specifications/HDCP_Specification%20Rev1_3_0.pdf"
         },
         "HDCP-1.4": {
-          "title": "High-bandwidth Digital Content Protection System, Revision 1.4",
-          "publisher": "Digital Content Protection LLC",
-          "date": "8 July 2009"
+          title: "High-bandwidth Digital Content Protection System, Revision 1.4",
+          publisher: "Digital Content Protection LLC",
+          date: "8 July 2009",
+          href: "https://www.digital-cp.com/sites/default/files/specifications/HDCP Specification Rev1_4_Secure.pdf"
         },
+        "HDCP-2.0-IIA": {
+          title: "High-bandwidth Digital Content Protection System: Interface Indepedent Adaptation, Revision 2.0",
+          publisher: "Digital Content Protection LLC",
+          date: "23 October 2008",
+          href: "https://www.digital-cp.com/sites/default/files/specifications/HDCP%20Interface%20Independent%20Adaptation%20Specification%20Rev2_0.pdf"
+        },
+        "HDCP-2.0-WHDI": {
+          title: "High-bandwidth Digital Content Protection System: Mapping HDCP to WHDI, Revision 2.0",
+          publisher: "Digital Content Protection LLC",
+          date: "21 October 2008",
+          href: "https://www.digital-cp.com/sites/default/files/specifications/HDCP on WHDI Specification Rev2_0 _2_.pdf"
+        },
+        "HDCP-2.1-IIA": {
+          title: "High-bandwidth Digital Content Protection System: Interface Indepedent Adaptation, Revision 2.1",
+          publisher: "Digital Content Protection LLC",
+          date: "18 July 2011",
+          href: "https://www.digital-cp.com/sites/default/files/specifications/HDCP%20Interface%20Independent%20Adaptation%20Specification%20Rev2_1.pdf"
+        },
+        "HDCP-2.2-DisplayPort": {
+          title: "High-bandwidth Digital Content Protection System: Mapping HDCP to DisplayPort, Revision 2.3",
+          publisher: "Digital Content Protection LLC",
+          date: "21 December 2012",
+          href: "https://www.digital-cp.com/sites/default/files/specifications/HDCP on DisplayPort Specification Rev2_2.pdf"
+        },
+        "HDCP-2.2-HDBaseT": {
+          title: "High-bandwidth Digital Content Protection System: Mapping HDCP to HDBaseT, Revision 2.3",
+          publisher: "Digital Content Protection LLC",
+          date: "1 September 2015",
+          href: "https://www.digital-cp.com/sites/default/files/specifications/HDCP on HDBaseT Specification Rev2_2.pdf"
+        },
+        "HDCP-2.2-MHL": {
+          title: "High-bandwidth Digital Content Protection System: Mapping HDCP to MHL, Revision 2.3",
+          publisher: "Digital Content Protection LLC",
+          date: "11 September 2013",
+          href: "https://www.digital-cp.com/sites/default/files/specifications/HDCP on MHL Specification Rev2_2.pdf"
+        },
+        "HDCP-2.2-USB": {
+          title: "High-bandwidth Digital Content Protection System: Mapping HDCP to USB, Revision 2.3",
+          publisher: "Digital Content Protection LLC",
+          date: "11 August 2014",
+          href: "https://www.digital-cp.com/sites/default/files/specifications/HDCP on USB Specification Rev2_2.pdf"
+        },
+        "HDCP-2.3-HDMI": {
+          title: "High-bandwidth Digital Content Protection System: Mapping HDCP to HDMI, Revision 2.3",
+          publisher: "Digital Content Protection LLC",
+          date: "28 February 2018",
+          href: "https://www.digital-cp.com/sites/default/files/specifications/HDCP on HDMI Specification Rev2_3.pdf",
+        },
+        "HDCP-2.3-DisplayPort": {
+          title: "High-bandwidth Digital Content Protection System: Mapping HDCP to DisplayPort, Revision 2.3",
+          publisher: "Digital Content Protection LLC",
+          date: "22 January 2019",
+          href: "https://www.digital-cp.com/sites/default/files/specifications/HDCP on DisplayPort Specification Rev2_3.pdf"
+        },
+        "HDCP-2.3-HDBaseT": {
+          title: "High-bandwidth Digital Content Protection System: Mapping HDCP to HDBaseT, Revision 2.3",
+          publisher: "Digital Content Protection LLC",
+          date: "26 July 2019",
+          href: "https://www.digital-cp.com/sites/default/files/specifications/HDCP on HDBaseT Specification Rev2_3.pdf"
+        },
+        "HDCP-2.3-WHDI": {
+          title: "High-bandwidth Digital Content Protection System: Mapping HDCP to WHDI, Revision 2.3",
+          publisher: "Digital Content Protection LLC",
+          date: "24 July 2018",
+          href: "https://www.digital-cp.com/sites/default/files/specifications/HDCP on WHDI Specification Rev2_3_zeev_2018_07_24.pdf"
+        }
       }
     };
     </script>
@@ -130,19 +201,19 @@
           </tr>
           <tr>
             <td><code>"2.0"</code></td>
-            <td>TODO</td>
+            <td>[[HDCP-2.0-IIA]], [[HDCP-2.0-WHDI]]</td>
           </tr>
           <tr>
             <td><code>"2.1"</code></td>
-            <td>TODO</td>
+            <td>[[HDCP-2.1-IIA]]</td>
           </tr>
           <tr>
             <td><code>"2.2"</code></td>
-            <td>TODO</td>
+            <td>[[HDCP-2.2-DisplayPort]], [[HDCP-2.2-HDBaseT]], [[HDCP-2.2-MHL]], [[HDCP-2.2-USB]]</td>
           </tr>
           <tr>
             <td><code>"2.3"</code></td>
-            <td>TODO</td>
+            <td>[[HDCP-2.3-DisplayPort]], [[HDCP-2.3-HDBaseT]], [[HDCP-2.3-HDMI]], [[HDCP-2.3-WHDI]]</td>
           </tr>
         </tbody>
       </table>

--- a/hdcp-version-registry-respec.html
+++ b/hdcp-version-registry-respec.html
@@ -21,9 +21,7 @@
         { name: "Joey Parrish", w3cid: "105371",
           company: "Google Inc.", companyURL: "https://www.google.com/" },
         { name: "Greg Freedman",
-          company: "Netflix Inc.", companyURL: "https://www.netflix.com/" },
-        { name: "Chris Needham", w3cid: "67414",
-          company: "British Broadcasting Corporation", companyURL: "https://bbc.co.uk/" },
+          company: "Netflix Inc.", companyURL: "https://www.netflix.com/" }
       ],
 
       github: "w3c/encrypted-media",

--- a/hdcp-version-registry-respec.html
+++ b/hdcp-version-registry-respec.html
@@ -30,27 +30,27 @@
       group: "media",
 
       localBiblio: {
-        "HDCP-REVISION-1.0": {
+        "HDCP-1.0": {
           "title": "High-bandwidth Digital Content Protection System, Revision 1.0",
           "publisher": "Digital Content Protection LLC",
           "date": "17 Feburary 2000"
         },
-        "HDCP-REVISION-1.1": {
+        "HDCP-1.1": {
           "title": "High-bandwidth Digital Content Protection System, Revision 1.1",
           "publisher": "Digital Content Protection LLC",
           "date": "9 June 2003"
         },
-        "HDCP-REVISION-1.2": {
+        "HDCP-1.2": {
           "title": "High-bandwidth Digital Content Protection System, Revision 1.2",
           "publisher": "Digital Content Protection LLC",
           "date": "13 June 2006"
         },
-        "HDCP-REVISION-1.3": {
+        "HDCP-1.3": {
           "title": "High-bandwidth Digital Content Protection System, Revision 1.3",
           "publisher": "Digital Content Protection LLC",
           "date": "21 December 2006"
         },
-        "HDCP-REVISION-1.4": {
+        "HDCP-1.4": {
           "title": "High-bandwidth Digital Content Protection System, Revision 1.4",
           "publisher": "Digital Content Protection LLC",
           "date": "8 July 2009"
@@ -121,23 +121,23 @@
         <tbody>
           <tr>
             <td><code>"1.0"</code></td>
-            <td>[[HDCP-REVISION-1.0]]</td>
+            <td>[[HDCP-1.0]]</td>
           </tr>
           <tr>
             <td><code>"1.1"</code></td>
-            <td>[[HDCP-REVISION-1.1]]</td>
+            <td>[[HDCP-1.1]]</td>
           </tr>
           <tr>
             <td><code>"1.2"</code></td>
-            <td>[[HDCP-REVISION-1.2]]</td>
+            <td>[[HDCP-1.2]]</td>
           </tr>
           <tr>
             <td><code>"1.3"</code></td>
-            <td>[[HDCP-REVISION-1.3]]</td>
+            <td>[[HDCP-1.3]]</td>
           </tr>
           <tr>
             <td><code>"1.4"</code></td>
-            <td>[[HDCP-REVISION-1.4]]</td>
+            <td>[[HDCP-1.4]]</td>
           </tr>
           <tr>
             <td><code>"2.0"</code></td>

--- a/hdcp-version-registry-respec.html
+++ b/hdcp-version-registry-respec.html
@@ -86,7 +86,8 @@
           Each entry must include a unique HDCP version number, as a string.
         </li>
         <li>
-          Each entry must include links that reference the publicly available specification(s) for the HDCP version.
+          Each entry must include reference to the specification(s) for the HDCP version,
+          with a link if the specification(s) are publicly available.
         </li>
         <li>
           Candidate entries must be announced by filing an issue in the

--- a/hdcp-version-registry-respec.html
+++ b/hdcp-version-registry-respec.html
@@ -67,25 +67,25 @@
           href: "https://www.digital-cp.com/sites/default/files/specifications/HDCP%20Interface%20Independent%20Adaptation%20Specification%20Rev2_1.pdf"
         },
         "HDCP-2.2-DisplayPort": {
-          title: "High-bandwidth Digital Content Protection System: Mapping HDCP to DisplayPort, Revision 2.3",
+          title: "High-bandwidth Digital Content Protection System: Mapping HDCP to DisplayPort, Revision 2.2",
           publisher: "Digital Content Protection LLC",
           date: "21 December 2012",
           href: "https://www.digital-cp.com/sites/default/files/specifications/HDCP on DisplayPort Specification Rev2_2.pdf"
         },
         "HDCP-2.2-HDBaseT": {
-          title: "High-bandwidth Digital Content Protection System: Mapping HDCP to HDBaseT, Revision 2.3",
+          title: "High-bandwidth Digital Content Protection System: Mapping HDCP to HDBaseT, Revision 2.2",
           publisher: "Digital Content Protection LLC",
           date: "1 September 2015",
           href: "https://www.digital-cp.com/sites/default/files/specifications/HDCP on HDBaseT Specification Rev2_2.pdf"
         },
         "HDCP-2.2-MHL": {
-          title: "High-bandwidth Digital Content Protection System: Mapping HDCP to MHL, Revision 2.3",
+          title: "High-bandwidth Digital Content Protection System: Mapping HDCP to MHL, Revision 2.2",
           publisher: "Digital Content Protection LLC",
           date: "11 September 2013",
           href: "https://www.digital-cp.com/sites/default/files/specifications/HDCP on MHL Specification Rev2_2.pdf"
         },
         "HDCP-2.2-USB": {
-          title: "High-bandwidth Digital Content Protection System: Mapping HDCP to USB, Revision 2.3",
+          title: "High-bandwidth Digital Content Protection System: Mapping HDCP to USB, Revision 2.2",
           publisher: "Digital Content Protection LLC",
           date: "11 August 2014",
           href: "https://www.digital-cp.com/sites/default/files/specifications/HDCP on USB Specification Rev2_2.pdf"

--- a/hdcp-version-registry-respec.html
+++ b/hdcp-version-registry-respec.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>Encrypted Media Extensions HDCP Version Registry</title>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
+    <script class="remove">
+    var respecConfig = {
+      // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
+      specStatus: "DRY",
+
+      // the specification's short name, as in https://www.w3.org/TR/short-name/
+      shortName: "eme-hdcp-version-registry",
+
+      // if there a publicly available Editor's Draft, this is the link
+      edDraftURI: "https://w3c.github.io/encrypted-media/hdcp-version-registry.html",
+
+      // if this is a LCWD, uncomment and set the end of its review period
+      // lcEnd: "2009-08-05",
+
+      // editors, add as many as you like
+      // only "name" is required
+      editors: [
+        { name: "Joey Parrish", w3cid: "105371",
+          company: "Google Inc.", companyURL: "https://www.google.com/" },
+        { name: "Greg Freedman",
+          company: "Netflix Inc.", companyURL: "https://www.netflix.com/" },
+        { name: "Chris Needham", w3cid: "67414",
+          company: "British Broadcasting Corporation", companyURL: "https://bbc.co.uk/" },
+      ],
+
+      github: "w3c/encrypted-media",
+
+      // name of the WG
+      group: "media",
+
+      localBiblio: {
+        "HDCP-REVISION-1.0": {
+          "title": "High-bandwidth Digital Content Protection System, Revision 1.0",
+          "publisher": "Digital Content Protection LLC",
+          "date": "17 Feburary 2000"
+        },
+        "HDCP-REVISION-1.1": {
+          "title": "High-bandwidth Digital Content Protection System, Revision 1.1",
+          "publisher": "Digital Content Protection LLC",
+          "date": "9 June 2003"
+        },
+        "HDCP-REVISION-1.2": {
+          "title": "High-bandwidth Digital Content Protection System, Revision 1.2",
+          "publisher": "Digital Content Protection LLC",
+          "date": "13 June 2006"
+        },
+        "HDCP-REVISION-1.3": {
+          "title": "High-bandwidth Digital Content Protection System, Revision 1.3",
+          "publisher": "Digital Content Protection LLC",
+          "date": "21 December 2006"
+        },
+        "HDCP-REVISION-1.4": {
+          "title": "High-bandwidth Digital Content Protection System, Revision 1.4",
+          "publisher": "Digital Content Protection LLC",
+          "date": "8 July 2009"
+        },
+      }
+    };
+    </script>
+  </head>
+  <body>
+    <section id="abstract">
+      <p>
+        This registry defines the set of High-bandwidth Digital Content Protection (HDCP) versions
+        used with the Encrypted Media Extensions <code>getStatusForPolicy</code> method [[ENCRYPTED-MEDIA]].
+      </p>
+    </section>
+
+    <section id="sotd">
+    </section>
+
+    <section id="conformance">
+      <p>This registry is non-normative.</p>
+    </section>
+
+    <section>
+      <h2>Organization</h2>
+      <p>This registry maintains a mapping between HDCP version strings and HDCP specifications as described below.</p>
+    </section>
+
+    <section>
+      <h2>Registration Entry Requirements</h2>
+      <ol>
+        <li>
+          Each entry must include a unique HDCP version number, as a string.
+        </li>
+        <li>
+          Each entry must include links that reference the publicly available specification(s) for the HDCP version.
+        </li>
+        <li>
+          Candidate entries must be announced by filing an issue in the
+          <a href="https://github.com/w3c/encrypted-media/issues">Encrypted Media Extensions GitHub issue tracker</a>
+          so they can be discussed and evaluated for compliance before being added to the registry.
+        </li>
+        <li>
+          If the Media Working Group reaches consensus to accept the candidate,
+          a pull request should be drafted
+          (either by the registry editors or by the party requesting the candidate registration)
+          to register the candidate.
+          The registry editors will review and merge the pull request.
+        </li>
+
+        <li>
+          Existing entries cannot be deleted or deprecated.
+          They may be changed after being published through the same process as candidate entries.
+          Possible changes include updating the link to the entry's specification.
+        </li>
+      </ol>
+    </section>
+
+    <section>
+      <h2>Registry</h2>
+      <table class="data">
+        <thead>
+          <tr>
+            <th>Value</th>
+            <th>Public Specification(s)</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>"1.0"</code></td>
+            <td>[[HDCP-REVISION-1.0]]</td>
+          </tr>
+          <tr>
+            <td><code>"1.1"</code></td>
+            <td>[[HDCP-REVISION-1.1]]</td>
+          </tr>
+          <tr>
+            <td><code>"1.2"</code></td>
+            <td>[[HDCP-REVISION-1.2]]</td>
+          </tr>
+          <tr>
+            <td><code>"1.3"</code></td>
+            <td>[[HDCP-REVISION-1.3]]</td>
+          </tr>
+          <tr>
+            <td><code>"1.4"</code></td>
+            <td>[[HDCP-REVISION-1.4]]</td>
+          </tr>
+          <tr>
+            <td><code>"2.0"</code></td>
+            <td>TODO</td>
+          </tr>
+          <tr>
+            <td><code>"2.1"</code></td>
+            <td>TODO</td>
+          </tr>
+          <tr>
+            <td><code>"2.2"</code></td>
+            <td>TODO</td>
+          </tr>
+          <tr>
+            <td><code>"2.3"</code></td>
+            <td>TODO</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+    <section>
+      <h2>Privacy Considerations</h2>
+      <p>Please refer to the Privacy section in [[ENCRYPTED-MEDIA]].</p>
+    </section>
+    <section>
+      <h2>Security Considerations</h2>
+      <p>Please refer to the Security section in [[ENCRYPTED-MEDIA]].</p>
+    </section>
+  </body>
+</html>

--- a/hdcp-version-registry-respec.html
+++ b/hdcp-version-registry-respec.html
@@ -15,9 +15,6 @@
       // if there a publicly available Editor's Draft, this is the link
       edDraftURI: "https://w3c.github.io/encrypted-media/hdcp-version-registry.html",
 
-      // if this is a LCWD, uncomment and set the end of its review period
-      // lcEnd: "2009-08-05",
-
       // editors, add as many as you like
       // only "name" is required
       editors: [

--- a/hdcp-version-registry-respec.html
+++ b/hdcp-version-registry-respec.html
@@ -6,29 +6,17 @@
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
     <script class="remove">
     var respecConfig = {
-      // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
       specStatus: "DRY",
-
-      // the specification's short name, as in https://www.w3.org/TR/short-name/
       shortName: "eme-hdcp-version-registry",
-
-      // if there a publicly available Editor's Draft, this is the link
       edDraftURI: "https://w3c.github.io/encrypted-media/hdcp-version-registry.html",
-
-      // editors, add as many as you like
-      // only "name" is required
       editors: [
         { name: "Joey Parrish", w3cid: "105371",
           company: "Google Inc.", companyURL: "https://www.google.com/" },
         { name: "Greg Freedman",
           company: "Netflix Inc.", companyURL: "https://www.netflix.com/" }
       ],
-
       github: "w3c/encrypted-media",
-
-      // name of the WG
       group: "media",
-
       localBiblio: {
         "HDCP-1.0": {
           "title": "High-bandwidth Digital Content Protection System, Revision 1.0",


### PR DESCRIPTION
Following from #515, this adds a draft registry for HDCP versions.

Still to do:

- [x] Add references for HDCP 2.0 and upwards
- [x] Add spec links
- [ ] Update EME spec to reference the registry