### PR TITLE
Replace "Optionally-blockable Content" with "Upgradeable Content"

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -3047,7 +3047,7 @@ interface MediaEncryptedEvent : Event {
                 <li><p>Let <var>initDataType</var> be the string representing the <a def-id="initialization-data-type"></a> of the Initialization Data.</p></li>
                 <li><p>Let <var>initData</var> be the Initialization Data.</p></li>
               </ol>
-              <p class="note">While the media element may allow loading of "Optionally-blockable Content" [[MIXED-CONTENT]], the user agent MUST NOT expose Initialization Data from such media data to the application.</p>
+              <p class="note">While the media element may allow loading of "Upgradeable Content" [[MIXED-CONTENT]], the user agent MUST NOT expose Initialization Data from such media data to the application.</p>
             </li>
             <li>
               <p><a def-id="Queue-a-task"></a> to create an event named <a def-id="encrypted"></a> that does not bubble and is not cancellable using the <a>MediaEncryptedEvent</a> interface with its <var>type</var> attribute set to <code>encrypted</code> and its <var>isTrusted</var> attribute initialized to <code>true</code>, and dispatch it at the <var>media element</var>.</p>


### PR DESCRIPTION
"Optionally-blockable Content" is now "Upgradeable Content" in https://www.w3.org/TR/mixed-content/.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/pull/518.html" title="Last updated on Dec 12, 2023, 2:41 PM UTC (2b1a79f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/518/0b2d5e3...2b1a79f.html" title="Last updated on Dec 12, 2023, 2:41 PM UTC (2b1a79f)">Diff</a>