### PR TITLE
Define GetStatusForPolicy behavior for ClearKey

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -7534,7 +7534,7 @@
             <li>
               <p>
                 The {{MediaKeys/getStatusForPolicy()}} method: Implementations should always
-                resolve promise with Usable. 
+                resolve promise with {{MediaKeyStatus/"usable"}}. 
               </p>
             </li>
             <li>

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -7532,6 +7532,13 @@
               </p>
             </li>
             <li>
+            <li>
+              <p>
+                The {{MediaKeys/getStatusForPolicy()}} method: Implementations should always
+                resolve promise with Usable. 
+              </p>
+            </li>
+            <li>
               <p>
                 The {{HTMLMediaElement/setMediaKeys()}} method: Implementations MAY support
                 associating the {{MediaKeys}} object with more than one {{HTMLMediaElement}}.

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -7532,7 +7532,6 @@
               </p>
             </li>
             <li>
-            <li>
               <p>
                 The {{MediaKeys/getStatusForPolicy()}} method: Implementations should always
                 resolve promise with Usable. 


### PR DESCRIPTION
The current GetStatusForPolicy behavior is undefined for ClearKey. This updates the spec so that clearkeys behavior and promises are defined to always resolve, no matter the hdcp min_version.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gvking/encrypted-media/pull/565.html" title="Last updated on Mar 25, 2025, 11:31 PM UTC (12fa28a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/565/81ab0ed...gvking:12fa28a.html" title="Last updated on Mar 25, 2025, 11:31 PM UTC (12fa28a)">Diff</a>