### PR TITLE
Add explicit places to trigger `hardware-context-reset`

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -3216,17 +3216,23 @@
           <p>
             The CDM unavailable algorithm is run to close all {{MediaKeySession}} objects
             associated with a {{MediaKeys}} object, <var>media keys</var> when the [=CDM=] instance
-            becomes unavailable.
+            becomes unavailable. Requests to run this algorithm include a
+            {{MediaKeySessionClosedReason}} value.
           </p>
           <p>
-            The following step is run:
+            The following steps are run:
           </p>
           <ol>
             <li>
               <p>
+                Let the <var>reason</var> be the specified {{MediaKeySessionClosedReason}} value.
+              </p>
+            </li>
+            <li>
+              <p>
                 For each {{MediaKeySession}} created by the <var>media keys</var> that is not
                 [=media key session/closed=], [=queue a task=] to run the [=Session Closed=]
-                algorithm on the session with reason {{MediaKeyStatus/"internal-error"}}.
+                algorithm on the session with the reason <var>reason</var>.
               </p>
             </li>
           </ol>
@@ -5367,8 +5373,16 @@
             </li>
             <li>
               <p>
-                If <var>cdm</var> has become unavailable, [=queue a task=] to run the [=CDM
-                Unavailable=] algorithm.
+                If <var>cdm</var> has become unavailable due to a hardware context reset,
+                [=queue a task=] to run the [=CDM Unavailable=] algorithm with reason
+                {{MediaKeySessionClosedReason/"hardware-context-reset"}}.
+              </p>
+            </li>
+            <li>
+              <p>
+                If <var>cdm</var> has become unavailable for any other reason,
+                [=queue a task=] to run the [=CDM Unavailable=] algorithm with reason
+                {{MediaKeySessionClosedReason/"internal-error"}}.
               </p>
             </li>
           </ol>
@@ -6223,9 +6237,6 @@
                   <p>
                     If <var>cdm</var> is no longer usable for any reason, run the following steps:
                   </p>
-                  <p class="note">
-                    These steps are intended to be run on unrecoverable failures of the [=CDM=].
-                  </p>
                   <ol>
                     <li>
                       <p>
@@ -6235,7 +6246,9 @@
                     </li>
                     <li>
                       <p>
-                        Run the [=CDM Unavailable=] algorithm on <var>media keys</var>.
+                        Run the [=CDM Unavailable=] algorithm on <var>media keys</var> with the
+                        reason {{MediaKeyStatus/"hardware-context-reset"}} for a hardware context
+                        reset or {{MediaKeyStatus/"internal-error"}} otherwise.
                       </p>
                     </li>
                     <li>
@@ -6337,9 +6350,10 @@
                                     </li>
                                     <li>
                                       <p>
-                                        If <var>cdm</var> is no longer usable for any reason then
-                                        run the [=CDM Unavailable=] algorithm on <var>media
-                                        keys</var>.
+                                        If <var>cdm</var> is no longer usable, run the [=CDM Unavailable=]
+                                        algorithm on <var>media keys</var> with the reason
+                                        {{MediaKeyStatus/"hardware-context-reset"}} for a hardware
+                                        context reset, or {{MediaKeyStatus/"internal-error"}} otherwise.
                                       </p>
                                     </li>
                                     <li>


### PR DESCRIPTION
Related to issue #494, where we want to specify `generateRequest` resolution on `hardware-context-reset`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/pull/537.html" title="Last updated on May 14, 2024, 10:21 PM UTC (efd8b85)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/537/c01e7e5...efd8b85.html" title="Last updated on May 14, 2024, 10:21 PM UTC (efd8b85)">Diff</a>