### PR TITLE
Fix exports

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -317,7 +317,7 @@
           <p>A license is key system-specific state information that includes one or more <a href="#decryption-key">key(s)</a> - each associated with a <a def-id="key-id"></a> - and potentially other information about key usage.</p>
         </dd>
 
-        <dt id="initialization-data">Initialization Data</dt>
+        <dt id="initialization-data"><dfn class="export" data-export="">Initialization Data</dfn></dt>
         <dd>
           <p class="note">
           <a def-id="keysystems"></a> usually require a block of initialization data containing information about the stream to be decrypted before they can construct a license request message.

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -332,7 +332,7 @@
 
           <p>
           The format of the initialization data depends upon the type of container, and containers MAY support more than one format
-          of initialization data. The <dfn class="export" data-export="" id="initialization-data-type">Initialization Data Type</dfn> is a string that indicates the
+          of initialization data. The <dfn class="export" data-export="">Initialization Data Type</dfn> is a string that indicates the
           format of the accompanying Initialization Data. Initialization Data Type strings are always matched case-sensitively. It is
           RECOMMENDED that Initialization Data Type strings are lower-case ASCII strings.
           </p>

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -289,7 +289,7 @@
           <p class="note">For example, a key is not usable for decryption if its license has expired.  Even if its license has not expired, a key is not usable for decryption if other conditions (e.g., output protection) for its use are not currently satisfied.</p>
         </dd>
 
-        <dt id="decryption-key-id"><dfn class="export" data-lt="Decryption key ID">Key ID</dfn></dt>
+        <dt id="decryption-key-id"><dfn class="export" data-export="" data-lt="Decryption key ID">Key ID</dfn></dt>
         <dd>
           <p>A <a href="#decryption-key">key</a> is associated with a key ID that is a sequence of octets and which uniquely identifies the key.
           The container specifies the ID of the key that can decrypt a block or set of blocks within the <a def-id="media-data"></a>.
@@ -332,7 +332,7 @@
 
           <p>
           The format of the initialization data depends upon the type of container, and containers MAY support more than one format
-          of initialization data. The <dfn class="export" id="initialization-data-type">Initialization Data Type</dfn> is a string that indicates the
+          of initialization data. The <dfn class="export" data-export="" id="initialization-data-type">Initialization Data Type</dfn> is a string that indicates the
           format of the accompanying Initialization Data. Initialization Data Type strings are always matched case-sensitively. It is
           RECOMMENDED that Initialization Data Type strings are lower-case ASCII strings.
           </p>
@@ -3027,9 +3027,9 @@ interface MediaEncryptedEvent : Event {
         </section>
 
         <section id="initdata-encountered">
-          <h4><dfn class="export">Initialization Data Encountered</dfn></h4>
+          <h4><dfn class="export" data-export="">Initialization Data Encountered</dfn></h4>
           <p>
-            The Initialization Data Encountered algorithm queues an <a def-id="encrypted"></a> event for <a def-id="initialization-data"></a> encounterd in the <a def-id="media-data"></a>.
+            The Initialization Data Encountered algorithm queues an <a def-id="encrypted"></a> event for <a def-id="initialization-data"></a> encountered in the <a def-id="media-data"></a>.
             Requests to run this algorithm include a target <a def-id="htmlmediaelement"></a> object.
           </p>
           <p>The following steps are run:</p>
@@ -3061,7 +3061,7 @@ interface MediaEncryptedEvent : Event {
         </section>
 
         <section id="encrypted-block-encountered">
-          <h4><dfn class="export">Encrypted Block Encountered</dfn></h4>
+          <h4><dfn class="export" data-export="">Encrypted Block Encountered</dfn></h4>
           <p>
             The Encrypted Block Encountered algorithm queues a block of encrypted media data for decryption and attempts to decrypt if possible.
             Requests to run this algorithm include a target <a def-id="htmlmediaelement"></a> object.


### PR DESCRIPTION
This is a follow up to #524. The attributes are needed because the spec uses an older version of ReSpec (which we can address later). This also adds an export for "Initialization Data", for the MP4 stream registry spec.