### PR TITLE
setMediaKeys(): move state changes and promise resolution to queued t…

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -5785,9 +5785,32 @@
                       </li>
                     </ul>
                     <p>
-                      then let this object's <var>attaching media keys</var> value be false and
-                      reject <var>promise</var> with a {{QuotaExceededError}}.
+                      then run the following steps:
                     </p>
+                    <ol>
+                      <li>
+                        <p>
+                          [=Queue a task=] to run the following steps:
+                        </p>
+                        <ol>
+                          <li>
+                            <p>
+                              Let this object's <var>attaching media keys</var> value be false.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Reject <var>promise</var> with a {{QuotaExceededError}}.
+                            </p>
+                          </li>
+                        </ol>
+                      </li>
+                      <li>
+                        <p>
+                          Abort these steps.
+                        </p>
+                      </li>
+                    </ol>
                   </li>
                   <li>
                     <p>
@@ -5797,20 +5820,65 @@
                     <ol>
                       <li>
                         <p>
-                          If the user agent or [=CDM=] do not support removing the association, let
-                          this object's <var>attaching media keys</var> value be false and reject
-                          <var>promise</var> with a {{NotSupportedError}}.
+                          If the user agent or [=CDM=] do not support removing the association, run
+                          the following steps:
                         </p>
+                        <ol>
+                          <li>
+                            <p>
+                              [=Queue a task=] to run the following steps:
+                            </p>
+                            <ol>
+                              <li>
+                                <p>
+                                  Let this object's <var>attaching media keys</var> value be false.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Reject <var>promise</var> with a {{NotSupportedError}}.
+                                </p>
+                              </li>
+                            </ol>
+                          </li>
+                          <li>
+                            <p>
+                              Abort these steps.
+                            </p>
+                          </li>
+                        </ol>
                       </li>
                       <li>
                         <p>
-                          If the association cannot currently be removed, let this object's
-                          <var>attaching media keys</var> value be false and reject
-                          <var>promise</var> with an {{InvalidStateError}}.
+                          If the association cannot currently be removed, run the following steps:
                         </p>
                         <p class="note">
                           For example, some implementations may not allow removal during playback.
                         </p>
+                        <ol>
+                          <li>
+                            <p>
+                              [=Queue a task=] to run the following steps:
+                            </p>
+                            <ol>
+                              <li>
+                                <p>
+                                  Let this object's <var>attaching media keys</var> value be false.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Reject <var>promise</var> with an {{InvalidStateError}}.
+                                </p>
+                              </li>
+                            </ol>
+                          </li>
+                          <li>
+                            <p>
+                              Abort these steps.
+                            </p>
+                          </li>
+                        </ol>
                       </li>
                       <li>
                         <p>
@@ -5822,10 +5890,33 @@
                       </li>
                       <li>
                         <p>
-                          If the preceding step failed, let this object's <var>attaching media
-                          keys</var> value be false and reject <var>promise</var> with the
-                          appropriate <a href="#error-names">error name</a>.
+                          If the preceding step failed, run the following steps:
                         </p>
+                        <ol>
+                          <li>
+                            <p>
+                              [=Queue a task=] to run the following steps:
+                            </p>
+                            <ol>
+                              <li>
+                                <p>
+                                  Let this object's <var>attaching media keys</var> value be false.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Reject <var>promise</var> with the appropriate
+                                  <a href="#error-names">error name</a>.
+                                </p>
+                              </li>
+                            </ol>
+                          </li>
+                          <li>
+                            <p>
+                              Abort these steps.
+                            </p>
+                          </li>
+                        </ol>
                       </li>
                     </ol>
                   </li>
@@ -5847,45 +5938,64 @@
                         <ol>
                           <li>
                             <p>
-                              Set the {{HTMLMediaElement/mediaKeys}} attribute to null.
+                              [=Queue a task=] to run the following steps:
                             </p>
+                            <ol>
+                              <li>
+                                <p>
+                                  Set the {{HTMLMediaElement/mediaKeys}} attribute to null.
+                                </p>
+                              </li>
+                              <!-- In case it was previously not null since the previous association has been removed. -->
+                              <li>
+                                <p>
+                                  Let this object's <var>attaching media keys</var> value be false.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Reject <var>promise</var> with a new {{DOMException}} whose name
+                                  is the appropriate <a href="#error-names">error name</a>.
+                                </p>
+                              </li>
+                            </ol>
                           </li>
-                          <!-- In case it was previously not null since the previous association has been removed. -->
                           <li>
                             <p>
-                              Let this object's <var>attaching media keys</var> value be false.
-                            </p>
-                          </li>
-                          <li>
-                            <p>
-                              Reject <var>promise</var> with a new {{DOMException}} whose name is
-                              the appropriate <a href="#error-names">error name</a>.
+                              Abort these steps.
                             </p>
                           </li>
                         </ol>
-                      </li>
-                      <li>
-                        <p>
-                          [=Queue a task=] to run the [=Attempt to Resume Playback If Necessary=]
-                          algorithm on the media element.
-                        </p>
                       </li>
                     </ol>
                   </li>
                   <li>
                     <p>
-                      Set the {{HTMLMediaElement/mediaKeys}} attribute to <var>mediaKeys</var>.
+                      [=Queue a task=] to run the following steps:
                     </p>
-                  </li>
-                  <li>
-                    <p>
-                      Let this object's <var>attaching media keys</var> value be false.
-                    </p>
-                  </li>
-                  <li>
-                    <p>
-                      Resolve <var>promise</var> with <code>undefined</code>.
-                    </p>
+                    <ol>
+                      <li>
+                        <p>
+                          Set the {{HTMLMediaElement/mediaKeys}} attribute to <var>mediaKeys</var>.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let this object's <var>attaching media keys</var> value be false.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Resolve <var>promise</var> with <code>undefined</code>.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If <var>mediaKeys</var> is not null, run the [=Attempt to Resume Playback
+                          If Necessary=] algorithm on the media element.
+                        </p>
+                      </li>
+                    </ol>
                   </li>
                 </ol>
               </li>


### PR DESCRIPTION
Fixes #585.

The setMediaKeys() algorithm in Section 7.2 of the EME specification performed several state mutations while running "in parallel", which violates the standard web platform concurrency model.

This change moves observable state changes, internal flag updates, and promise resolution inside a queued task to ensure they are executed on the main thread.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/xhwang-chromium/encrypted-media/pull/596.html" title="Last updated on May 13, 2026, 5:46 AM UTC (c7440ef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/596/7517d4c...xhwang-chromium:c7440ef.html" title="Last updated on May 13, 2026, 5:46 AM UTC (c7440ef)">Diff</a>