### PR TITLE
Fix getStatusForPolicy() logic error

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -3089,7 +3089,7 @@
                         <p>
                           If the [=CDM=] would block presentation of decrypted media data for the
                           [=dictionary member=], then resolve <var>promise</var> with
-                          {{MediaKeyStatus/"output-restricted"}}.
+                          {{MediaKeyStatus/"output-restricted"}} and abort these steps.
                         </p>
                       </li>
                     </ol>


### PR DESCRIPTION
The algorithm was resolving the promise multiple times without aborting. This commit adds 'and abort these steps' to the restriction check.

Fixes: https://github.com/w3c/encrypted-media/issues/588


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/pull/589.html" title="Last updated on May 5, 2026, 6:48 AM UTC (279f4e8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/589/93ea5b0...279f4e8.html" title="Last updated on May 5, 2026, 6:48 AM UTC (279f4e8)">Diff</a>