### PR TITLE
Update registries to use W3C Registry Track

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -291,7 +291,7 @@
 
         <dt id="decryption-key-id">Key ID</dt>
         <dd>
-          <p>A <a href="#decryption-key">key</a> is associated with a key ID that is a sequence of octets and which uniquely identifies the key.
+          <p>A <a href="#decryption-key">key</a> is associated with a <dfn class="export" data-lt="Decryption key ID">key ID</dfn> that is a sequence of octets and which uniquely identifies the key.
           The container specifies the ID of the key that can decrypt a block or set of blocks within the <a def-id="media-data"></a>.
           <a def-id="initialization-data"></a> MAY contain key ID(s) to identify the keys that are needed to decrypt the media data.
           However, there is no requirement that Initialization Data contain any or all key IDs used in the <a def-id="media-data"></a> or <a def-id="media-resource"></a>.
@@ -3029,7 +3029,7 @@ interface MediaEncryptedEvent : Event {
         <section id="initdata-encountered">
           <h4>Initialization Data Encountered</h4>
           <p>
-            The Initialization Data Encountered algorithm queues an <a def-id="encrypted"></a> event for <a def-id="initialization-data"></a> encounterd in the <a def-id="media-data"></a>.
+            The <dfn class="export">Initialization Data Encountered</dfn> algorithm queues an <a def-id="encrypted"></a> event for <a def-id="initialization-data"></a> encounterd in the <a def-id="media-data"></a>.
             Requests to run this algorithm include a target <a def-id="htmlmediaelement"></a> object.
           </p>
           <p>The following steps are run:</p>
@@ -3063,7 +3063,7 @@ interface MediaEncryptedEvent : Event {
         <section id="encrypted-block-encountered">
           <h4>Encrypted Block Encountered</h4>
           <p>
-            The Encrypted Block Encountered algorithm queues a block of encrypted media data for decryption and attempts to decrypt if possible.
+            The <dfn class="export" id="encrypted-block-encountered">Encrypted Block Encountered</dfn> algorithm queues a block of encrypted media data for decryption and attempts to decrypt if possible.
             Requests to run this algorithm include a target <a def-id="htmlmediaelement"></a> object.
           </p>
           <p>The following steps are run:</p>

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -289,9 +289,9 @@
           <p class="note">For example, a key is not usable for decryption if its license has expired.  Even if its license has not expired, a key is not usable for decryption if other conditions (e.g., output protection) for its use are not currently satisfied.</p>
         </dd>
 
-        <dt id="decryption-key-id">Key ID</dt>
+        <dt id="decryption-key-id"><dfn class="export" data-lt="Decryption key ID">Key ID</dfn></dt>
         <dd>
-          <p>A <a href="#decryption-key">key</a> is associated with a <dfn class="export" data-lt="Decryption key ID">key ID</dfn> that is a sequence of octets and which uniquely identifies the key.
+          <p>A <a href="#decryption-key">key</a> is associated with a key ID that is a sequence of octets and which uniquely identifies the key.
           The container specifies the ID of the key that can decrypt a block or set of blocks within the <a def-id="media-data"></a>.
           <a def-id="initialization-data"></a> MAY contain key ID(s) to identify the keys that are needed to decrypt the media data.
           However, there is no requirement that Initialization Data contain any or all key IDs used in the <a def-id="media-data"></a> or <a def-id="media-resource"></a>.
@@ -3027,9 +3027,9 @@ interface MediaEncryptedEvent : Event {
         </section>
 
         <section id="initdata-encountered">
-          <h4>Initialization Data Encountered</h4>
+          <h4><dfn class="export">Initialization Data Encountered</dfn></h4>
           <p>
-            The <dfn class="export">Initialization Data Encountered</dfn> algorithm queues an <a def-id="encrypted"></a> event for <a def-id="initialization-data"></a> encounterd in the <a def-id="media-data"></a>.
+            The Initialization Data Encountered algorithm queues an <a def-id="encrypted"></a> event for <a def-id="initialization-data"></a> encounterd in the <a def-id="media-data"></a>.
             Requests to run this algorithm include a target <a def-id="htmlmediaelement"></a> object.
           </p>
           <p>The following steps are run:</p>
@@ -3061,9 +3061,9 @@ interface MediaEncryptedEvent : Event {
         </section>
 
         <section id="encrypted-block-encountered">
-          <h4>Encrypted Block Encountered</h4>
+          <h4><dfn class="export">Encrypted Block Encountered</dfn></h4>
           <p>
-            The <dfn class="export" id="encrypted-block-encountered">Encrypted Block Encountered</dfn> algorithm queues a block of encrypted media data for decryption and attempts to decrypt if possible.
+            The Encrypted Block Encountered algorithm queues a block of encrypted media data for decryption and attempts to decrypt if possible.
             Requests to run this algorithm include a target <a def-id="htmlmediaelement"></a> object.
           </p>
           <p>The following steps are run:</p>

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -332,7 +332,7 @@
 
           <p>
           The format of the initialization data depends upon the type of container, and containers MAY support more than one format
-          of initialization data. The <dfn id="initialization-data-type">Initialization Data Type</dfn> is a string that indicates the
+          of initialization data. The <dfn class="export" id="initialization-data-type">Initialization Data Type</dfn> is a string that indicates the
           format of the accompanying Initialization Data. Initialization Data Type strings are always matched case-sensitively. It is
           RECOMMENDED that Initialization Data Type strings are lower-case ASCII strings.
           </p>

--- a/format-registry/initdata/cenc-respec.html
+++ b/format-registry/initdata/cenc-respec.html
@@ -3,8 +3,7 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>"cenc" Initialization Data Format</title>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
-    <script src="../../encrypted-media.js" class="remove"></script>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <script class="remove">
     var respecConfig = {
       // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
@@ -16,11 +15,6 @@
       // if there a publicly available Editor's Draft, this is the link
       edDraftURI: "https://w3c.github.io/encrypted-media/format-registry/initdata/cenc.html",
 
-      // if this is a LCWD, uncomment and set the end of its review period
-      // lcEnd: "2009-08-05",
-
-      // editors, add as many as you like
-      // only "name" is required
       editors: [
         { name: "Joey Parrish", w3cid: "105371",
           company: "Google Inc.", companyURL: "https://www.google.com/" },
@@ -39,21 +33,8 @@
           company: "Microsoft Corporation", companyURL: "https://www.microsoft.com/" },
       ],
 
-      otherLinks: [
-        { key: "Repository", href: "https://github.com/w3c/encrypted-media/" },
-      ],
-
-      emeDefGroupName: "cenc-format",
-      emeUnusedGroupNameExcludeList: [
-        "encrypted-media",
-        "eme-references-from-registry",
-      ],
-
-      // name of the WG
-      wg: "Media Working Group",
-
-      // URI of the public WG page
-      wgURI: "https://www.w3.org/media-wg/",
+      group: "media",
+      github: "w3c/encrypted-media",
 
       // name (without the @w3c.org) of the public mailing to which comments are due
       wgPublicList: "public-media-wg",
@@ -65,22 +46,6 @@
       // Team Contact.
       wgPatentURI: "https://www.w3.org/2004/01/pp-impl/115198/status",
 
-      noIDLIn: true,
-
-      scheme: "https",
-
-      // Empty definitions for objects declared in the document are here to
-      // prevent error messages from being displayed for references to these objects.
-      definitionMap: {},
-
-      preProcess: [ encryptedMediaPreProcessor ],
-
-      // Empty definitions for objects declared in the document are here to
-      // prevent error messages from being displayed for references to these objects.
-      definitionMap: {},
-
-      postProcess: [ encryptedMediaPostProcessor ],
-
       localBiblio: {
         "CENC": {
           title: "ISO/IEC 23001-7:2016, Information technology — MPEG systems technologies — Part 7: Common encryption in ISO base media file format files",
@@ -89,6 +54,8 @@
           publisher: "ISO/IEC",
         },
       },
+
+      xref: ["encrypted-media"]
     };
     </script>
     <!-- script to register bugs -->
@@ -102,13 +69,14 @@
   <body>
     <!-- TODO: Use styles for ISO boxes like the MSE registry. -->
     <section id="abstract">
-      <p>This specification defines the <code>"cenc"</code> <a def-id="initialization-data"></a> format for use with the <a def-id="eme-spec"></a> [[!ENCRYPTED-MEDIA]].
-        This format is commonly used with the <a def-id="stream-registry-mp4"></a> [[EME-STREAM-REGISTRY]].
+      <p>This specification defines the <code>"cenc"</code> [=initialization data=] format for use with the [[[ENCRYPTED-MEDIA]]] [[ENCRYPTED-MEDIA]].
+        This format is commonly used with the [[[EME-STREAM-MP4]]] [[EME-STREAM-REGISTRY]].
       </p>
       <p>This specification also defines a common SystemID and PSSH box format for use with Encrypted Media Extensions.</p>
-      <p class="note">This format's <a def-id="initialization-data-type"></a> string <code>"cenc"</code> refers to the [[CENC]] spec that defines the PSSH boxes that comprise the format.
+      <p class="note">This format's [=initialization data type=] string <code>"cenc"</code> refers to the [[CENC]] spec that defines the PSSH boxes that comprise the format.
         It does not relate to or imply a stream format, including the use of the 'cenc' protection scheme.
-        Stream formats are indicated by the content types as defined in <a def-id="stream-registry"></a> [[EME-STREAM-REGISTRY]].
+        Stream formats are indicated by the content types as defined in the [[[EME-STREAM-REGISTRY]]] [[EME-STREAM-REGISTRY]].
+      </p>
     </section>
 
     <section id="sotd">
@@ -116,11 +84,11 @@
 
     <section id="format">
       <h2>Format</h2>
-      <p>The format is one or more concatenated Protection System Specific Header ('pssh') boxes [[!CENC]], each for a unique SystemID.
+      <p>The format is one or more concatenated Protection System Specific Header ('pssh') boxes [[CENC]], each for a unique SystemID.
         One of the concatenated 'pssh' boxes SHOULD use the <a href="#common-system">Common SystemID and PSSH Box Format</a>.
       </p>
 
-      <p class="note">[[!CENC]] also specifies storage of a 'pssh' box base64-encoded in an XML element of the form <code>&lt;cenc:pssh (base64 'pssh')&gt;</code>.
+      <p class="note">[[CENC]] also specifies storage of a 'pssh' box base64-encoded in an XML element of the form <code>&lt;cenc:pssh (base64 'pssh')&gt;</code>.
         For example, [[MPEGDASH]] manifests may provide 'pssh' boxes in this format, each contained in a ContentProtection Descriptor element identified by a SystemID.
         These 'pssh' boxes may be decoded and concatenated by an application to provide equivalent Initialization Data to that stored in movie or movie fragment boxes.
       </p>
@@ -128,7 +96,7 @@
 
     <section id="processing">
       <h2>Processing</h2>
-      <p>When such Initialization Data is provided by the application, an implementation (the user agent and/or CDM) MUST :</p>
+      <p>When such Initialization Data is provided by the application, an implementation (the user agent and/or CDM) MUST:</p>
       <ol>
         <li><p>Examine the series of 'pssh' boxes to find the <em>first</em> 'pssh' box that the CDM instance supports. This includes checking the SystemID, box version, and system-specific values.</p></li>
         <li><p>If no such supported box is found, the provided data SHALL be considered "not supported by the CDM."</p></li>
@@ -137,7 +105,7 @@
 
     <section id="clear-key">
       <h3>Use with Clear Key</h3>
-      <p>When Initialization data is provided with <var>initDataType</var> <code>"cenc"</code>, <a def-id="clear-key"></a> implementations MUST look for and use the PSSH box with the <a href="#common-system">Common SystemID</a>.</p>
+      <p>When Initialization data is provided with <var>initDataType</var> <code>"cenc"</code>, <a data-cite="encrypted-media#clear-key">Clear Key</a> implementations MUST look for and use the PSSH box with the <a href="#common-system">Common SystemID</a>.</p>
     </section>
 
     <section id="common-system">
@@ -149,19 +117,19 @@
         Use of this SystemID is RECOMMENDED for applications, packagers, and implementors.
         Use of other SystemIDs with the Encrypted Media Extensions APIs is discouraged.
         'pssh' box(es) for this SystemID SHOULD be included in all new or repackaged content so that the content can be used with any compliant Key System.
-        For existing content, applications may alternatively obtain a 'pssh' box containing this SystemID or another Initialization Data Type (e.g., <a def-id="initdata-registry-keyids"></a>  [[EME-STREAM-REGISTRY]]) from another source.
+        For existing content, applications may alternatively obtain a 'pssh' box containing this SystemID or another Initialization Data Type (e.g., [[[EME-INITDATA-KEYIDS]]] [[EME-STREAM-REGISTRY]]) from another source.
       </p>
       <p class="note">Implementations MAY support other SystemIDs for backwards compatibility with existing streams.</p>
 
       <section id="common-system-definition">
         <h3>Definition</h3>
         <p>The SystemID is <code>1077efec-c0b2-4d02-ace3-3c1e52e2fb4b</code>.</p>
-        <p>The PSSH box format is as follows. It follows version 1 of the 'pssh' box as defined in [[!CENC]].</p>
+        <p>The PSSH box format is as follows. It follows version 1 of the 'pssh' box as defined in [[CENC]].</p>
         <dl>
           <dt>version</dt>
           <dd><code>1</code></dd>
           <dt>KID and KID_count</dt>
-          <dd>The <a def-id="key-id"></a>(s) represented by the PSSH box. For example, those key ID(s) used by the Movie ('moov') or Movie Fragment ('moof').</dd>
+          <dd>The [=Decryption key ID|key ID=](s) represented by the PSSH box. For example, those key ID(s) used by the Movie ('moov') or Movie Fragment ('moof').</dd>
           <dt>Data and DataSize</dt>
           <dd>Reserved for future use. DataSize SHALL be set to <code>0</code> when constructing this box. When processing, if dataSize is non-zero the Data field SHALL be ignored.</dd>
         </dl>
@@ -184,6 +152,9 @@ var pssh = [
 ];
 </pre>
       </section>
+    </section>
 
+    <section id="conformance">
+    </section>
   </body>
 </html>

--- a/format-registry/initdata/index-respec.html
+++ b/format-registry/initdata/index-respec.html
@@ -7,7 +7,7 @@
     <script class="remove">
     var respecConfig = {
       // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
-      specStatus: "DRY",
+      specStatus: "ED",
 
       // the specification's short name, as in https://www.w3.org/TR/short-name/
       shortName: "eme-initdata-registry",
@@ -99,7 +99,7 @@
         <li><p>Each entry must include a unique [=initialization data type=] string.</p></li>
         <li>
           <p>Each entry must include a link that references a publicly available specification.
-            It is RECOMMENDED that such a specification be made available without cost (other than reasonable shipping and handling if not available by online means).
+            It is recommended that such a specification be made available without cost (other than reasonable shipping and handling if not available by online means).
           </p>
         </li>
         <li>
@@ -109,7 +109,7 @@
             the registry.
           </p>
         </li>
-        <li><p>Per the [[[ENCRYPTED-MEDIA]]] specification, entries MUST be fully specified and support common formats such that instances of the format can be processed in a fully specified and compatible way.</p></li>
+        <li><p>Per the [[[ENCRYPTED-MEDIA]]] specification, entries must be fully specified and support common formats such that instances of the format can be processed in a fully specified and compatible way.</p></li>
         <li>
           <p>Existing entries cannot be deleted or deprecated.</p>
         </li>

--- a/format-registry/initdata/index-respec.html
+++ b/format-registry/initdata/index-respec.html
@@ -3,12 +3,11 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>Encrypted Media Extensions Initialization Data Format Registry</title>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
-    <script src="../../encrypted-media.js" class="remove"></script>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <script class="remove">
     var respecConfig = {
       // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
-      specStatus: "ED",
+      specStatus: "DRY",
 
       // the specification's short name, as in https://www.w3.org/TR/short-name/
       shortName: "eme-initdata-registry",
@@ -16,11 +15,6 @@
       // if there a publicly available Editor's Draft, this is the link
       edDraftURI: "https://w3c.github.io/encrypted-media/format-registry/initdata/",
 
-      // if this is a LCWD, uncomment and set the end of its review period
-      // lcEnd: "2009-08-05",
-
-      // editors, add as many as you like
-      // only "name" is required
       editors: [
         { name: "Joey Parrish", w3cid: "105371",
           company: "Google Inc.", companyURL: "https://www.google.com/" },
@@ -39,21 +33,8 @@
           company: "Microsoft Corporation", companyURL: "https://www.microsoft.com/" },
       ],
 
-      otherLinks: [
-        { key: "Repository", href: "https://github.com/w3c/encrypted-media/" },
-      ],
-
-      emeDefGroupName: "format-registry",
-      emeUnusedGroupNameExcludeList: [
-        "encrypted-media",
-        "eme-references-from-registry",
-      ],
-
-      // name of the WG
-      wg: "Media Working Group",
-
-      // URI of the public WG page
-      wgURI: "https://www.w3.org/media-wg/",
+      group: "media",
+      github: "w3c/encrypted-media",
 
       // name (without the @w3c.org) of the public mailing to which comments are due
       wgPublicList: "public-media-wg",
@@ -64,22 +45,6 @@
       // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
       // Team Contact.
       wgPatentURI: "https://www.w3.org/2004/01/pp-impl/115198/status",
-
-      noIDLIn: true,
-
-      scheme: "https",
-
-      // Empty definitions for objects declared in the document are here to
-      // prevent error messages from being displayed for references to these objects.
-      definitionMap: {},
-
-      preProcess: [ encryptedMediaPreProcessor ],
-
-      // Empty definitions for objects declared in the document are here to
-      // prevent error messages from being displayed for references to these objects.
-      definitionMap: {},
-
-      postProcess: [ encryptedMediaPostProcessor ],
     };
     </script>
     <!-- script to register bugs -->
@@ -97,14 +62,15 @@
       #registry table td, table th { border-left: solid; border-right: solid; border-bottom: solid thin; vertical-align: top; padding: 0.2em; }
     </style>
   </head>
-  <body>
+  <body data-cite="html encrypted-media">
 
     <section id="abstract">
-      <p>This specification defines the <a def-id="initialization-data"></a> formats for use with the <a def-id="eme-spec"></a> [[!ENCRYPTED-MEDIA]].</p>
+      <p>This specification defines the [=initialization data=] formats for use with the [[[ENCRYPTED-MEDIA]]] [[ENCRYPTED-MEDIA]].</p>
 
-      <p>Some formats may be extracted from <a def-id="media-data"></a> [[HTML5]] as defined in the <a def-id="stream-registry"></a> [[EME-STREAM-REGISTRY]].
+      <p>Some formats may be extracted from [=HTMLMediaElement/media data=] as defined in the [[[EME-STREAM-REGISTRY]]] [[EME-STREAM-REGISTRY]].
         All may be provided separately, such as via a manifest or other application data.
       </p>
+      <p>This registry is non-normative.</p>
     </section>
 
     <section id="sotd">
@@ -113,15 +79,15 @@
     <section id="purpose">
       <h2>Purpose</h2>
       <p>This registry is intended to enhance interoperability among implementations and users of encrypted media streams with the
-        <a def-id="eme-spec"></a> (EME) specification [[!ENCRYPTED-MEDIA]]. In particular, this registry provides the means (1) to identify
+        [[[ENCRYPTED-MEDIA]]] (EME) specification [[ENCRYPTED-MEDIA]]. In particular, this registry provides the means (1) to identify
         and avoid collisions among initialization data type strings, and (2) to disclose information about initialization data formats accepted by EME
         implementations to promote interoperability.
     </section>
 
     <section id="organization">
       <h2>Organization</h2>
-      <p>The registry maintains a mapping between <a def-id="initialization-data-type"></a> strings and format specifications, which describe the structure and semantics of initialization data.
-        The strings are those used for <code>initDataType</code> values provided by and to <a def-id="eme-spec"></a> [[!ENCRYPTED-MEDIA]] APIs.
+      <p>The registry maintains a mapping between [=initialization data type=] strings and format specifications, which describe the structure and semantics of initialization data.
+        The strings are those used for <code>initDataType</code> values provided by and to [[[ENCRYPTED-MEDIA]]] [[ENCRYPTED-MEDIA]] APIs.
       </p>
       <p>This registry is not intended to include any information on whether a format is encumbered by intellectual property claims. Implementors and users
         are advised to seek appropriate legal counsel in this matter if they intend to implement or use a specific format.</p>
@@ -130,18 +96,23 @@
     <section id="entry-requirements">
       <h2>Registration Entry Requirements</h2>
       <ol>
-        <li><p>Each entry must include a unique <a def-id="initialization-data-type"></a> string.</p></li>
+        <li><p>Each entry must include a unique [=initialization data type=] string.</p></li>
         <li>
           <p>Each entry must include a link that references a publicly available specification.
             It is RECOMMENDED that such a specification be made available without cost (other than reasonable shipping and handling if not available by online means).
           </p>
         </li>
         <li>
-          <p>Candidate entries must be announced on <a href="mailto:public-media-wg@w3.org">public-media-wg@w3.org</a>(<a href="mailto:public-media-wg-request@w3.org">subscribe</a>,
-            <a href="https://lists.w3.org/Archives/Public/public-media-wg/">archives</a>) so they can be discussed and evaluated for compliance before being added to the registry.
+          <p>Candidate entries must be announced by filing an issue in the
+            <a href="https://github.com/w3c/encrypted-media/issues/">Encrypted Media Extensions GitHub issue tracker</a>
+            so they can be discussed and evaluated for compliance before being added to
+            the registry.
           </p>
         </li>
-        <li><p>Per the <a def-id="eme-spec"></a> specification, entries MUST be fully specified and support common formats such that instances of the format can be processed in a fully specified and compatible way.</p></li>
+        <li><p>Per the [[[ENCRYPTED-MEDIA]]] specification, entries MUST be fully specified and support common formats such that instances of the format can be processed in a fully specified and compatible way.</p></li>
+        <li>
+          <p>Existing entries cannot be deleted or deprecated.</p>
+        </li>
       </ol>
     </section>
 
@@ -159,19 +130,19 @@
             <td>
               cenc
             </td>
-            <td><a def-id='initdata-registry-cenc'></a> [[!EME-INITDATA-CENC]]</td>
+            <td>[[[EME-INITDATA-CENC]]] [[EME-INITDATA-CENC]]</td>
           </tr>
           <tr>
             <td>
               keyids
             </td>
-            <td><a def-id="initdata-registry-keyids"></a> [[!EME-INITDATA-KEYIDS]]</td>
+            <td>[[[EME-INITDATA-KEYIDS]]] [[EME-INITDATA-KEYIDS]]</td>
           </tr>
           <tr>
             <td>
               webm
             </td>
-            <td><a def-id="initdata-registry-webm"></a> [[!EME-INITDATA-WEBM]]</td>
+            <td>[[[EME-INITDATA-WEBM]]] [[EME-INITDATA-WEBM]]</td>
           </tr>
         </tbody>
       </table>

--- a/format-registry/initdata/index-respec.html
+++ b/format-registry/initdata/index-respec.html
@@ -45,6 +45,8 @@
       // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
       // Team Contact.
       wgPatentURI: "https://www.w3.org/2004/01/pp-impl/115198/status",
+
+      xref: ["html", "encrypted-media"]
     };
     </script>
     <!-- script to register bugs -->
@@ -62,7 +64,7 @@
       #registry table td, table th { border-left: solid; border-right: solid; border-bottom: solid thin; vertical-align: top; padding: 0.2em; }
     </style>
   </head>
-  <body data-cite="html encrypted-media">
+  <body>
 
     <section id="abstract">
       <p>This specification defines the [=initialization data=] formats for use with the [[[ENCRYPTED-MEDIA]]] [[ENCRYPTED-MEDIA]].</p>

--- a/format-registry/initdata/keyids-respec.html
+++ b/format-registry/initdata/keyids-respec.html
@@ -3,8 +3,7 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>"keyids" Initialization Data Format</title>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
-    <script src="../../encrypted-media.js" class="remove"></script>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <script class="remove">
     var respecConfig = {
       // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
@@ -16,11 +15,6 @@
       // if there a publicly available Editor's Draft, this is the link
       edDraftURI: "https://w3c.github.io/encrypted-media/format-registry/initdata/keyids.html",
 
-      // if this is a LCWD, uncomment and set the end of its review period
-      // lcEnd: "2009-08-05",
-
-      // editors, add as many as you like
-      // only "name" is required
       editors: [
         { name: "Joey Parrish", w3cid: "105371",
           company: "Google Inc.", companyURL: "https://www.google.com/" },
@@ -39,21 +33,8 @@
           company: "Microsoft Corporation", companyURL: "https://www.microsoft.com/" },
       ],
 
-      otherLinks: [
-        { key: "Repository", href: "https://github.com/w3c/encrypted-media/" },
-      ],
-
-      emeDefGroupName: "keyids-format",
-      emeUnusedGroupNameExcludeList: [
-        "encrypted-media",
-        "eme-references-from-registry",
-      ],
-
-      // name of the WG
-      wg: "Media Working Group",
-
-      // URI of the public WG page
-      wgURI: "https://www.w3.org/media-wg/",
+      group: "media",
+      github: "w3c/encrypted-media",
 
       // name (without the @w3c.org) of the public mailing to which comments are due
       wgPublicList: "public-media-wg",
@@ -65,17 +46,7 @@
       // Team Contact.
       wgPatentURI: "https://www.w3.org/2004/01/pp-impl/115198/status",
 
-      noIDLIn: true,
-
-      scheme: "https",
-
-      preProcess: [ encryptedMediaPreProcessor ],
-
-      // Empty definitions for objects declared in the document are here to
-      // prevent error messages from being displayed for references to these objects.
-      definitionMap: {},
-
-      postProcess: [ encryptedMediaPostProcessor ],
+      xref: ["encoding", "encrypted-media"]
     };
     </script>
     <!-- script to register bugs -->
@@ -88,8 +59,8 @@
   </head>
   <body>
     <section id="abstract">
-      <p>This specification defines the <code>"keyids"</code> <a def-id="initialization-data"></a> format for use with the <a def-id="eme-spec"></a> [[!ENCRYPTED-MEDIA]].</p>
-      <p class="note">It defines a stream format-independent format for specifying a list of <a def-id="key-id"></a>(s).
+      <p>This specification defines the <code>"keyids"</code> [=initialization data=] format for use with the [[[ENCRYPTED-MEDIA]]] [[ENCRYPTED-MEDIA]].</p>
+      <p class="note">It defines a stream format-independent format for specifying a list of [=Decryption key ID|key ID=](s).
       This type can be used by applications to directly provide information necessary to generate a license request without using media data or constructing container-specific formats.
       </p>
     </section>
@@ -99,28 +70,30 @@
 
     <section id="format">
       <h2>Format</h2>
-      <p>The format is a JSON object, encoded in UTF-8 as specified in the Encoding specification [[!encoding]], containing the following member:</p>
+      <p>The format is a JSON object, encoded in UTF-8 as specified in the Encoding specification [[encoding]], containing the following member:</p>
       <dl>
         <dt>"kids"</dt>
-        <dd>An array of <a def-id="key-id"></a>(s). Each element of the array is the base64url encoding of the octet sequence containing the key ID value.</dd>
+        <dd>An array of [=Decryption key ID|key ID=](s). Each element of the array is the base64url encoding of the octet sequence containing the key ID value.</dd>
       </dl>
 
-      <p class="note">See <a def-id="using-base64url"></a>.</p>
-      <p class="note">Applications may encode the JSON string using the <a def-id="interface-textencoder"></a> [[encoding]]</p>
+      <p class="note">See <a data-cite="eme-initdata-cenc#using-base64url">Using base64url</a>.</p>
+      <p class="note">Applications may encode the JSON string using the {{TextEncoder}} interface [[encoding]].</p>
     </section>
 
     <section class="informative">
       <h2>Example</h2>
-      <p>The following example will generate a license request for two <a def-id="key-id"></a>(s). (Line breaks are for readability only.)</p>
+      <p>The following example will generate a license request for two [=Decryption key ID|key ID=](s). (Line breaks are for readability only.)</p>
         <pre class="example">
 {
   "kids":
     [
      "LwVHf8JLtPrv2GUXFW2v_A",
      "0DdtU9od-Bh5L3xbv0Xf_A"
-    ],
+    ]
 }</pre>
     </section>
 
+    <section id="conformance">
+    </section>
   </body>
 </html>

--- a/format-registry/initdata/webm-respec.html
+++ b/format-registry/initdata/webm-respec.html
@@ -3,8 +3,7 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>"webm" Initialization Data Format</title>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
-    <script src="../../encrypted-media.js" class="remove"></script>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <script class="remove">
     var respecConfig = {
       // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
@@ -16,11 +15,6 @@
       // if there a publicly available Editor's Draft, this is the link
       edDraftURI: "https://w3c.github.io/encrypted-media/format-registry/initdata/webm.html",
 
-      // if this is a LCWD, uncomment and set the end of its review period
-      // lcEnd: "2009-08-05",
-
-      // editors, add as many as you like
-      // only "name" is required
       editors: [
         { name: "Joey Parrish", w3cid: "105371",
           company: "Google Inc.", companyURL: "https://www.google.com/" },
@@ -39,21 +33,8 @@
           company: "Microsoft Corporation", companyURL: "https://www.microsoft.com/" },
       ],
 
-      otherLinks: [
-        { key: "Repository", href: "https://github.com/w3c/encrypted-media/" },
-      ],
-
-      emeDefGroupName: "webm-format",
-      emeUnusedGroupNameExcludeList: [
-        "encrypted-media",
-        "eme-references-from-registry",
-      ],
-
-      // name of the WG
-      wg: "Media Working Group",
-
-      // URI of the public WG page
-      wgURI: "https://www.w3.org/media-wg/",
+      group: "media",
+      github: "w3c/encrypted-media",
 
       // name (without the @w3c.org) of the public mailing to which comments are due
       wgPublicList: "public-media-wg",
@@ -65,22 +46,6 @@
       // Team Contact.
       wgPatentURI: "https://www.w3.org/2004/01/pp-impl/115198/status",
 
-      noIDLIn: true,
-
-      scheme: "https",
-
-      // Empty definitions for objects declared in the document are here to
-      // prevent error messages from being displayed for references to these objects.
-      definitionMap: {},
-
-      preProcess: [ encryptedMediaPreProcessor ],
-
-      // Empty definitions for objects declared in the document are here to
-      // prevent error messages from being displayed for references to these objects.
-      definitionMap: {},
-
-      postProcess: [ encryptedMediaPostProcessor ],
-
       localBiblio: {
         "WebM-Encryption": {
           title: "WebM Encryption",
@@ -90,6 +55,8 @@
           date: "4 March 2015",
         },
       },
+
+      xref: ["encrypted-media"]
     };
     </script>
     <!-- script to register bugs -->
@@ -102,8 +69,8 @@
   </head>
   <body>
     <section id="abstract">
-      <p>This specification defines the <code>"webm"</code> <a def-id="initialization-data"></a> format for use with the <a def-id="eme-spec"></a> [[!ENCRYPTED-MEDIA]].
-        This format is commonly used with the <a def-id="stream-registry-webm"></a> [[EME-STREAM-REGISTRY]].
+      <p>This specification defines the <code>"webm"</code> [=initialization data=] format for use with the [[[ENCRYPTED-MEDIA]]] [[ENCRYPTED-MEDIA]].
+        This format is commonly used with the [[[EME-STREAM-WEBM]]] [[EME-STREAM-REGISTRY]].
       </p>
     </section>
 
@@ -112,7 +79,10 @@
 
     <section id="format">
       <h2>Format</h2>
-      <p>The format is a single <a def-id="key-id"></a> of one or more bytes, as defined by the <a href="https://matroska.org/technical/specs/index.html#ContentEncKeyID">ContentEncKeyID</a> [[!Matroska]] element and [[!WebM-Encryption]].</p>
+      <p>The format is a single [=Decryption key ID|key ID=] of one or more bytes, as defined by the <a href="https://matroska.org/technical/specs/index.html#ContentEncKeyID">ContentEncKeyID</a> [[Matroska]] element and [[WebM-Encryption]].</p>
+    </section>
+
+    <section id="conformance">
     </section>
   </body>
 </html>

--- a/format-registry/stream/index-respec.html
+++ b/format-registry/stream/index-respec.html
@@ -3,12 +3,11 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>Encrypted Media Extensions Stream Format Registry</title>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
-    <script src="../../encrypted-media.js" class="remove"></script>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <script class="remove">
     var respecConfig = {
       // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
-      specStatus: "ED",
+      specStatus: "DRY",
 
       // the specification's short name, as in https://www.w3.org/TR/short-name/
       shortName: "eme-stream-registry",
@@ -16,11 +15,6 @@
       // if there a publicly available Editor's Draft, this is the link
       edDraftURI: "https://w3c.github.io/encrypted-media/format-registry/stream/",
 
-      // if this is a LCWD, uncomment and set the end of its review period
-      // lcEnd: "2009-08-05",
-
-      // editors, add as many as you like
-      // only "name" is required
       editors: [
         { name: "Joey Parrish", w3cid: "105371",
           company: "Google Inc.", companyURL: "https://www.google.com/" },
@@ -39,18 +33,8 @@
           company: "Microsoft Corporation", companyURL: "https://www.microsoft.com/" },
       ],
 
-      otherLinks: [
-        { key: "Repository", href: "https://github.com/w3c/encrypted-media/" },
-      ],
-
-      emeDefGroupName: "format-registry",
-      emeUnusedGroupNameExcludeList: [
-        "encrypted-media",
-        "eme-references-from-registry",
-      ],
-
-      // name of the WG
-      wg: "Media Working Group",
+      group: "media",
+      github: "w3c/encrypted-media",
 
       // URI of the public WG page
       wgURI: "https://www.w3.org/media-wg/",
@@ -64,22 +48,6 @@
       // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
       // Team Contact.
       wgPatentURI: "https://www.w3.org/2004/01/pp-impl/115198/status",
-
-      noIDLIn: true,
-
-      scheme: "https",
-
-      // Empty definitions for objects declared in the document are here to
-      // prevent error messages from being displayed for references to these objects.
-      definitionMap: {},
-
-      preProcess: [ encryptedMediaPreProcessor ],
-
-      // Empty definitions for objects declared in the document are here to
-      // prevent error messages from being displayed for references to these objects.
-      definitionMap: {},
-
-      postProcess: [ encryptedMediaPostProcessor ],
     };
     </script>
     <!-- script to register bugs -->
@@ -97,10 +65,11 @@
       #registry table td, table th { border-left: solid; border-right: solid; border-bottom: solid thin; vertical-align: top; padding: 0.2em; }
     </style>
   </head>
-  <body>
+  <body data-cite="encrypted-media">
 
     <section id="abstract">
-      <p>This specification defines the stream formats for use with the <a def-id="eme-spec"></a> [[!ENCRYPTED-MEDIA]].</p>
+      <p>This specification defines the stream formats for use with the [[[ENCRYPTED-MEDIA]]] [[ENCRYPTED-MEDIA]].</p>
+      <p>This registry is non-normative.</p>
     </section>
 
     <section id="sotd">
@@ -109,7 +78,7 @@
     <section id="purpose">
       <h2>Purpose</h2>
       <p>This registry is intended to enhance interoperability among implementations and users of encrypted media streams with the
-        <a def-id="eme-spec"></a> (EME) specification [[!ENCRYPTED-MEDIA]]. In particular, this registry provides the means (1) to identify
+        [[[ENCRYPTED-MEDIA]]] (EME) specification [[ENCRYPTED-MEDIA]]. In particular, this registry provides the means (1) to identify
         and avoid collisions among content type strings, and (2) to disclose information about encrypted data formats accepted by EME
         implementations to promote interoperability.
     </section>
@@ -117,7 +86,7 @@
     <section id="organization">
       <h2>Organization</h2>
       <p>The registry maintains a mapping between content type strings and encryption format specifications, which describe the structure, semantics, and processing of the formats.
-        The strings are those used for the media type/subtype pairs in <code>contentType</code> values provided to <a def-id="eme-spec"></a> [[!ENCRYPTED-MEDIA]] APIs.
+        The strings are those used for the media type/subtype pairs in <code>contentType</code> values provided to [[[ENCRYPTED-MEDIA]]] [[ENCRYPTED-MEDIA]] APIs.
       </p>
       <p>This registry is not intended to include any information on whether a stream format is encumbered by intellectual property claims. Implementors and users
         are advised to seek appropriate legal counsel in this matter if they intend to implement or use a specific stream format.</p>
@@ -126,19 +95,24 @@
     <section id="entry-requirements">
       <h2>Registration Entry Requirements</h2>
       <ol>
-        <li><p>Each entry must include a unique <a def-id="initialization-data-type"></a> string.</p></li>
+        <li>
+          <p>Each entry must include a unique MIME-type/subtype pair. If the byte stream format is derived-from an existing file format, then it should use the MIME-type/subtype pairs typically used for the file format.</p>
+        </li>
         <li>
           <p>Each entry must include a link that references a publicly available specification.
             It is RECOMMENDED that such a specification be made available without cost (other than reasonable shipping and handling if not available by online means).
           </p>
         </li>
         <li>
-          <p>Candidate entries must be announced on <a href="mailto:public-media-wg@w3.org">public-media-wg@w3.org</a>(<a href="mailto:public-media-wg-request@w3.org">subscribe</a>,
-            <a href="https://lists.w3.org/Archives/Public/public-media-wg/">archives</a>) so they can be discussed and evaluated for compliance before being added to the registry.
+          <p>Candidate entries must be announced by filing an issue in the
+            <a href="https://github.com/w3c/encrypted-media/issues/">Encrypted Media Extensions GitHub issue tracker</a>
+            so they can be discussed and evaluated for compliance before being added to
+            the registry.
           </p>
         </li>
-        <li><p>Per the <a def-id="eme-spec"></a> specification, the media container for a stream format MUST NOT be encrypted.</p></li>
-        <li><p>Per the <a def-id="eme-spec"></a> specification, entries MUST be fully specified and support "common encryption" such that the content can decrypted in a fully specified and compatible way when a key or keys are provided.</p></li>
+        <li><p>Per the [[[ENCRYPTED-MEDIA]]] specification, the media container for a stream format MUST NOT be encrypted.</p></li>
+        <li><p>Per the [[[ENCRYPTED-MEDIA]]] specification, entries MUST be fully specified and support "common encryption" such that the content can decrypted in a fully specified and compatible way when a key or keys are provided.</p></li>
+        <li><p>Existing entries cannot be deleted or deprecated.</p></li>
       </ol>
     </section>
 
@@ -157,14 +131,14 @@
               audio/mp4
               <br/>video/mp4
             </td>
-            <td><a def-id="stream-registry-mp4"></a> [[!EME-STREAM-MP4]]</td>
+            <td>[[[EME-STREAM-MP4]]] [[EME-STREAM-MP4]]</td>
           </tr>
           <tr>
             <td>
               audio/webm
               <br/>video/webm
             </td>
-            <td><a def-id="stream-registry-webm"></a> [[!EME-STREAM-WEBM]]</td>
+            <td>[[[EME-STREAM-WEBM]]] [[EME-STREAM-WEBM]]</td>
           </tr>
         </tbody>
       </table>

--- a/format-registry/stream/index-respec.html
+++ b/format-registry/stream/index-respec.html
@@ -48,6 +48,8 @@
       // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
       // Team Contact.
       wgPatentURI: "https://www.w3.org/2004/01/pp-impl/115198/status",
+
+      xref: ["encrypted-media"]
     };
     </script>
     <!-- script to register bugs -->
@@ -65,7 +67,7 @@
       #registry table td, table th { border-left: solid; border-right: solid; border-bottom: solid thin; vertical-align: top; padding: 0.2em; }
     </style>
   </head>
-  <body data-cite="encrypted-media">
+  <body>
 
     <section id="abstract">
       <p>This specification defines the stream formats for use with the [[[ENCRYPTED-MEDIA]]] [[ENCRYPTED-MEDIA]].</p>

--- a/format-registry/stream/index-respec.html
+++ b/format-registry/stream/index-respec.html
@@ -7,7 +7,7 @@
     <script class="remove">
     var respecConfig = {
       // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
-      specStatus: "DRY",
+      specStatus: "ED",
 
       // the specification's short name, as in https://www.w3.org/TR/short-name/
       shortName: "eme-stream-registry",
@@ -100,7 +100,7 @@
         </li>
         <li>
           <p>Each entry must include a link that references a publicly available specification.
-            It is RECOMMENDED that such a specification be made available without cost (other than reasonable shipping and handling if not available by online means).
+            It is recommended that such a specification be made available without cost (other than reasonable shipping and handling if not available by online means).
           </p>
         </li>
         <li>
@@ -110,8 +110,8 @@
             the registry.
           </p>
         </li>
-        <li><p>Per the [[[ENCRYPTED-MEDIA]]] specification, the media container for a stream format MUST NOT be encrypted.</p></li>
-        <li><p>Per the [[[ENCRYPTED-MEDIA]]] specification, entries MUST be fully specified and support "common encryption" such that the content can decrypted in a fully specified and compatible way when a key or keys are provided.</p></li>
+        <li><p>Per the [[[ENCRYPTED-MEDIA]]] specification, the media container for a stream format must not be encrypted.</p></li>
+        <li><p>Per the [[[ENCRYPTED-MEDIA]]] specification, entries must be fully specified and support "common encryption" such that the content can decrypted in a fully specified and compatible way when a key or keys are provided.</p></li>
         <li><p>Existing entries cannot be deleted or deprecated.</p></li>
       </ol>
     </section>

--- a/format-registry/stream/mp4-respec.html
+++ b/format-registry/stream/mp4-respec.html
@@ -3,7 +3,7 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>ISO Common Encryption Protection Scheme for ISO Base Media File Format Stream Format</title>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <script src="../../encrypted-media.js" class="remove"></script>
     <script class="remove">
     var respecConfig = {
@@ -16,11 +16,6 @@
       // if there a publicly available Editor's Draft, this is the link
       edDraftURI: "https://w3c.github.io/encrypted-media/format-registry/stream/mp4.html",
 
-      // if this is a LCWD, uncomment and set the end of its review period
-      // lcEnd: "2009-08-05",
-
-      // editors, add as many as you like
-      // only "name" is required
       editors: [
         { name: "Joey Parrish", w3cid: "105371",
           company: "Google Inc.", companyURL: "https://www.google.com/" },
@@ -43,17 +38,8 @@
         { key: "Repository", href: "https://github.com/w3c/encrypted-media/" },
       ],
 
-      emeDefGroupName: "mp4-stream-format",
-      emeUnusedGroupNameExcludeList: [
-        "encrypted-media",
-        "eme-references-from-registry",
-      ],
-
-      // name of the WG
-      wg: "Media Working Group",
-
-      // URI of the public WG page
-      wgURI: "https://www.w3.org/media-wg/",
+      group: "media",
+      github: "w3c/encrypted-media",
 
       // name (without the @w3c.org) of the public mailing to which comments are due
       wgPublicList: "public-media-wg",
@@ -65,22 +51,6 @@
       // Team Contact.
       wgPatentURI: "https://www.w3.org/2004/01/pp-impl/115198/status",
 
-      noIDLIn: true,
-
-      scheme: "https",
-
-      // Empty definitions for objects declared in the document are here to
-      // prevent error messages from being displayed for references to these objects.
-      definitionMap: {},
-
-      preProcess: [ encryptedMediaPreProcessor ],
-
-      // Empty definitions for objects declared in the document are here to
-      // prevent error messages from being displayed for references to these objects.
-      definitionMap: {},
-
-      postProcess: [ encryptedMediaPostProcessor ],
-
       localBiblio: {
         "CENC": {
           title: "ISO/IEC 23001-7:2016, Information technology — MPEG systems technologies — Part 7: Common encryption in ISO Base Media File Format files",
@@ -89,6 +59,8 @@
           publisher: "ISO/IEC",
         },
       },
+
+      xref: ["encrypted-media"]
     };
     </script>
     <!-- script to register bugs -->
@@ -104,16 +76,16 @@
     <section id="abstract">
       <p>
         This specification defines the stream format for using ISO Base Media
-        File Format [[!ISOBMFF]] content that uses the ISO Common Encryption
-        protection schemes [[!CENC]] with the <a def-id="eme-spec"></a>
-        [[!ENCRYPTED-MEDIA]].
+        File Format [[ISOBMFF]] content that uses the ISO Common Encryption
+        protection schemes [[CENC]] with the [[[ENCRYPTED-MEDIA]]]
+        [[ENCRYPTED-MEDIA]].
       </p>
       <p class="note">
-        Although the ISO Base Media File Format [[!ISOBMFF]] associated with
+        Although the ISO Base Media File Format [[ISOBMFF]] associated with
         this format's MIME type/subtype strings supports multiple protection
         schemes, when used with Encrypted Media Extensions, these strings refer
         specifically to content encrypted and packaged using the 'cenc' or
-        'cbcs' protection schemes, as defined by section 4.2 of [[!CENC]].
+        'cbcs' protection schemes, as defined by section 4.2 of [[CENC]].
       </p>
     </section>
 
@@ -123,15 +95,15 @@
     <section id="stream-format">
       <h2>Stream Format</h2>
       <p>
-        ISO Base Media File Format [[!ISOBMFF]] content that is encrypted using
-        the ISO Common Encryption protection schemes [[!CENC]] SHALL be
+        ISO Base Media File Format [[ISOBMFF]] content that is encrypted using
+        the ISO Common Encryption protection schemes [[CENC]] SHALL be
         encrypted at the sample level with either the 'cenc' (AES-128 CTR) or
         'cbcs' (AES-128 CBC) encryption schemes, as defined in section 4.2 of
-        [[!CENC]].  These protection methods enabls multiple Key Systems to
+        [[CENC]].  These protection methods enable multiple Key Systems to
         decrypt the same media content.
       </p>
       <p>
-        Each key is identified by a <a def-id="key-id"></a> and each encrypted
+        Each key is identified by a [=Decryption key ID|key ID=] and each encrypted
         sample is associated with the key ID of the key needed to decrypt it.
         This association is signaled either through the specification of a
         default key ID in the track encryption box ('tenc') or by assigning the
@@ -144,26 +116,25 @@
       <h2>Detection</h2>
       <p>
         For a stream determined to be in the ISO Base Media File Format
-        [[!ISOBMFF]], the ISO Common Encryption protection schemes may be
+        [[ISOBMFF]], the ISO Common Encryption protection schemes may be
         detected as follows.
       </p>
       <p>
-        Protection scheme signaling conforms with [[!ISOBMFF]]. When protection
+        Protection scheme signaling conforms with [[ISOBMFF]]. When protection
         has been applied, the stream type will be transformed to 'encv' for
         video or 'enca' for audio, with a Protection Scheme Information Box
         ('sinf') added to the sample entry in the Sample Description Box
         ('stsd'). The Protection Scheme Information Box ('sinf') will contain a
         Scheme Type Box ('schm') with a scheme_type field set to a value of
-        <code>'cenc'</code> or <code>'cbcs'</code>. [[!CENC]]
+        <code>'cenc'</code> or <code>'cbcs'</code> [[CENC]].
       </p>
     </section>
 
     <section id="detect-encrypted-blocks">
       <h2>Detecting Encrypted Blocks</h2>
       <p>
-        For the purposes of the <a
-        def-id="encrypted-block-encountered-algorithm"></a>, encrypted blocks
-        are identified as follows.
+        For the purposes of the [=Encrypted Block Encountered=] algorithm,
+        encrypted blocks are identified as follows.
       </p>
       <p>
         The encrypted block is a sample. Determining whether a sample is
@@ -180,31 +151,35 @@
         referenced by SampleAuxiliaryInformationSizesBox ('saiz') and
         SampleAuxiliaryInformationOffsetsBox ('saio') boxes.
       </p>
-      <p>For complete information, see [[!CENC]].</p>
+      <p>For complete information, see [[CENC]].</p>
     </section>
 
     <section id="init-data">
       <h2>Initialization Data Extraction</h2>
       <p>
         Streams may contain one or more Protection System Specific Header
-        ('pssh') boxes [[!CENC]], each for a unique SystemID, at each location
+        ('pssh') boxes [[CENC]], each for a unique SystemID, at each location
         where a 'pssh' box is necessary.  Content using this stream format
-        SHOULD include a box containing the <a def-id="cenc-common-system"></a>.
+        SHOULD include a box containing the
+        <a data-cite="eme-initdata-cenc#common-system">Common SystemID and PSSH Box Format</a>.
       </p>
       <p>
-        <a def-id="initialization-data"></a> is always one or more concatenated
-        'pssh' boxes as defined by the <a def-id="initdata-registry-cenc"></a>
-        [[!EME-INITDATA-REGISTRY]].
+        [=Initialization data=] is always one or more concatenated
+        'pssh' boxes as defined by the [[[EME-INITDATA-CENC]]]
+        [[EME-INITDATA-REGISTRY]].
       </p>
       <p>
-        Each time one or more 'pssh' boxes are encountered, the <a
-        def-id="initdata-encountered-algorithm"></a> algorithm SHALL be invoked
+        Each time one or more 'pssh' boxes are encountered, the
+        [=Initialization Data Enountered=] algorithm SHALL be invoked
         with <var title="">initDataType</var> = <code>"<a
-        def-id="initdata-registry-cenc">cenc</a>"</code>
-        [[!EME-INITDATA-REGISTRY]] and <var title="">initData</var> = the 'pssh'
+          data-cite="eme-initdata-cenc#format">cenc</a>"</code>
+        [[EME-INITDATA-REGISTRY]] and <var title="">initData</var> = the 'pssh'
         box(es).  Multiple 'pssh' boxes MUST be provided together if and only if
         they appear directly next to each other in the stream.
       </p>
+    </section>
+
+    <section id="conformance">
     </section>
   </body>
 </html>

--- a/format-registry/stream/webm-respec.html
+++ b/format-registry/stream/webm-respec.html
@@ -3,8 +3,7 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>WebM Stream Format</title>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
-    <script src="../../encrypted-media.js" class="remove"></script>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <script class="remove">
     var respecConfig = {
       // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
@@ -16,11 +15,6 @@
       // if there a publicly available Editor's Draft, this is the link
       edDraftURI: "https://w3c.github.io/encrypted-media/format-registry/stream/webm.html",
 
-      // if this is a LCWD, uncomment and set the end of its review period
-      // lcEnd: "2009-08-05",
-
-      // editors, add as many as you like
-      // only "name" is required
       editors: [
         { name: "Joey Parrish", w3cid: "105371",
           company: "Google Inc.", companyURL: "https://www.google.com/" },
@@ -39,21 +33,8 @@
           company: "Microsoft Corporation", companyURL: "https://www.microsoft.com/" },
       ],
 
-      otherLinks: [
-        { key: "Repository", href: "https://github.com/w3c/encrypted-media/" },
-      ],
-
-      emeDefGroupName: "webm-stream-format",
-      emeUnusedGroupNameExcludeList: [
-        "encrypted-media",
-        "eme-references-from-registry",
-      ],
-
-      // name of the WG
-      wg: "Media Working Group",
-
-      // URI of the public WG page
-      wgURI: "https://www.w3.org/media-wg/",
+      group: "media",
+      github: "w3c/encrypted-media",
 
       // name (without the @w3c.org) of the public mailing to which comments are due
       wgPublicList: "public-media-wg",
@@ -65,22 +46,6 @@
       // Team Contact.
       wgPatentURI: "https://www.w3.org/2004/01/pp-impl/115198/status",
 
-      noIDLIn: true,
-
-      scheme: "https",
-
-      // Empty definitions for objects declared in the document are here to
-      // prevent error messages from being displayed for references to these objects.
-      definitionMap: {},
-
-      preProcess: [ encryptedMediaPreProcessor ],
-
-      // Empty definitions for objects declared in the document are here to
-      // prevent error messages from being displayed for references to these objects.
-      definitionMap: {},
-
-      postProcess: [ encryptedMediaPostProcessor ],
-
       localBiblio: {
         "WebM-Encryption": {
           title: "WebM Encryption",
@@ -90,6 +55,8 @@
           date: "4 March 2015",
         },
       },
+
+      xref: ["encrypted-media"]
     };
     </script>
     <!-- script to register bugs -->
@@ -102,7 +69,7 @@
   </head>
   <body>
     <section id="abstract">
-      <p>This specification defines the stream format for using WebM [[!WebM]] content with the <a def-id="eme-spec"></a> [[!ENCRYPTED-MEDIA]].</p>
+      <p>This specification defines the stream format for using WebM [[WebM]] content with the [[[ENCRYPTED-MEDIA]]] [[ENCRYPTED-MEDIA]].</p>
     </section>
 
     <section id="sotd">
@@ -110,8 +77,8 @@
 
     <section id="stream-format">
       <h2>Stream Format</h2>
-      <p>Encrypted WebM streams [[!WebM-Encryption]] are encrypted at the block level with AES-128 CTR encryption.
-      The container SHALL include appropriate values within the <a href="https://matroska.org/technical/specs/index.html#ContentEncryption">ContentEncryption</a> [[!Matroska]] element.
+      <p>Encrypted WebM streams [[WebM-Encryption]] are encrypted at the block level with AES-128 CTR encryption.
+      The container SHALL include appropriate values within the <a href="https://matroska.org/technical/specs/index.html#ContentEncryption">ContentEncryption</a> [[Matroska]] element.
       </p>
       <p>WebM streams may be partially encrypted, both at the <a href="https://matroska.org/technical/specs/index.html#LevelTrack">Track</a> level and the block level.
       In the former case, a subset of Tracks in the stream have a <a href="https://matroska.org/technical/specs/index.html#ContentEncryption">ContentEncryption</a> element.
@@ -121,18 +88,21 @@
 
     <section id="detect-format">
       <h2>Detection</h2>
-      <p>For a stream determined to be in the WebM format [[!WebM]], when a <a href="https://matroska.org/technical/specs/index.html#LevelTrack">Track</a> [[!Matroska]] is parsed, the presence of a <a href="https://matroska.org/technical/specs/index.html#ContentEncKeyID">ContentEncKeyID</a> element indicates that blocks in the track may be encrypted.</p>
+      <p>For a stream determined to be in the WebM format [[WebM]], when a <a href="https://matroska.org/technical/specs/index.html#LevelTrack">Track</a> [[Matroska]] is parsed, the presence of a <a href="https://matroska.org/technical/specs/index.html#ContentEncKeyID">ContentEncKeyID</a> element indicates that blocks in the track may be encrypted.</p>
     </section>
 
     <section id="detect-encrypted-blocks">
       <h2>Detecting Encrypted Blocks</h2>
-      <p>For the purposes of the <a def-id="encrypted-block-encountered-algorithm"></a>, encrypted blocks are those marked encrypted by the <a href="https://www.webmproject.org/docs/webm-encryption/#46-signal-byte-format">Signal Byte.</a> [[!WebM-Encryption]]</p>
+      <p>For the purposes of the [=Encrypted Block Encountered=] algorithm, encrypted blocks are those marked encrypted by the <a href="https://www.webmproject.org/docs/webm-encryption/#46-signal-byte-format">Signal Byte</a> [[WebM-Encryption]].</p>
     </section>
 
     <section id="init-data">
       <h2>Initialization Data Extraction</h2>
-      <p><a def-id="initialization-data"></a> is always a single <a def-id="key-id"></a>, as defined by the <a def-id="initdata-registry-webm"></a> [[!EME-INITDATA-REGISTRY]].</p>
-      <p>Each time a <a href="https://matroska.org/technical/specs/index.html#ContentEncKeyID">ContentEncKeyID</a> [[!Matroska]] element is encountered in a <a href="https://matroska.org/technical/specs/index.html#LevelTrack">Track</a>, the <a def-id="initdata-encountered-algorithm"></a> algorithm SHALL be invoked with <var title="">initDataType</var> = <code>"<a def-id="initdata-registry-webm">webm</a>"</code> [[!EME-INITDATA-REGISTRY]] and <var title="">initData</var> = the value in that element.</p>
+      <p>[=Initialization Data=] is always a single [=Decryption key ID|key ID=], as defined by the [[[EME-INITDATA-WEBM]]] [[EME-INITDATA-REGISTRY]].</p>
+      <p>Each time a <a href="https://matroska.org/technical/specs/index.html#ContentEncKeyID">ContentEncKeyID</a> [[Matroska]] element is encountered in a <a href="https://matroska.org/technical/specs/index.html#LevelTrack">Track</a>, the [=Initialization Data Encountered=] algorithm SHALL be invoked with <var title="">initDataType</var> = <code>"<a data-cite="eme-initdata-webm#format">webm</a>"</code> [[EME-INITDATA-REGISTRY]] and <var title="">initData</var> = the value in that element.</p>
+    </section>
+
+    <section id="conformance">
     </section>
   </body>
 </html>


### PR DESCRIPTION
This PR updates the EME initdata and Stream Format Registries to use the [W3C Registry Track](https://www.w3.org/2023/Process-20231103/#registries).

* ReSpec complains that there should be a compliance section. The [WebCodecs Codec Registry](https://www.w3.org/TR/webcodecs-codec-registry/) doesn't have one, so I'm not sure what to do about the warning.
* "Initialization Data Type" is referenced by the initdata registry, so I have exported the definition so ReSpec can find it.
* The Stream Format Registry requirements described needing an Initialization Data Type, whereas it actually needs a MIME type/subtype pair. I've copied wording from the [MSE Byte Stream Format Registry](https://www.w3.org/TR/mse-byte-stream-format-registry/)
* For completeness, and as suggested (but not required) by the Registry Track process, I added that existing entries cannot be deleted or deprecated.
* Use the latest ReSpec script, and removed the custom JavaScript, which is no longer needed.
* Use the DRY (draft registry) document type.
* Use GitHub issues to add new entries, rather than a mailing list.
* RFC2119 words are sometimes lower case, sometimes upper case, should we make these consistent?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/pull/524.html" title="Last updated on Mar 18, 2024, 8:30 PM UTC (4b23f67)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/524/0bc7d34...4b23f67.html" title="Last updated on Mar 18, 2024, 8:30 PM UTC (4b23f67)">Diff</a>