### PR TITLE
Replace "use the cdm"

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -3673,7 +3673,7 @@
                     <ol>
                       <li>
                         <p>
-                          If the <var>sanitized init data</var> is not supported by the
+                          If the <var>sanitized init data</var> is not supported by
                           <var>cdm</var>, reject <var>promise</var> with a {{NotSupportedError}}.
                         </p>
                       </li>
@@ -3733,12 +3733,12 @@
                                   <var>initDataType</var>.
                                 </p>
                                 <p>
-                                  The <var>cdm</var> MUST NOT use any stream-specific data,
+                                  <var>cdm</var> MUST NOT use any stream-specific data,
                                   including [=HTMLMediaElement/media data=], not provided via the
                                   <var>sanitized init data</var>.
                                 </p>
                                 <p>
-                                  The <var>cdm</var> SHOULD NOT store session data, including the
+                                  <var>cdm</var> SHOULD NOT store session data, including the
                                   session ID, at this point. See <a href="#session-storage">Session
                                   Storage and Persistence</a>.
                                 </p>

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -3668,7 +3668,7 @@
                   </li>
                   <li>
                     <p>
-                      Use the <var>cdm</var> to execute the following steps:
+                      Use <var>cdm</var> to execute the following steps:
                     </p>
                     <ol>
                       <li>
@@ -3945,7 +3945,7 @@
                   </li>
                   <li>
                     <p>
-                      Use the <var>cdm</var> to execute the following steps:
+                      Use <var>cdm</var> to execute the following steps:
                     </p>
                     <ol>
                       <li>
@@ -4172,7 +4172,7 @@
                   </li>
                   <li>
                     <p>
-                      Use the <var>cdm</var> to execute the following steps:
+                      Use <var>cdm</var> to execute the following steps:
                     </p>
                     <ol>
                       <li>
@@ -4546,7 +4546,7 @@
                   </li>
                   <li>
                     <p>
-                      Use the <var>cdm</var> to execute the following steps:
+                      Use <var>cdm</var> to execute the following steps:
                     </p>
                     <ol>
                       <li>
@@ -6385,7 +6385,7 @@
                     keys</var> that is not [=media key session/closed=], run the following steps:
                   </p>
                   <p class="note">
-                    This check ensures the <var>cdm</var> has finished loading and is a
+                    This check ensures that <var>cdm</var> has finished loading and is a
                     prerequisite for a matching key being available.
                   </p>
                   <ol>
@@ -6405,7 +6405,7 @@
                     </li>
                     <li>
                       <p>
-                        Use the <var>cdm</var> to execute the following steps:
+                        Use <var>cdm</var> to execute the following steps:
                       </p>
                       <ol>
                         <li>
@@ -6448,7 +6448,7 @@
                           <ol>
                             <li>
                               <p>
-                                Use the <var>cdm</var> to decrypt <var>block</var> using <var>block
+                                Use <var>cdm</var> to decrypt <var>block</var> using <var>block
                                 key</var>.
                               </p>
                             </li>

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -3733,13 +3733,13 @@
                                   <var>initDataType</var>.
                                 </p>
                                 <p>
-                                  <var>cdm</var> MUST NOT use any stream-specific data,
+                                  The [=CDM=], <var>cdm</var>, MUST NOT use any stream-specific data,
                                   including [=HTMLMediaElement/media data=], not provided via the
                                   <var>sanitized init data</var>.
                                 </p>
                                 <p>
-                                  <var>cdm</var> SHOULD NOT store session data, including the
-                                  session ID, at this point. See <a href="#session-storage">Session
+                                  The [=CDM=], <var>cdm</var>, SHOULD NOT store session data, including
+                                  the session ID, at this point. See <a href="#session-storage">Session
                                   Storage and Persistence</a>.
                                 </p>
                               </li>


### PR DESCRIPTION
Various algorithms in the spec say "use the cdm", but in these cases "cdm" is actally a variable that refers to an instance of the CDM. Hence "use cdm" is more appropriate.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/pull/609.html" title="Last updated on Jun 9, 2026, 7:07 PM UTC (89a41a1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/609/631787f...89a41a1.html" title="Last updated on Jun 9, 2026, 7:07 PM UTC (89a41a1)">Diff</a>