### PR TITLE
Reword Notes to remove RFC2119 keywords

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -402,10 +402,11 @@
             for each [=Initialization Data Type=] they support.
           </p>
           <p class="note">
-            Use of proprietary formats/contents is discouraged, and supporting or using
-            <em>only</em> proprietary formats is strongly discouraged. Proprietary formats should
-            only be used with pre-existing content or on pre-existing client devices that do not
-            support the common formats.
+            Use of proprietary formats/contents, i.e., formats not defined in
+            [[EME-INITDATA-REGISTRY]] is discouraged, and supporting or using <em>only</em>
+            proprietary formats is strongly discouraged. Proprietary formats should only be used
+            with pre-existing content or on pre-existing client devices that do not support the
+            common formats.
           </p>
         </dd>
         <dt>
@@ -1377,9 +1378,9 @@
                           never supported.
                         </p>
                         <p class="note">
-                          The <var>initDataType</var> MUST be supported independent of content
-                          types in order to avoid unexpectedly rejecting the configuration in later
-                          steps. Support for <var>initDataType</var> includes both license
+                          The configuration may be unexpectedly rejected in later steps if the
+                          <var>initDataType</var> is not supported independent of content
+                          type. Support for <var>initDataType</var> includes both license
                           generation and, when appropriate, extraction from media data. See
                           <a href="#initialization-data-type-support-requirements">Initialization
                           Data Type Support requirements</a>.
@@ -1807,7 +1808,7 @@
                 <div class="note">
                   <p>
                     The "unique per origin and profile" and "clearable" conditions cannot be false
-                    in a compliant implementation because implementations MUST <a href=
+                    in a compliant implementation because implementations <a href=
                     "#per-origin-per-profile-identifiers">use per-origin per-profile
                     identifiers</a> and <a href="#allow-identifiers-cleared">allow the user to
                     clear identifier</a>.
@@ -3494,12 +3495,12 @@
             </p>
             <p class="note">
               The map entries and their values may be updated whenever the event loop spins. The
-              map MUST NOT ever be inconsistent or partially updated, but it may change between
+              map will never be inconsistent or partially updated, but it may change between
               accesses if the event loop spins in between the accesses. Key IDs may be added as the
               result of a {{MediaKeySession/load()}} or {{MediaKeySession/update()}} call. Key IDs
               may be removed as the result of a {{MediaKeySession/update()}} call that removes
               knowledge of existing keys (or replaces the existing set of keys with a new set). Key
-              IDs MUST NOT be removed because they became unusable, such as due to expiration.
+              IDs are not removed if they became unusable, such as due to expiration.
               Instead, such keys MUST be given an appropriate status, such as
               {{MediaKeyStatus/"expired"}}.
             </p>
@@ -5144,7 +5145,7 @@
                 The effect of these steps is that the contents of <var>session</var>'s
                 {{MediaKeySession/keyStatuses}} attribute are replaced without invalidating
                 existing references to the attribute. This replacement is atomic from a script
-                perspective. That is, script MUST NOT ever see a partially populated sequence.
+                perspective. That is, script will not ever see a partially populated sequence.
               </p>
             </li>
             <li>


### PR DESCRIPTION
As [discussed yesterday](https://www.w3.org/2026/06/09-mediawg-minutes.html), this updates a few Notes to remove RFC 2119 keywords.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/pull/615.html" title="Last updated on Jun 10, 2026, 11:30 AM UTC (3dc94af)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/615/d8916f3...3dc94af.html" title="Last updated on Jun 10, 2026, 11:30 AM UTC (3dc94af)">Diff</a>