### PR TITLE
Terminology: fix BufferSource 'empty array' and use 'get a copy of th…

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -63,7 +63,7 @@
         },
       },
 
-      xref: ["dom", "html", "infra", "mimesniff", "webaudio"]
+      xref: ["dom", "html", "infra", "mimesniff", "webaudio", "webidl"]
     };
     </script>
     <link rel="stylesheet" href="eme.css">
@@ -3130,14 +3130,13 @@
               </li>
               <li>
                 <p>
-                  If <var>serverCertificate</var> is an empty array, return a promise rejected with
+                  If <var>serverCertificate</var> is empty, return a promise rejected with
                   a newly created {{TypeError}}.
                 </p>
               </li>
               <li>
                 <p>
-                  Let <var>certificate</var> be a copy of the contents of the
-                  <var>serverCertificate</var> parameter.
+                  Let <var>certificate</var> be the result of <a data-cite="webidl#dfn-get-buffer-source-copy">get a copy of the bytes held by</a> <var>serverCertificate</var>.
                 </p>
               </li>
               <li>
@@ -3575,7 +3574,7 @@
               </li>
               <li>
                 <p>
-                  If <var>initData</var> is an empty array, return a promise rejected with a newly
+                  If <var>initData</var> is empty, return a promise rejected with a newly
                   created {{TypeError}}.
                 </p>
               </li>
@@ -3589,8 +3588,7 @@
               </li>
               <li>
                 <p>
-                  Let <var>init data</var> be a copy of the contents of the <var>initData</var>
-                  parameter.
+                  Let <var>init data</var> be the result of <a data-cite="webidl#dfn-get-buffer-source-copy">get a copy of the bytes held by</a> <var>initData</var>.
                 </p>
               </li>
               <li>
@@ -4106,14 +4104,13 @@
               </li>
               <li>
                 <p>
-                  If <var>response</var> is an empty array, return a promise rejected with a newly
+                  If <var>response</var> is empty, return a promise rejected with a newly
                   created {{TypeError}}.
                 </p>
               </li>
               <li>
                 <p>
-                  Let <var>response copy</var> be a copy of the contents of the <var>response</var>
-                  parameter.
+                  Let <var>response copy</var> be the result of <a data-cite="webidl#dfn-get-buffer-source-copy">get a copy of the bytes held by</a> <var>response</var>.
                 </p>
               </li>
               <li>


### PR DESCRIPTION
Fixes #592


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/xhwang-chromium/encrypted-media/pull/597.html" title="Last updated on May 13, 2026, 5:48 AM UTC (21ff016)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/597/7517d4c...xhwang-chromium:21ff016.html" title="Last updated on May 13, 2026, 5:48 AM UTC (21ff016)">Diff</a>