### PR TITLE
Update registration requirements

### DIFF
--- a/format-registry/initdata/index-respec.html
+++ b/format-registry/initdata/index-respec.html
@@ -97,6 +97,19 @@
 
     <section id="entry-requirements">
       <h2>Registration Entry Requirements</h2>
+      <p>
+        To register an entry, file an issue in the
+        <a href="https://github.com/w3c/encrypted-media/issues">Encrypted Media Extensions GitHub issue tracker</a>
+        so it can be discussed and evaluated for compliance before being added to the registry.
+      </p>
+      <p>
+        For the entry to be included, there needs to be interest from at least one
+        implementer in the Media Working Group.
+        If the Media Working Group reaches consensus to accept the candidate,
+        send a pull request (either by the registry editors or by the party requesting
+        the candidate registration) to register the candidate
+        that meets the following requirements:
+      </p>
       <ol>
         <li>
           Each entry must include a unique [=initialization data type=] string.
@@ -108,23 +121,14 @@
         <li>
           Per the [[[ENCRYPTED-MEDIA]]] specification, entries must be fully specified and support common formats such that instances of the format can be processed in a fully specified and compatible way.
         </li>
-        <li>
-          Candidate entries must be announced by filing an issue in the
-          <a href="https://github.com/w3c/encrypted-media/issues/">Encrypted Media Extensions GitHub issue tracker</a>
-          so they can be discussed and evaluated for compliance before being added to
-          the registry.
-        </li>
-        <li>
-          If the Media Working Group reaches consensus to accept the candidate,
-          a pull request should be drafted
-          (either by the registry editors or by the party requesting the candidate registration)
-          to register the candidate.
-          The registry editors will review and merge the pull request.
-        </li>
-        <li>
-          Existing entries cannot be deleted or deprecated.
-        </li>
       </ol>
+      <p>
+        Once consensus is reached by the Working Group,
+        the registry editors will review and merge the pull request.
+      </p>
+      <p>
+        Existing entries cannot be deleted or deprecated.
+      </p>
     </section>
 
     <section id="registry">

--- a/format-registry/stream/index-respec.html
+++ b/format-registry/stream/index-respec.html
@@ -96,6 +96,19 @@
 
     <section id="entry-requirements">
       <h2>Registration Entry Requirements</h2>
+      <p>
+        To register an entry, file an issue in the
+        <a href="https://github.com/w3c/encrypted-media/issues">Encrypted Media Extensions GitHub issue tracker</a>
+        so it can be discussed and evaluated for compliance before being added to the registry.
+      </p>
+      <p>
+        For the entry to be included, there needs to be interest from at least one
+        implementer in the Media Working Group.
+        If the Media Working Group reaches consensus to accept the candidate,
+        send a pull request (either by the registry editors or by the party requesting
+        the candidate registration) to register the candidate
+        that meets the following requirements:
+      </p>
       <ol>
         <li>
           Each entry must include a unique MIME-type/subtype pair. If the byte stream format is derived-from an existing file format, then it should use the MIME-type/subtype pairs typically used for the file format.
@@ -108,23 +121,15 @@
           Per the [[[ENCRYPTED-MEDIA]]] specification, the media container for a stream format must not be encrypted.</li>
         <li>
           Per the [[[ENCRYPTED-MEDIA]]] specification, entries must be fully specified and support "common encryption" such that the content can decrypted in a fully specified and compatible way when a key or keys are provided.
-        <li>
-          Candidate entries must be announced by filing an issue in the
-          <a href="https://github.com/w3c/encrypted-media/issues/">Encrypted Media Extensions GitHub issue tracker</a>
-          so they can be discussed and evaluated for compliance before being added to
-          the registry.
-        </li>
-        <li>
-          If the Media Working Group reaches consensus to accept the candidate,
-          a pull request should be drafted
-          (either by the registry editors or by the party requesting the candidate registration)
-          to register the candidate.
-          The registry editors will review and merge the pull request.
-        </li>
-        <li>
-          Existing entries cannot be deleted or deprecated.
         </li>
       </ol>
+      <p>
+        Once consensus is reached by the Working Group,
+        the registry editors will review and merge the pull request.
+      </p>
+      <p>
+        Existing entries cannot be deleted or deprecated.
+      </p>
     </section>
 
     <section id="registry">

--- a/hdcp-version-registry-respec.html
+++ b/hdcp-version-registry-respec.html
@@ -139,6 +139,19 @@
 
     <section>
       <h2>Registration Entry Requirements</h2>
+      <p>
+        To register an entry, file an issue in the
+        <a href="https://github.com/w3c/encrypted-media/issues">Encrypted Media Extensions GitHub issue tracker</a>
+        so it can be discussed and evaluated for compliance before being added to the registry.
+      </p>
+      <p>
+        For the entry to be included, there needs to be interest from at least one
+        implementer in the Media Working Group.
+        If the Media Working Group reaches consensus to accept the candidate,
+        send a pull request (either by the registry editors or by the party requesting
+        the candidate registration) to register the candidate
+        that meets the following requirements:
+      </p>
       <ol>
         <li>
           Each entry must include a unique HDCP version number, as a string.
@@ -147,24 +160,18 @@
           Each entry must include reference to the specification(s) for the HDCP version,
           with a link if the specification(s) are publicly available.
         </li>
-        <li>
-          Candidate entries must be announced by filing an issue in the
-          <a href="https://github.com/w3c/encrypted-media/issues">Encrypted Media Extensions GitHub issue tracker</a>
-          so they can be discussed and evaluated for compliance before being added to the registry.
-        </li>
-        <li>
-          If the Media Working Group reaches consensus to accept the candidate,
-          a pull request should be drafted
-          (either by the registry editors or by the party requesting the candidate registration)
-          to register the candidate.
-          The registry editors will review and merge the pull request.
-        </li>
-        <li>
-          Existing entries cannot be deleted or deprecated.
-          They may be changed after being published through the same process as candidate entries.
-          Possible changes include updating the link to the entry's specification.
-        </li>
       </ol>
+      <p>
+        Once consensus is reached by the Working Group,
+        the registry editors will review and merge the pull request.
+      </p>
+      <p>
+        Existing entries cannot be deleted or deprecated.
+      </p>
+      <p>
+        They may be changed after being published through the same process as candidate entries.
+        Possible changes include updating the link to the entry's specification.
+      </p>
     </section>
 
     <section>

--- a/hdcp-version-registry-respec.html
+++ b/hdcp-version-registry-respec.html
@@ -169,7 +169,7 @@
         Existing entries cannot be deleted or deprecated.
       </p>
       <p>
-        They may be changed after being published through the same process as candidate entries.
+        Existing entries may be changed after being published through the same process as candidate entries.
         Possible changes include updating the link to the entry's specification.
       </p>
     </section>


### PR DESCRIPTION
Add requirement for implementer support. We recently made a similar change to the [WebCodecs Codec Registry](https://www.w3.org/TR/webcodecs-codec-registry/), so seems useful to update the EME registries similarly.