### PR TITLE
Affirmative form: MediaKeys Interface (name the user agent / CDM)

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -2832,8 +2832,8 @@
             <td>
               <p>
                 A session for which the license (and potentially other data related to the session)
-                will be persisted. The [=CDM=] SHALL persist a [=record of license destruction=] when the
-                license and key(s) it contains are destroyed. The <dfn data-lt=
+                will be persisted. The [=CDM=] SHALL persist a [=record of license destruction=]
+                when the license and key(s) it contains are destroyed. The <dfn data-lt=
                 "record(s) of license destruction|records of license destruction">record of license
                 destruction</dfn> is a [=Key System=]-specific attestation that the license and
                 key(s) it contains are no longer usable by the client. Support for this session
@@ -3289,8 +3289,8 @@
           The [=user agent=] MUST always store persisted data such that only the [=origin=] of this
           object's [=Document=] can access it. In addition, the [=user agent=] MUST make the data
           accessible only to the current [=browsing profile=]; the [=user agent=] MUST NOT allow
-          other browsing profiles, user agents, and applications to access the stored data. See <a href="#privacy-storedinfo">Information Stored on
-          User Devices</a>.
+          other browsing profiles, user agents, and applications to access the stored data. See
+          <a href="#privacy-storedinfo">Information Stored on User Devices</a>.
         </p>
         <p>
           See <a href="#security"></a> and <a href="#privacy"></a> for additional considerations

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -2832,7 +2832,7 @@
             <td>
               <p>
                 A session for which the license (and potentially other data related to the session)
-                will be persisted. A [=record of license destruction=] SHALL be persisted when the
+                will be persisted. The [=CDM=] SHALL persist a [=record of license destruction=] when the
                 license and key(s) it contains are destroyed. The <dfn data-lt=
                 "record(s) of license destruction|records of license destruction">record of license
                 destruction</dfn> is a [=Key System=]-specific attestation that the license and
@@ -3286,10 +3286,10 @@
           it creates.
         </p>
         <p>
-          Persisted data MUST always be stored such that only the [=origin=] of this object's
-          [=Document=] can access it. In addition, the data MUST only be accessible by the current
-          [=browsing profile=]; other browsing profiles, user agents, and applications MUST NOT be
-          able to access the stored data. See <a href="#privacy-storedinfo">Information Stored on
+          The [=user agent=] MUST always store persisted data such that only the [=origin=] of this
+          object's [=Document=] can access it. In addition, the [=user agent=] MUST make the data
+          accessible only to the current [=browsing profile=]; the [=user agent=] MUST NOT allow
+          other browsing profiles, user agents, and applications to access the stored data. See <a href="#privacy-storedinfo">Information Stored on
           User Devices</a>.
         </p>
         <p>


### PR DESCRIPTION
Names the user agent or the CDM as the actor for previously passive normative requirements in the MediaKeys Interface section, per the conformance classes in #531.

The CDM assignment was checked against WebKit engine source: the record of license destruction is stored by the CDM instance (CDMInstanceSession::storeRecordOfKeyUsage), not by the user agent.

Part of #595.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/pull/619.html" title="Last updated on Jun 19, 2026, 4:53 PM UTC (3a546e1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/619/84cb893...3a546e1.html" title="Last updated on Jun 19, 2026, 4:53 PM UTC (3a546e1)">Diff</a>