### PR TITLE
Identify conformance classes (user agent and CDM)

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -60,7 +60,7 @@
     </script>
     <link rel="stylesheet" href="eme.css">
   </head>
-  <body>
+  <body data-cite="INFRA">
     <section id="abstract">
       <p>
         This specification extends {{HTMLMediaElement}} [[HTML]] providing APIs to control playback
@@ -168,7 +168,8 @@
       </h2>
       <dl>
         <dt>
-          <dfn class="export" data-lt="CDM">Content Decryption Module (CDM)</dfn>
+          <dfn class="export" data-lt="CDM|Content Decryption Module">Content Decryption Module
+          (CDM)</dfn>
         </dt>
         <dd>
           <p>
@@ -8813,7 +8814,16 @@
         </p>
       </section>
     </section>
-    <section id="conformance"></section>
+    <section id="conformance">
+      <p>
+        Only two classes of product can conform to this specification: a [=user agent=] and a
+        [=Content Decryption Module=].
+      </p>
+      <p>
+        A requirement that explicitly identifies the [=Content Decryption Module=] applies to the
+        [=CDM=]. Every other requirement applies to the [=user agent=].
+      </p>
+    </section>
     <section id="examples" class="informative">
       <h2>
         Examples


### PR DESCRIPTION
This identifies the specification's conformance classes: user agent and CDM.

Closes #531


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/pull/618.html" title="Last updated on Jun 18, 2026, 7:45 PM UTC (f1ac7d7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/618/84cb893...f1ac7d7.html" title="Last updated on Jun 18, 2026, 7:45 PM UTC (f1ac7d7)">Diff</a>