### PR TITLE
Init data registry: add missing paragraph on updates

### DIFF
--- a/format-registry/initdata/index-respec.html
+++ b/format-registry/initdata/index-respec.html
@@ -127,6 +127,9 @@
         the registry editors will review and merge the pull request.
       </p>
       <p>
+        Existing entries may be changed after being published through the same process as candidate entries. Possible changes include updating the link to the entry's specification.
+      </p>
+      <p>
         Existing entries cannot be deleted or deprecated.
       </p>
     </section>


### PR DESCRIPTION
Registration requirements got updated recently to align with other draft registries published by the Media Working Group, but the sentence on posibly updating entries after publication is missing, which seems an oversight.