### PR TITLE
Tidy up and export "Key System"

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -189,7 +189,7 @@
           </p>
         </dd>
         <dt>
-          <dfn data-lt="Key System(s)">Key System</dfn>
+          <dfn class="export">Key System</dfn>
         </dt>
         <dd>
           <p>
@@ -8135,7 +8135,7 @@
         Privacy
       </h2>
       <p>
-        The presence or use of [=Key System(s)=] on a user's device raises a number of privacy
+        The presence or use of [=Key System|Key System(s)=] on a user's device raises a number of privacy
         issues, falling into two categories: (a) user-specific information that may be disclosed by
         the EME interface itself or within [=Key System=] messages and (b) user-specific
         information that may be persistently stored on the user's device.


### PR DESCRIPTION
"Key System" needs to be exported to be able to reference it from Media Capabilities (see https://github.com/w3c/media-capabilities/issues/224). This PR also simplifies the dfn so we get `#dfn-key-system` instead of `#dfn-key-system-s`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/pull/555.html" title="Last updated on Aug 7, 2024, 12:59 PM UTC (686f403)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/555/cefbd73...686f403.html" title="Last updated on Aug 7, 2024, 12:59 PM UTC (686f403)">Diff</a>