### PR TITLE
Add missing w3cid for Greg, as editor

### DIFF
--- a/format-registry/initdata/cenc-respec.html
+++ b/format-registry/initdata/cenc-respec.html
@@ -18,7 +18,7 @@
       editors: [
         { name: "Joey Parrish", w3cid: "105371",
           company: "Google Inc.", companyURL: "https://www.google.com/" },
-        { name: "Greg Freedman",
+        { name: "Greg Freedman", w3cid: "115364",
           company: "Netflix Inc.", companyURL: "https://www.netflix.com/" },
       ],
 

--- a/format-registry/initdata/index-respec.html
+++ b/format-registry/initdata/index-respec.html
@@ -18,7 +18,7 @@
       editors: [
         { name: "Joey Parrish", w3cid: "105371",
           company: "Google Inc.", companyURL: "https://www.google.com/" },
-        { name: "Greg Freedman",
+        { name: "Greg Freedman", w3cid: "115364",
           company: "Netflix Inc.", companyURL: "https://www.netflix.com/" },
       ],
 

--- a/format-registry/initdata/keyids-respec.html
+++ b/format-registry/initdata/keyids-respec.html
@@ -18,7 +18,7 @@
       editors: [
         { name: "Joey Parrish", w3cid: "105371",
           company: "Google Inc.", companyURL: "https://www.google.com/" },
-        { name: "Greg Freedman",
+        { name: "Greg Freedman", w3cid: "115364",
           company: "Netflix Inc.", companyURL: "https://www.netflix.com/" },
       ],
 

--- a/format-registry/initdata/webm-respec.html
+++ b/format-registry/initdata/webm-respec.html
@@ -18,7 +18,7 @@
       editors: [
         { name: "Joey Parrish", w3cid: "105371",
           company: "Google Inc.", companyURL: "https://www.google.com/" },
-        { name: "Greg Freedman",
+        { name: "Greg Freedman", w3cid: "115364",
           company: "Netflix Inc.", companyURL: "https://www.netflix.com/" },
       ],
 

--- a/format-registry/stream/index-respec.html
+++ b/format-registry/stream/index-respec.html
@@ -18,7 +18,7 @@
       editors: [
         { name: "Joey Parrish", w3cid: "105371",
           company: "Google Inc.", companyURL: "https://www.google.com/" },
-        { name: "Greg Freedman",
+        { name: "Greg Freedman", w3cid: "115364",
           company: "Netflix Inc.", companyURL: "https://www.netflix.com/" },
       ],
 

--- a/format-registry/stream/mp4-respec.html
+++ b/format-registry/stream/mp4-respec.html
@@ -18,7 +18,7 @@
       editors: [
         { name: "Joey Parrish", w3cid: "105371",
           company: "Google Inc.", companyURL: "https://www.google.com/" },
-        { name: "Greg Freedman",
+        { name: "Greg Freedman", w3cid: "115364",
           company: "Netflix Inc.", companyURL: "https://www.netflix.com/" },
       ],
 
@@ -169,7 +169,7 @@
       </p>
       <p>
         Each time one or more 'pssh' boxes are encountered, the
-        [=Initialization Data Enountered=] algorithm SHALL be invoked
+        [=Initialization Data Encountered=] algorithm SHALL be invoked
         with <var title="">initDataType</var> = <code>"<a
           data-cite="eme-initdata-cenc#format">cenc</a>"</code>
         [[EME-INITDATA-REGISTRY]] and <var title="">initData</var> = the 'pssh'

--- a/format-registry/stream/webm-respec.html
+++ b/format-registry/stream/webm-respec.html
@@ -18,7 +18,7 @@
       editors: [
         { name: "Joey Parrish", w3cid: "105371",
           company: "Google Inc.", companyURL: "https://www.google.com/" },
-        { name: "Greg Freedman",
+        { name: "Greg Freedman", w3cid: "115364",
           company: "Netflix Inc.", companyURL: "https://www.netflix.com/" },
       ],
 

--- a/hdcp-version-registry-respec.html
+++ b/hdcp-version-registry-respec.html
@@ -12,7 +12,7 @@
       editors: [
         { name: "Joey Parrish", w3cid: "105371",
           company: "Google Inc.", companyURL: "https://www.google.com/" },
-        { name: "Greg Freedman",
+        { name: "Greg Freedman", w3cid: "115364",
           company: "Netflix Inc.", companyURL: "https://www.netflix.com/" }
       ],
       github: "w3c/encrypted-media",


### PR DESCRIPTION
The `w3cid` is required by PubRules.

The update also fixes a typo in the reference of one of the specs.