### PR TITLE
Fix typos in Notes

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -781,7 +781,7 @@
             </li>
           </ul>
           <p class="note">
-            While Distinctive Identifier are usually [=associable by an entity|associable by the
+            While Distinctive Identifiers are usually [=associable by an entity|associable by the
             entity that generated them=] they MUST be [=non-associable by applications=]. In other
             words, such correlation or association is only possible by the entity, such as an
             [=individualization=] server, that originally generated the Distinctive Identifier
@@ -2540,7 +2540,7 @@
           {{MediaKeySystemMediaCapability/robustness}}.
         </p>
         <p class="note">
-          If any of a set of codecs is acceptable, use a separate instances of this dictionary for
+          If any of a set of codecs is acceptable, use separate instances of this dictionary for
           each codec.
         </p>
         <div>
@@ -3952,7 +3952,7 @@
                         <p>
                           If there is no data stored for the <var>sanitized session ID</var> in the
                           <var>origin</var>, resolve <var>promise</var> with <code>false</code> and
-                          abort the parallel steps of this algorithm. 
+                          abort the parallel steps of this algorithm.
                           <!-- Per https://github.com/w3ctag/promises-guide#rejections-should-be-used-for-exceptional-situations. -->
                         </p>
                       </li>
@@ -5141,7 +5141,7 @@
                 </li>
               </ol>
               <p class="note">
-                The effect of this steps is that the contents of <var>session</var>'s
+                The effect of these steps is that the contents of <var>session</var>'s
                 {{MediaKeySession/keyStatuses}} attribute are replaced without invalidating
                 existing references to the attribute. This replacement is atomic from a script
                 perspective. That is, script MUST NOT ever see a partially populated sequence.
@@ -8667,7 +8667,7 @@
             continue to track the user during a session, and can then pass all this information to
             a third party along with any identifying information (names, credit card numbers,
             addresses) obtained by the site. If a third party cooperates with multiple sites to
-            obtain such information, and if identifiers are not 
+            obtain such information, and if identifiers are not
             <!-- Issue #101 may affect this text. --><a href=
             "#per-origin-per-profile-identifiers">unique per origin and profile</a>, then a profile
             can still be created.


### PR DESCRIPTION
This PR fixes a couple of typos I found while reviewing Notes in the spec as part of #545.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/pull/608.html" title="Last updated on Jun 9, 2026, 3:01 PM UTC (62339b9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/608/631787f...62339b9.html" title="Last updated on Jun 9, 2026, 3:01 PM UTC (62339b9)">Diff</a>