### PR TITLE
Affirmative form: HTMLMediaElement Extensions (name the user agent)

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -5702,8 +5702,8 @@
           </dt>
           <dd>
             <p>
-              Event handler for the {{encrypted}} event. The [=user agent=] MUST support it on all
-              {{HTMLMediaElement}}s as both a content attribute and an IDL attribute.
+              Event handler for the {{encrypted}} event. The [=user agent=] MUST support the event
+              handler on all {{HTMLMediaElement}}s as both a content attribute and an IDL attribute.
             </p>
           </dd>
           <dt>
@@ -5711,8 +5711,9 @@
           </dt>
           <dd>
             <p>
-              Event handler for the {{waitingforkey}} event. The [=user agent=] MUST support it on
-              all {{HTMLMediaElement}}s as both a content attribute and an IDL attribute.
+              Event handler for the {{waitingforkey}} event. The [=user agent=] MUST support the
+              event handler on all {{HTMLMediaElement}}s as both a content attribute and an IDL
+              attribute.
             </p>
           </dd>
         </dl>

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -5579,8 +5579,8 @@
             changed other than advancing in the <a data-cite="html#direction-of-playback">direction
             of playback</a> as part of normal playback, the [=user agent=] SHALL empty the
             <var>encrypted block queue</var> value, initialize the <var>decryption blocked waiting
-            for key</var> value to <code>false</code>, and set the <var>playback blocked waiting for
-            key</var> value to <code>false</code>.
+            for key</var> value to <code>false</code>, and set the <var>playback blocked waiting
+            for key</var> value to <code>false</code>.
           </p>
           <p class="note">
             In other words, these values should be reset when, for example, <a data-cite=
@@ -5703,7 +5703,8 @@
           <dd>
             <p>
               Event handler for the {{encrypted}} event. The [=user agent=] MUST support the event
-              handler on all {{HTMLMediaElement}}s as both a content attribute and an IDL attribute.
+              handler on all {{HTMLMediaElement}}s as both a content attribute and an IDL
+              attribute.
             </p>
           </dd>
           <dt>

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -5566,21 +5566,21 @@
       <ul>
         <li>
           <p>
-            When a {{HTMLMediaElement}} is created, its <var>attaching media keys</var> value SHALL
-            be initialized to <code>false</code>, its <var>encrypted block queue</var> value SHALL
-            be empty, its <var>decryption blocked waiting for key</var> value SHALL be initialized
-            to <code>false</code>, and its <var>playback blocked waiting for key</var> value SHALL
-            be initialized to <code>false</code>.
+            When a {{HTMLMediaElement}} is created, the [=user agent=] SHALL initialize its
+            <var>attaching media keys</var> value to <code>false</code>, empty its <var>encrypted
+            block queue</var> value, initialize its <var>decryption blocked waiting for key</var>
+            value to <code>false</code>, and initialize its <var>playback blocked waiting for
+            key</var> value to <code>false</code>.
           </p>
         </li>
         <li>
           <p>
             When the <a data-cite="html#current-playback-position">current playback position</a> is
             changed other than advancing in the <a data-cite="html#direction-of-playback">direction
-            of playback</a> as part of normal playback, the <var>encrypted block queue</var> value
-            SHALL be empty, the <var>decryption blocked waiting for key</var> value SHALL be
-            initialized to <code>false</code>, and the <var>playback blocked waiting for key</var>
-            value SHALL be set to <code>false</code>.
+            of playback</a> as part of normal playback, the [=user agent=] SHALL empty the
+            <var>encrypted block queue</var> value, initialize the <var>decryption blocked waiting
+            for key</var> value to <code>false</code>, and set the <var>playback blocked waiting for
+            key</var> value to <code>false</code>.
           </p>
           <p class="note">
             In other words, these values should be reset when, for example, <a data-cite=
@@ -5590,9 +5590,10 @@
         </li>
         <li>
           <p>
-            In addition to the criteria specified in [[HTML]], an {{HTMLMediaElement}} SHALL be
-            considered a <a data-cite="html#blocked-media-element">blocked media element</a> if its
-            <var>playback blocked waiting for key</var> value is <code>true</code>.
+            In addition to the criteria specified in [[HTML]], the [=user agent=] SHALL consider an
+            {{HTMLMediaElement}} to be a <a data-cite="html#blocked-media-element">blocked media
+            element</a> if its <var>playback blocked waiting for key</var> value is
+            <code>true</code>.
           </p>
         </li>
         <li>
@@ -5701,7 +5702,7 @@
           </dt>
           <dd>
             <p>
-              Event handler for the {{encrypted}} event. It MUST be supported by all
+              Event handler for the {{encrypted}} event. The [=user agent=] MUST support it on all
               {{HTMLMediaElement}}s as both a content attribute and an IDL attribute.
             </p>
           </dd>
@@ -5710,8 +5711,8 @@
           </dt>
           <dd>
             <p>
-              Event handler for the {{waitingforkey}} event. It MUST be supported by all
-              {{HTMLMediaElement}}s as both a content attribute and an IDL attribute.
+              Event handler for the {{waitingforkey}} event. The [=user agent=] MUST support it on
+              all {{HTMLMediaElement}}s as both a content attribute and an IDL attribute.
             </p>
           </dd>
         </dl>


### PR DESCRIPTION
Names the user agent as the actor for previously passive normative requirements in the HTMLMediaElement Extensions section, per the conformance classes in #531.

Part of #595.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/pull/621.html" title="Last updated on Jun 19, 2026, 4:35 PM UTC (ef9dd19)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/621/84cb893...ef9dd19.html" title="Last updated on Jun 19, 2026, 4:35 PM UTC (ef9dd19)">Diff</a>