### PR TITLE
Simplify xref in spec

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -63,7 +63,10 @@
         },
       },
 
-      xref: ["dom", "html", "infra"]
+      xref: {
+        specs: ["webaudio"],
+        profile: "web-platform"
+      }
     };
     </script>
     <link rel="stylesheet" href="eme.css">

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -63,7 +63,7 @@
         },
       },
 
-      xref: ["web-platform"]
+      xref: ["dom", "html", "infra"]
     };
     </script>
     <link rel="stylesheet" href="eme.css">

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -63,7 +63,7 @@
         },
       },
 
-      xref: ["dom", "html", "infra", "webaudio"]
+      xref: ["web-platform"]
     };
     </script>
     <link rel="stylesheet" href="eme.css">


### PR DESCRIPTION
Try using web-platform to simplify spec as per recommendation in xref.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gvking/encrypted-media/pull/567.html" title="Last updated on Mar 29, 2025, 4:17 PM UTC (2881259)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/567/4bef312...gvking:2881259.html" title="Last updated on Mar 29, 2025, 4:17 PM UTC (2881259)">Diff</a>