### PR TITLE
[Editorial] Drop "div" around IDL sections

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -658,7 +658,7 @@
       <section>
         <h3><dfn>Navigator</dfn> Extension: <code>requestMediaKeySystemAccess()</code></h3>
 
-        <div><pre class="idl">[Exposed=Window]
+        <pre class="idl">[Exposed=Window]
 partial interface Navigator {
     [SecureContext] Promise&lt;MediaKeySystemAccess&gt; requestMediaKeySystemAccess (DOMString keySystem, sequence&lt;MediaKeySystemConfiguration&gt; supportedConfigurations);
 };</pre><section><h2>Methods</h2><dl class="methods" data-dfn-for="Navigator" data-link-for="Navigator"><dt><dfn><code>requestMediaKeySystemAccess</code></dfn></dt><dd>
@@ -731,7 +731,7 @@ partial interface Navigator {
               </td></tr><tr><td class="prmName">supportedConfigurations</td><td class="prmType"><code>sequence&lt;MediaKeySystemConfiguration&gt;</code></td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td><td class="prmDesc">
                 A sequence of <a>MediaKeySystemConfiguration</a> configurations to try in order.
                 The first element with a satisfiable configuration will be used.
-              </td></tr></tbody></table><div><em>Return type: </em><code>Promise&lt;MediaKeySystemAccess&gt;</code></div></dd></dl></section></div>
+              </td></tr></tbody></table><div><em>Return type: </em><code>Promise&lt;MediaKeySystemAccess&gt;</code></div></dd></dl></section>
 
         <section>
           <h4>Algorithms</h4>
@@ -1265,7 +1265,7 @@ partial interface Navigator {
       <section>
         <h3><a>MediaKeySystemConfiguration</a> dictionary</h3>
 
-        <div><pre class="idl">enum MediaKeysRequirement {
+        <pre class="idl">enum MediaKeysRequirement {
     "required",
     "optional",
     "not-allowed"
@@ -1294,9 +1294,9 @@ The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows:
               <dt>When returned by a <a>MediaKeySystemAccess</a> object</dt>
               <dd>CDM instances created by the object MUST NOT use this feature.</dd>
             </dl>
-          </td></tr></tbody></table></div>
+          </td></tr></tbody></table>
 
-        <div><pre class="idl">dictionary MediaKeySystemConfiguration {
+        <pre class="idl">dictionary MediaKeySystemConfiguration {
              DOMString                               label = "";
              sequence&lt;DOMString&gt;                     initDataTypes = [];
              sequence&lt;MediaKeySystemMediaCapability&gt; audioCapabilities = [];
@@ -1352,7 +1352,6 @@ The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows:
 
       <section>
         <h3><dfn>MediaKeySystemMediaCapability</dfn> dictionary</h3>
-        <div>
           <pre class="idl">dictionary MediaKeySystemMediaCapability {
              DOMString contentType = "";
              DOMString? encryptionScheme = null;
@@ -1435,7 +1434,7 @@ The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows:
               </div>
             </dd>
           </dl>
-        </section></div>
+        </section>
 
         <p>In order for the capability represented by this object to be considered supported, <a def-id="capability-contentType"></a> MUST NOT be the empty string and its entire value, including all codecs, MUST be supported with <a def-id="capability-robustness"></a>.</p>
         <p class="note">If any of a set of codecs is acceptable, use a separate instances of this dictionary for each codec.</p>
@@ -1447,7 +1446,7 @@ The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows:
       <h2><dfn>MediaKeySystemAccess</dfn> Interface</h2>
       <p>The MediaKeySystemAccess object provides access to a <a def-id="keysystem"></a>.</p>
 
-      <div><pre class="idl">[Exposed=Window, SecureContext] interface MediaKeySystemAccess {
+      <pre class="idl">[Exposed=Window, SecureContext] interface MediaKeySystemAccess {
     readonly        attribute DOMString keySystem;
     MediaKeySystemConfiguration getConfiguration ();
     Promise&lt;MediaKeys&gt;          createMediaKeys ();
@@ -1515,7 +1514,7 @@ The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows:
             </li>
             <li><p>Return <var>promise</var>.</p></li>
           </ol>
-        <div><em>No parameters.</em></div><div><em>Return type: </em><code>Promise&lt;MediaKeys&gt;</code></div></dd></dl></section></div>
+        <div><em>No parameters.</em></div><div><em>Return type: </em><code>Promise&lt;MediaKeys&gt;</code></div></dd></dl></section>
     </section>
 
 
@@ -1529,7 +1528,7 @@ The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows:
       <p>For methods that return a promise, all errors are reported asynchronously by rejecting the returned Promise. This includes [[WEBIDL]] type mapping errors.</p>
       <p>The steps of an algorithm are always aborted when rejecting a promise.</p>
 
-      <div><pre class="idl">enum MediaKeySessionType {
+      <pre class="idl">enum MediaKeySessionType {
     "temporary",
     "persistent-license"
 };</pre>
@@ -1562,18 +1561,17 @@ The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows:
             See <a def-id="session-storage"></a>.
           </p>
         </td></tr>
-      </tbody></table></div>
+      </tbody></table>
 
-      <div>
-        <pre class="idl">
-          [Exposed=Window, SecureContext] interface MediaKeys {
-              MediaKeySession  createSession (optional MediaKeySessionType sessionType = "temporary");
-              Promise&lt;MediaKeyStatus&gt; getStatusForPolicy (optional MediaKeysPolicy policy = {});
-              Promise&lt;boolean&gt; setServerCertificate (BufferSource serverCertificate);
-          };
-        </pre>
+      <pre class="idl">
+        [Exposed=Window, SecureContext] interface MediaKeys {
+            MediaKeySession  createSession (optional MediaKeySessionType sessionType = "temporary");
+            Promise&lt;MediaKeyStatus&gt; getStatusForPolicy (optional MediaKeysPolicy policy = {});
+            Promise&lt;boolean&gt; setServerCertificate (BufferSource serverCertificate);
+        };
+      </pre>
 
-        <section id="">
+        <section>
           <h2>Methods</h2>
           <dl class="methods" data-dfn-for="MediaKeys" data-link-for="MediaKeys">
             <dt><dfn><code>createSession</code></dfn></dt><dd>
@@ -1730,9 +1728,8 @@ The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows:
           </dd>
           </dl>
         </section>
-      </div>
 
-      <section id="">
+      <section>
         <h3>Algorithms</h3>
         <section id="is-persistent-session-type">
           <h4>Is persistent session type?</h4>
@@ -1825,7 +1822,7 @@ The <dfn>MediaKeysRequirement</dfn> enumeration is defined as follows:
       <p>For methods that return a promise, all errors are reported asynchronously by rejecting the returned Promise. This includes [[WEBIDL]] type mapping errors.</p>
       <p>The following steps of an algorithm are always aborted when rejecting a promise.</p>
 
-<div><pre class="idl">enum MediaKeySessionClosedReason {
+<pre class="idl">enum MediaKeySessionClosedReason {
     "internal-error",
     "closed-by-application",
     "release-acknowledged",
@@ -1859,9 +1856,9 @@ The <dfn>MediaKeySessionClosedReason</dfn> enumeration is defined as follows:
                 If the closed session is still needed for some reason, the application developer should consider some strategy to reduce the number of sessions needed or proactively close unneeded sessions.
               </p>
             </div>
-          </td></tr></tbody></table></div>
+          </td></tr></tbody></table>
 
-      <div><pre class="idl">[Exposed=Window, SecureContext] interface MediaKeySession : EventTarget {
+      <pre class="idl">[Exposed=Window, SecureContext] interface MediaKeySession : EventTarget {
     readonly        attribute DOMString                            sessionId;
     readonly        attribute unrestricted double                  expiration;
     readonly        attribute Promise&lt;MediaKeySessionClosedReason&gt; closed;
@@ -2346,14 +2343,14 @@ The <dfn>MediaKeySessionClosedReason</dfn> enumeration is defined as follows:
             </li>
             <li><p>Return <var>promise</var>.</p></li>
           </ol>
-        <div><em>No parameters.</em></div><div><em>Return type: </em><code>Promise&lt;undefined&gt;</code></div></dd></dl></section></div>
+        <div><em>No parameters.</em></div><div><em>Return type: </em><code>Promise&lt;undefined&gt;</code></div></dd></dl></section>
 
       <section>
         <h2><dfn>MediaKeyStatusMap</dfn> Interface</h2>
         <p>The MediaKeyStatusMap object is a read-only map of <a def-id="key-id">key IDs</a> to the current status of the associated key.</p>
         <p>A key's status is independent of whether the key is currently being used and of media data.</p>
         <p class="note">For example, if a key has output requirements that cannot currently be met, the key's status should be <a def-id="status-output-downscaled"></a> or <a def-id="status-output-restricted"></a>, as appropriate, regardless of whether that key has been or is currently needed to decrypt media data.</p>
-        <div><pre class="idl">[Exposed=Window, SecureContext] interface MediaKeyStatusMap {
+        <pre class="idl">[Exposed=Window, SecureContext] interface MediaKeyStatusMap {
     iterable&lt;BufferSource,MediaKeyStatus&gt;;
     readonly        attribute unsigned long size;
     boolean has (BufferSource keyId);
@@ -2398,9 +2395,8 @@ The <dfn>MediaKeySessionClosedReason</dfn> enumeration is defined as follows:
               order than the first <var>m</var> octets of <var>B</var> or those octets are equal and <var>m</var> &lt; <var>n</var>.
             </p>
           </section>
-        </div>
 
-        <div><pre class="idl">enum MediaKeyStatus {
+        <pre class="idl">enum MediaKeyStatus {
     "usable",
     "expired",
     "released",
@@ -2444,7 +2440,7 @@ The <dfn>MediaKeySessionClosedReason</dfn> enumeration is defined as follows:
           </td></tr><tr><td><dfn><code id="idl-def-MediaKeyStatus.internal-error">internal-error</code></dfn></td><td>
             The key is not currently <a def-id="usable-for-decryption"></a> because of an error in the CDM unrelated to the other values.
             This value is not actionable by the application.
-          </td></tr></tbody></table></div>
+          </td></tr></tbody></table>
       </section>
 
       <section>
@@ -2452,7 +2448,7 @@ The <dfn>MediaKeySessionClosedReason</dfn> enumeration is defined as follows:
         <p>The MediaKeyMessageEvent object is used for the <a def-id="message"></a> event.</p>
         <p>Events are constructed as defined in <a def-id="constructing-events"></a> [[DOM]].</p>
 
-        <div><pre class="idl">enum MediaKeyMessageType {
+        <pre class="idl">enum MediaKeyMessageType {
     "license-request",
     "license-renewal",
     "license-release",
@@ -2462,9 +2458,9 @@ The <dfn>MediaKeySessionClosedReason</dfn> enumeration is defined as follows:
   <table class="simple" data-dfn-for="MediaKeyMessageType" data-link-for="MediaKeyMessageType"><tbody><tr><th colspan="2">Enumeration description</th></tr><tr><td><dfn><code id="idl-def-MediaKeyMessageType.license-request">license-request</code></dfn></td><td>The message contains a request for a new license.</td></tr><tr><td><dfn><code id="idl-def-MediaKeyMessageType.license-renewal">license-renewal</code></dfn></td><td>The message contains a request to renew an existing license.</td></tr><tr><td><dfn><code id="idl-def-MediaKeyMessageType.license-release">license-release</code></dfn></td><td>The message contains a <a def-id="record-of-license-destruction"></a>.</td></tr><tr><td><dfn><code id="idl-def-MediaKeyMessageType.individualization-request">individualization-request</code></dfn></td><td>
             The message contains a request for <a href="#app-assisted-individualization">App-Assisted Individualization</a> (or re-individualization).<br>
             As with all other messages, any identifiers in the message MUST be <a href="#per-origin-per-profile-identifiers">distinctive per origin and profile</a> and MUST NOT be <a def-id="distinctive-permanent-identifier-maybe-plural"></a>.
-          </td></tr></tbody></table></div>
+          </td></tr></tbody></table>
 
-        <div><pre class="idl">[Exposed=Window, SecureContext]
+        <pre class="idl">[Exposed=Window, SecureContext]
 interface MediaKeyMessageEvent : Event {
     constructor(DOMString type, MediaKeyMessageEventInit eventInitDict);
     readonly        attribute MediaKeyMessageType messageType;
@@ -2482,18 +2478,18 @@ interface MediaKeyMessageEvent : Event {
             </p>
           </dd><dt><dfn><code>message</code></dfn> of type <span class="idlAttrType">{{ArrayBuffer}}</span>, readonly       </dt><dd>
             The message from the CDM. Messages are Key System-specific.
-          </dd></dl></section></div>
+          </dd></dl></section>
 
         <section>
           <h4><dfn>MediaKeyMessageEventInit</dfn></h4>
-          <div><pre class="idl" data-cite="DOM">dictionary MediaKeyMessageEventInit : EventInit {
+          <pre class="idl" data-cite="DOM">dictionary MediaKeyMessageEventInit : EventInit {
              required MediaKeyMessageType messageType;
              required ArrayBuffer         message;
 };</pre><section><h2>Dictionary <a class="idlType">MediaKeyMessageEventInit</a> Members</h2><dl class="dictionary-members" data-dfn-for="MediaKeyMessageEventInit" data-link-for="MediaKeyMessageEventInit"><dt><dfn><code>messageType</code></dfn> of type <span class="idlMemberType"><a>MediaKeyMessageType</a></span></dt><dd>
               The type of the message.
             </dd><dt><dfn><code>message</code></dfn> of type <span class="idlMemberType">{{ArrayBuffer}}</span></dt><dd>
               The message.
-            </dd></dl></section></div>
+            </dd></dl></section>
         </section>
       </section>
 
@@ -2867,7 +2863,7 @@ interface MediaKeyMessageEvent : Event {
       <p>For methods that return a promise, all errors are reported asynchronously by rejecting the returned Promise. This includes [[WEBIDL]] type mapping errors.</p>
       <p>The steps of an algorithm are always aborted when rejecting a promise.</p>
 
-      <div><pre class="idl">[Exposed=Window] partial interface HTMLMediaElement {
+      <pre class="idl">[Exposed=Window] partial interface HTMLMediaElement {
     [SecureContext] readonly        attribute MediaKeys?   mediaKeys;
                                     attribute EventHandler onencrypted;
                                     attribute EventHandler onwaitingforkey;
@@ -2938,14 +2934,14 @@ interface MediaKeyMessageEvent : Event {
           </ol>
         <table class="parameters"><tbody><tr><th>Parameter</th><th>Type</th><th>Nullable</th><th>Optional</th><th>Description</th></tr><tr><td class="prmName">mediaKeys</td><td class="prmType"><code>MediaKeys</code></td><td class="prmNullTrue"><span role="img" aria-label="True">✔</span></td><td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td><td class="prmDesc">
               A <!-- Restore when https://github.com/w3c/respec/issues/893 is fixed. <a> -->MediaKeys<!-- </a> --> object.
-            </td></tr></tbody></table><div><em>Return type: </em><code>Promise&lt;undefined&gt;</code></div></dd></dl></secion></div>
+            </td></tr></tbody></table><div><em>Return type: </em><code>Promise&lt;undefined&gt;</code></div></dd></dl></section>
 
       <section>
         <h3><a>MediaEncryptedEvent</a></h3>
         <p>The MediaEncryptedEvent object is used for the <a def-id="encrypted"></a> event.</p>
         <p>Events are constructed as defined in <a def-id="constructing-events"></a> [[DOM]].</p>
 
-        <div><pre class="idl">[Exposed=Window]
+        <pre class="idl">[Exposed=Window]
 interface MediaEncryptedEvent : Event {
     constructor(DOMString type, optional MediaEncryptedEventInit eventInitDict = {});
     readonly        attribute DOMString    initDataType;
@@ -2956,18 +2952,18 @@ interface MediaEncryptedEvent : Event {
             Indicates the <a def-id="initialization-data-type"></a> of the <a def-id="initialization-data"></a> contained in the <a def-id="encrypted-event-initdata-attribute"></a> attribute.
           </dd><dt><dfn><code>initData</code></dfn> of type <span class="idlAttrType">{{ArrayBuffer}}</span>, readonly       , nullable</dt><dd>
             The <a def-id="initialization-data"></a> for the event.
-          </dd></dl></section></div>
+          </dd></dl></section>
 
         <section>
           <h4><dfn>MediaEncryptedEventInit</dfn></h4>
-          <div><pre class="idl" data-cite="DOM">dictionary MediaEncryptedEventInit : EventInit {
+          <pre class="idl" data-cite="DOM">dictionary MediaEncryptedEventInit : EventInit {
              DOMString    initDataType = "";
              ArrayBuffer? initData = null;
 };</pre><section><h2>Dictionary <a class="idlType">MediaEncryptedEventInit</a> Members</h2><dl class="dictionary-members" data-dfn-for="MediaEncryptedEventInit" data-link-for="MediaEncryptedEventInit"><dt><dfn><code>initDataType</code></dfn> of type <span class="idlMemberType">{{DOMString}}</span>, defaulting to <code>""</code></dt><dd>
               The <a def-id="initialization-data-type"></a>.
             </dd><dt><dfn><code>initData</code></dfn> of type <span class="idlMemberType">{{ArrayBuffer}}</span>, nullable, defaulting to <code>null</code></dt><dd>
               The <a def-id="initialization-data"></a>.
-            </dd></dl></section></div>
+            </dd></dl></section>
         </section>
       </section>
 


### PR DESCRIPTION
The use of `<div>` around sections that define IDL seems to confuse ReSpec as it takes out the headings included in that section from the table of contents.

If that's intended, the right way to exclude headings from the table of contents would be to flag the headings with a `notoc` class: https://respec.org/docs/#notoc-class

The `<div>` seem useless in any case. This update gets rid of them.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/pull/517.html" title="Last updated on Nov 15, 2023, 9:40 AM UTC (162030b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/517/0b2d5e3...162030b.html" title="Last updated on Nov 15, 2023, 9:40 AM UTC (162030b)">Diff</a>