### PR TITLE
Update minHdcpVersion to reference registry

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -2979,7 +2979,7 @@
             <div>
               <pre class="idl">
                   dictionary MediaKeysPolicy {
-                      HDCPVersion minHdcpVersion;
+                      DOMString minHdcpVersion;
                   };
                 </pre>
               <p>
@@ -2990,23 +2990,11 @@
               </p>
             </div>
             <div>
-              <pre class="idl">
-                  enum HDCPVersion {
-                      "1.0",
-                      "1.1",
-                      "1.2",
-                      "1.3",
-                      "1.4",
-                      "2.0",
-                      "2.1",
-                      "2.2",
-                      "2.3",
-                  };
-                </pre>
               <p>
-                The HDCP Policy is represented by {{MediaKeysPolicy/minHdcpVersion}}. When set, the
-                policy requirement will be fulfilled if the system supports
-                {{MediaKeysPolicy/minHdcpVersion}} on the current display.
+                The HDCP Policy is represented by {{MediaKeysPolicy/minHdcpVersion}}. If the system
+                can enable the HDCP version specified or higher, then the policy will result in a
+                {{MediaKeyStatus}} of {{MediaKeyStatus/"usable"}}. Implementations MUST support
+                {{MediaKeysPolicy/minHdcpVersion}} values defined in [[EME-HDCP-VERSION-REGISTRY]].
               </p>
               <p class="note">
                 The determination of HDCP status should be done in the same way that the [=CDM=]
@@ -3027,6 +3015,20 @@
                   Let <var>promise</var> be a new promise.
                 </p>
                 <ol>
+                  <li>
+                    <p>
+                      For each [=dictionary member=] of <var>policy</var>, run the following steps:
+                    </p>
+                    <ol>
+                      <li>
+                        <p>
+                          If the key is not a valid {{MediaKeysPolicy}} member or the type of the
+                          value is incorrect, then reject <var>promise</var> with {{TypeError}} and
+                          abort these steps.
+                        </p>
+                      </li>
+                    </ol>
+                  </li>
                   <li>
                     <p>
                       For each [=dictionary member=] of <var>policy</var>, run the following steps:


### PR DESCRIPTION
This updates `minHdcpVersion` to point to the registry. [Specref](https://www.specref.org/) will need to be updated as well.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gregwfreedman/encrypted-media/pull/535.html" title="Last updated on May 13, 2024, 9:53 PM UTC (b1303c0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/535/c01e7e5...gregwfreedman:b1303c0.html" title="Last updated on May 13, 2024, 9:53 PM UTC (b1303c0)">Diff</a>