### PR TITLE
Fix refs to `hardware-context-reset` and `internal-error`

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -6249,8 +6249,9 @@
                     <li>
                       <p>
                         Run the [=CDM Unavailable=] algorithm on <var>media keys</var> with the
-                        reason {{MediaKeyStatus/"hardware-context-reset"}} for a hardware context
-                        reset or {{MediaKeyStatus/"internal-error"}} otherwise.
+                        reason {{MediaKeySessionClosedReason/"hardware-context-reset"}} for a
+                        hardware context reset or {{MediaKeySessionClosedReason/"internal-error"}}
+                        otherwise.
                       </p>
                     </li>
                     <li>
@@ -6354,9 +6355,10 @@
                                       <p>
                                         If <var>cdm</var> is no longer usable, run the [=CDM
                                         Unavailable=] algorithm on <var>media keys</var> with the
-                                        reason {{MediaKeyStatus/"hardware-context-reset"}} for a
-                                        hardware context reset, or
-                                        {{MediaKeyStatus/"internal-error"}} otherwise.
+                                        reason
+                                        {{MediaKeySessionClosedReason/"hardware-context-reset"}}
+                                        for a hardware context reset, or
+                                        {{MediaKeySessionClosedReason/"internal-error"}} otherwise.
                                       </p>
                                     </li>
                                     <li>


### PR DESCRIPTION
The prose incorrectly referenced `{{MediaKeyStatus/"hardware-context-reset"}}` which does not exist, instead of using the `MediaKeySessionClosedReason` enum.

The CDM Unavailable algorithm takes a `MediaKeySessionClosedReason` value as input, so the references to `{{MediaKeyStatus/"internal-error"}}` were incorrect too.

In practice, it's not clear to me that the `"internal-error"` value for `MediaKeyStatus` is still useful. Nothing ever sets the status to that value in the specification in particular. I left it in for now but perhaps it can be dropped entirely?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/pull/548.html" title="Last updated on Jun 18, 2024, 4:23 PM UTC (e5c6c26)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/548/28b28d2...e5c6c26.html" title="Last updated on Jun 18, 2024, 4:23 PM UTC (e5c6c26)">Diff</a>