### PR TITLE
Fix base64url reference in keyids registry entry

### DIFF
--- a/format-registry/initdata/keyids-respec.html
+++ b/format-registry/initdata/keyids-respec.html
@@ -76,7 +76,7 @@
         <dd>An array of [=Decryption key ID|key ID=](s). Each element of the array is the base64url encoding of the octet sequence containing the key ID value.</dd>
       </dl>
 
-      <p class="note">See <a data-cite="eme-initdata-cenc#using-base64url">Using base64url</a>.</p>
+      <p class="note">See <a data-cite="encrypted-media#using-base64url">Using base64url</a>.</p>
       <p class="note">Applications may encode the JSON string using the {{TextEncoder}} interface [[encoding]].</p>
     </section>
 


### PR DESCRIPTION
This fixes #560, but when rendered, the reference goes to `encrypted-media-1`, and I'm not sure how to fix that.