### PR TITLE
List substantive changes since Rec in Status section

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -95,7 +95,42 @@
         license or other server.
       </p>
     </section>
-    <section id="sotd"></section>
+    <section id="sotd">
+      <p>
+        Two new features were added since publication as a <abbr title=
+        "World Wide Web Consortium">W3C</abbr> Recommendation in <a href=
+        "https://www.w3.org/TR/2017/REC-encrypted-media-20170918/">September 2017</a>:
+      </p>
+      <ul>
+        <li>Encryption scheme capability detection, through the
+        {{MediaKeySystemMediaCapability/encryptionScheme}} attribute.
+        </li>
+        <li>The ability to query the status of a key associated with an HDCP policy, through the
+        {{MediaKeys/getStatusForPolicy()}} method.
+        </li>
+      </ul>
+      <p>
+        Inclusion of other features is out of scope for the Media Working Group. On top of
+        editorial updates, other substantive changes made to this specification address maintenance
+        issues against this specification:
+      </p>
+      <ul>
+        <li>Integrate with the Permissions Policy through the [=encrypted-media=] identifier.
+        </li>
+        <li>Add {{MediaKeyStatus/"usable-in-future"}} to {{MediaKeyStatus}} for keys that are not
+        yet usable for decryption.
+        </li>
+        <li>Return [=QuotaExceededError=] when steps fail due to a lack of resources.
+        </li>
+        <li>Add {{MediaKeySessionClosedReason}} to describe possible reasons for a session closure,
+        and adjust algorithms accordingly.
+        </li>
+      </ul>
+      <p>
+        For a full list of changes made since the previous version, see the <a href=
+        "https://github.com/w3c/encrypted-media/commits/main">commits</a>.
+      </p>
+    </section>
     <section class="informative">
       <h2>
         Introduction


### PR DESCRIPTION
This adjusts the Status of this Document section to list the two new features that were added since publication as a Recommendation in 2017, note that inclusion of additional features is out of scope, and list substantive changes that were made to address maintenance issues.

The list of changes could perhaps be moved to a "Changes since..." section later on. My immediate goal was to be explicit about changes in the Status of this Document section en route to publication as First Public Working Draft.

I went through the commits to report substantive changes. Hopefully I did not forget anything :) I did not list changes made to "refresh" the spec, as they are editorial in essence.

Fixes #546.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/pull/547.html" title="Last updated on Jun 18, 2024, 4:06 PM UTC (e49afe2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/547/28b28d2...e49afe2.html" title="Last updated on Jun 18, 2024, 4:06 PM UTC (e49afe2)">Diff</a>