### PR TITLE
Affirmative form: Obtaining Access to Key Systems (name the user agent)

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -2178,9 +2178,8 @@
                     </p>
                     <p>
                       The [=user agent=] MUST obtain consent that includes consent to use a
-                      [=Distinctive Identifier(s)=]
-                      and/or [=Distinctive Permanent Identifier(s)=] as appropriate if
-                      <var>accumulated configuration</var>'s
+                      [=Distinctive Identifier(s)=] and/or [=Distinctive Permanent Identifier(s)=]
+                      as appropriate if <var>accumulated configuration</var>'s
                       {{MediaKeySystemConfiguration/distinctiveIdentifier}} member is
                       {{MediaKeysRequirement/"required"}}.
                     </p>
@@ -2527,10 +2526,10 @@
             <dd>
               <p>
                 The robustness level associated with the content type. The empty string indicates
-                that any ability to decrypt and decode the content type is acceptable.
-                The [=user agent=] MUST configure the [=CDM=] to support at least the robustness
-                levels specified in the configuration of the {{MediaKeySystemAccess}} object used
-                to create the {{MediaKeys}} object.
+                that any ability to decrypt and decode the content type is acceptable. The [=user
+                agent=] MUST configure the [=CDM=] to support at least the robustness levels
+                specified in the configuration of the {{MediaKeySystemAccess}} object used to
+                create the {{MediaKeys}} object.
               </p>
             </dd>
           </dl>

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -2292,7 +2292,7 @@
                     When returned by a {{MediaKeySystemAccess}} object
                   </dt>
                   <dd>
-                    The [=user agent=] cannot, and MUST NOT, include this value in such an object.
+                    The [=user agent=] MUST NOT include this value in such an object.
                   </dd>
                 </dl>
               </td>
@@ -2439,9 +2439,9 @@
           </dd>
         </dl>
         <p>
-          The [=user agent=] SHOULD NOT add members to this dictionary. Should member(s) be added,
-          they MUST be of type {{MediaKeysRequirement}}, and it is RECOMMENDED that they have
-          default values of {{MediaKeysRequirement/"optional"}} to support the widest range of
+          The [=user agent=] SHOULD NOT add members to this dictionary. If the [=user agent=] adds
+          member(s), they MUST be of type {{MediaKeysRequirement}}, and it is RECOMMENDED that they
+          have default values of {{MediaKeysRequirement/"optional"}} to support the widest range of
           application and client combinations.
         </p>
         <p class="note">

--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -1080,8 +1080,8 @@
                 will correspond to the first such element.
               </p>
               <p>
-                Any permission checks or user interaction, such as a prompt for consent, MUST be
-                performed before resolving the promise.
+                The [=user agent=] MUST perform any permission checks or user interaction, such as
+                a prompt for consent, before resolving the promise.
               </p>
               <p>
                 If the <code>keySystem</code> is not supported or not allowed (in at least one of
@@ -2177,7 +2177,8 @@
                       <var>origin</var> and wait for the user response.
                     </p>
                     <p>
-                      The consent MUST include consent to use a [=Distinctive Identifier(s)=]
+                      The [=user agent=] MUST obtain consent that includes consent to use a
+                      [=Distinctive Identifier(s)=]
                       and/or [=Distinctive Permanent Identifier(s)=] as appropriate if
                       <var>accumulated configuration</var>'s
                       {{MediaKeySystemConfiguration/distinctiveIdentifier}} member is
@@ -2264,7 +2265,7 @@
                     When used in a call to {{Navigator/requestMediaKeySystemAccess()}}
                   </dt>
                   <dd>
-                    The returned object MUST support this feature.
+                    The [=user agent=] MUST return an object that supports this feature.
                   </dd>
                   <dt>
                     When returned by a {{MediaKeySystemAccess}} object
@@ -2291,7 +2292,7 @@
                     When returned by a {{MediaKeySystemAccess}} object
                   </dt>
                   <dd>
-                    This value cannot and MUST NOT be present in such an object.
+                    The [=user agent=] cannot, and MUST NOT, include this value in such an object.
                   </dd>
                 </dl>
               </td>
@@ -2438,7 +2439,7 @@
           </dd>
         </dl>
         <p>
-          Implementations SHOULD NOT add members to this dictionary. Should member(s) be added,
+          The [=user agent=] SHOULD NOT add members to this dictionary. Should member(s) be added,
           they MUST be of type {{MediaKeysRequirement}}, and it is RECOMMENDED that they have
           default values of {{MediaKeysRequirement/"optional"}} to support the widest range of
           application and client combinations.
@@ -2451,7 +2452,7 @@
           members.
         </p>
         <p>
-          This dictionary MUST NOT be used to pass state or data to the [=CDM=].
+          The [=user agent=] MUST NOT use this dictionary to pass state or data to the [=CDM=].
         </p>
       </section>
       <section>
@@ -2527,7 +2528,7 @@
               <p>
                 The robustness level associated with the content type. The empty string indicates
                 that any ability to decrypt and decode the content type is acceptable.
-                Implementations MUST configure the [=CDM=] to support at least the robustness
+                The [=user agent=] MUST configure the [=CDM=] to support at least the robustness
                 levels specified in the configuration of the {{MediaKeySystemAccess}} object used
                 to create the {{MediaKeys}} object.
               </p>


### PR DESCRIPTION
Names the user agent as the actor for previously passive normative requirements in the Obtaining Access to Key Systems section, per the conformance classes in #531.

Part of #595.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/pull/622.html" title="Last updated on Jun 19, 2026, 4:38 PM UTC (358d0ba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/encrypted-media/622/84cb893...358d0ba.html" title="Last updated on Jun 19, 2026, 4:38 PM UTC (358d0ba)">Diff</a>