### PR TITLE
Fix MediaKeySession.load() logic error

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -3962,7 +3962,7 @@
                         <p>
                           If there is no data stored for the <var>sanitized session ID</var> in the
                           <var>origin</var>, resolve <var>promise</var> with <code>false</code> and
-                          abort these steps. 
+                          abort the parallel steps of this algorithm. 
                           <!-- Per https://github.com/w3ctag/promises-guide#rejections-should-be-used-for-exceptional-situations. -->
                         </p>
                       </li>


### PR DESCRIPTION
The algorithm was continuing to update session state even when no session data was found. This commit ensures the algorithm terminates correctly by using 'abort the parallel steps of this algorithm'.

Fixes: https://github.com/w3c/encrypted-media/issues/590


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/pull/591.html" title="Last updated on May 5, 2026, 7:59 AM UTC (6602d8c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/591/93ea5b0...6602d8c.html" title="Last updated on May 5, 2026, 7:59 AM UTC (6602d8c)">Diff</a>