### PR TITLE
Clarify 'key replacement algorithm'

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -348,6 +348,16 @@
             usage.
           </p>
         </dd>
+        <dt>
+          <dfn>Key Replacement Algorithm</dfn>
+        </dt>
+        <dd>
+          <p>
+            A key replacement algorithm is the process used by a [=CDM=] to manage the keys within
+            a [=key session|session=] when new keys are provided, for example by evicting
+            existing keys to make room for new ones.
+          </p>
+        </dd>
         <dt id="initialization-data">
           <dfn class="export">Initialization Data</dfn>
         </dt>
@@ -3496,11 +3506,10 @@
               map MUST NOT ever be inconsistent or partially updated, but it may change between
               accesses if the event loop spins in between the accesses. Key IDs may be added as the
               result of a {{MediaKeySession/load()}} or {{MediaKeySession/update()}} call. Key IDs
-              may be removed as the result of a {{MediaKeySession/update()}} call that removes
-              knowledge of existing keys (or replaces the existing set of keys with a new set). Key
-              IDs MUST NOT be removed because they became unusable, such as due to expiration.
-              Instead, such keys MUST be given an appropriate status, such as
-              {{MediaKeyStatus/"expired"}}.
+              may be removed as the result of a {{MediaKeySession/update()}} call, for example if
+              the [=key replacement algorithm=] is run. Key IDs MUST NOT be removed because they
+              became unusable, such as due to expiration. Instead, such keys MUST be given an
+              appropriate status, such as {{MediaKeyStatus/"expired"}}.
             </p>
             <p class="note">
               Some older platforms may contain [=Key System=] implementations that do not expose
@@ -4242,13 +4251,13 @@
                               related data indexed by key ID.
                             </p>
                             <p class="note">
-                              The replacement algorithm within a session is [=Key
+                              The [=key replacement algorithm=] within a session is [=Key
                               System=]-dependent.
                             </p>
                             <p class="note">
-                              It is RECOMMENDED that [=CDM=] implementations support a standard and
+                              It is recommended that [=CDM=] implementations support a standard and
                               reasonably high minimum number of keys per {{MediaKeySession}}
-                              object, including a standard replacement algorithm, and a standard
+                              object, including a standard [=key replacement algorithm=], and a standard
                               and reasonably high minimum number of {{MediaKeySession}} objects.
                               This enables a reasonable number of key rotation algorithms to be
                               implemented across user agents and may reduce the likelihood of


### PR DESCRIPTION
Fixes [583](https://github.com/w3c/encrypted-media/issues/583).

This commit defines 'Key Replacement Algorithm' in the Definitions section to clarify how CDMs manage keys when capacity is reached or new versions are provided. It also updates notes in MediaKeySession to use this definition and ensures non-normative language ('recommended' instead of 'RECOMMENDED') is used in notes.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/xhwang-chromium/encrypted-media/pull/598.html" title="Last updated on May 13, 2026, 5:45 AM UTC (b7fd5d7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/598/7517d4c...xhwang-chromium:b7fd5d7.html" title="Last updated on May 13, 2026, 5:45 AM UTC (b7fd5d7)">Diff</a>