### PR TITLE
Affirmative form: Definitions (name the user agent / CDM)

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -247,10 +247,11 @@
             a new session.
           </p>
           <p>
-            The [=CDM=] SHALL make each Session ID unique within the browsing context in which it
-            was created. For session types for which the [=Is persistent session type?=] algorithm
-            returns <code>true</code>, the [=CDM=] MUST make Session IDs unique within the
-            [=origin=] over time, including across browsing sessions.
+            The [=CDM=] SHALL generate each Session ID such that it is unique within the browsing
+            context in which it was created. For session types for which the
+            [=Is persistent session type?=] algorithm returns <code>true</code>, the [=CDM=] MUST
+            generate Session IDs such that they are unique within the [=origin=] over time,
+            including across browsing sessions.
           </p>
           <p class="note">
             The underlying content protection protocol does not necessarily need to support Session

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -248,10 +248,10 @@
           </p>
           <p>
             The [=CDM=] SHALL generate each Session ID such that it is unique within the browsing
-            context in which it was created. For session types for which the
-            [=Is persistent session type?=] algorithm returns <code>true</code>, the [=CDM=] MUST
-            generate Session IDs such that they are unique within the [=origin=] over time,
-            including across browsing sessions.
+            context in which it was created. For session types for which the [=Is persistent
+            session type?=] algorithm returns <code>true</code>, the [=CDM=] MUST generate Session
+            IDs such that they are unique within the [=origin=] over time, including across
+            browsing sessions.
           </p>
           <p class="note">
             The underlying content protection protocol does not necessarily need to support Session
@@ -267,8 +267,9 @@
             blocks within [=HTMLMediaElement/media data=]. Each such key is uniquely identified by
             a [=key ID=]. A key is associated with the [=key session|session=] used to provide it
             to the [=CDM=]. (The same key may be present in multiple sessions.) The [=user agent=]
-            MUST only provide such keys to the [=CDM=] via an {{MediaKeySession/update()}} call. (They may later be
-            loaded by {{MediaKeySession/load()}} as part of the stored session data.)
+            MUST only provide such keys to the [=CDM=] via an {{MediaKeySession/update()}} call.
+            (They may later be loaded by {{MediaKeySession/load()}} as part of the stored session
+            data.)
           </p>
           <div>
             <p>
@@ -398,9 +399,9 @@
             code.
           </p>
           <p>
-            Initialization Data SHOULD NOT contain Key System-specific data or values.
-            [=CDMs=] MUST support the common formats defined in [[EME-INITDATA-REGISTRY]]
-            for each [=Initialization Data Type=] they support.
+            Initialization Data SHOULD NOT contain Key System-specific data or values. [=CDMs=]
+            MUST support the common formats defined in [[EME-INITDATA-REGISTRY]] for each
+            [=Initialization Data Type=] they support.
           </p>
           <p class="note">
             Use of proprietary formats/contents, i.e., formats not defined in
@@ -574,9 +575,9 @@
           </p>
           <p>
             When exposing Distinctive Permanent Identifiers and values derived from or otherwise
-            related to them outside the client, the [=CDM=] MUST <a href="#encrypt-identifiers">encrypt</a> them.
-            The [=CDM=] MUST NOT ever expose Distinctive Permanent Identifiers to the application, even in
-            encrypted form.
+            related to them outside the client, the [=CDM=] MUST <a href=
+            "#encrypt-identifiers">encrypt</a> them. The [=CDM=] MUST NOT ever expose Distinctive
+            Permanent Identifiers to the application, even in encrypted form.
           </p>
           <p class="note">
             While a Distinctive Permanent Identifier is typically unique to a user or client

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -399,7 +399,7 @@
             code.
           </p>
           <p>
-            Initialization Data SHOULD NOT contain Key System-specific data or values. [=CDMs=]
+            Initialization Data SHOULD NOT contain Key System-specific data or values. [=User agents=] and [=CDMs=]
             MUST support the common formats defined in [[EME-INITDATA-REGISTRY]] for each
             [=Initialization Data Type=] they support.
           </p>

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -227,8 +227,8 @@
             when the {{MediaKeySession}} object is destroyed.
           </p>
           <p>
-            All license(s) and key(s) associated with a Key Session which have not been explicitly
-            stored MUST be destroyed when the Key Session is closed.
+            The [=CDM=] MUST destroy all license(s) and key(s) associated with a Key Session which
+            have not been explicitly stored when the Key Session is closed.
           </p>
           <p>
             [=Key IDs=] MUST be unique within a session.
@@ -247,10 +247,10 @@
             a new session.
           </p>
           <p>
-            Each Session ID SHALL be unique within the browsing context in which it was created.
-            For session types for which the [=Is persistent session type?=] algorithm returns
-            <code>true</code>, Session IDs MUST be unique within the [=origin=] over time,
-            including across browsing sessions.
+            The [=CDM=] SHALL make each Session ID unique within the browsing context in which it
+            was created. For session types for which the [=Is persistent session type?=] algorithm
+            returns <code>true</code>, the [=CDM=] MUST make Session IDs unique within the
+            [=origin=] over time, including across browsing sessions.
           </p>
           <p class="note">
             The underlying content protection protocol does not necessarily need to support Session
@@ -265,8 +265,8 @@
             Unless otherwise stated, key refers to a decryption key that can be used to decrypt
             blocks within [=HTMLMediaElement/media data=]. Each such key is uniquely identified by
             a [=key ID=]. A key is associated with the [=key session|session=] used to provide it
-            to the [=CDM=]. (The same key may be present in multiple sessions.) Such keys MUST only
-            be provided to the [=CDM=] via an {{MediaKeySession/update()}} call. (They may later be
+            to the [=CDM=]. (The same key may be present in multiple sessions.) The [=user agent=]
+            MUST only provide such keys to the [=CDM=] via an {{MediaKeySession/update()}} call. (They may later be
             loaded by {{MediaKeySession/load()}} as part of the stored session data.)
           </p>
           <div>
@@ -398,7 +398,7 @@
           </p>
           <p>
             Initialization Data SHOULD NOT contain Key System-specific data or values.
-            Implementations MUST support the common formats defined in [[EME-INITDATA-REGISTRY]]
+            [=CDMs=] MUST support the common formats defined in [[EME-INITDATA-REGISTRY]]
             for each [=Initialization Data Type=] they support.
           </p>
           <p class="note">
@@ -572,9 +572,9 @@
             Identifier</dfn> is a [=Permanent Identifier=] that is [=distinctive=].
           </p>
           <p>
-            When exposed outside the client, Distinctive Permanent Identifiers and values derived
-            from or otherwise related to them MUST be <a href="#encrypt-identifiers">encrypted</a>.
-            Distinctive Permanent Identifiers MUST NOT ever be exposed to the application, even in
+            When exposing Distinctive Permanent Identifiers and values derived from or otherwise
+            related to them outside the client, the [=CDM=] MUST <a href="#encrypt-identifiers">encrypt</a> them.
+            The [=CDM=] MUST NOT ever expose Distinctive Permanent Identifiers to the application, even in
             encrypted form.
           </p>
           <p class="note">
@@ -940,8 +940,8 @@
             lifetime of related such entities, it exposes, even in encrypted form, one or more
             [=Distinctive Permanent Identifier(s)=], information about them, or values derived from
             or otherwise related to them outside the client. This includes but is not limited to
-            providing such a value to an [=individualization=] server. Such values MUST NOT be
-            provided to the application.
+            providing such a value to an [=individualization=] server. The [=CDM=] MUST NOT provide
+            such values to the application.
           </p>
           <p>
             An implementation, configuration, instance, or object <dfn data-lt=


### PR DESCRIPTION
Names the user agent or the CDM as the actor for previously passive normative requirements in the Definitions section, per the conformance classes in #531.

The user-agent-versus-CDM split was checked against engine source: Session ID generation is a CDM operation in both WebKit (the Clear Key CDM mints the identifier and the user agent stores what the CDM returns) and Firefox/Gecko (the Clear Key CDM's session manager generates it), so the uniqueness requirement is correctly the CDM's.

Part of #595.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/pull/620.html" title="Last updated on Jun 26, 2026, 2:59 PM UTC (b6d77ee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/620/84cb893...b6d77ee.html" title="Last updated on Jun 26, 2026, 2:59 PM UTC (b6d77ee)">Diff</a>