### PR TITLE
Align registry requirements with MSE Byte stream format registry

### DIFF
--- a/format-registry/initdata/index-respec.html
+++ b/format-registry/initdata/index-respec.html
@@ -105,6 +105,10 @@
         so it can be discussed and evaluated for compliance before being added to the registry.
       </p>
       <p>
+        The Media Working Group may seek expertise from outside the Working Group as part of its evaluation,
+        e.g., from the editors or relevant standards group of the underlying format specification.
+        If the underlying format specification is not publicly available,
+        it must be made available to the Working Group for evaluation.
         For the entry to be included, there needs to be interest from at least one
         implementer in the Media Working Group.
         If the Media Working Group reaches consensus to accept the candidate,
@@ -117,11 +121,13 @@
           Each entry must include a unique [=initialization data type=] string.
         </li>
         <li>
-          Each entry must include a link that references a publicly available specification.
-          It is recommended that such a specification be made available without cost (other than reasonable shipping and handling if not available by online means).
+          Each entry must include a link that references a publicly available registration specification.
         </li>
         <li>
           Per the [[[ENCRYPTED-MEDIA]]] specification, entries must be fully specified and support common formats such that instances of the format can be processed in a fully specified and compatible way.
+        </li>
+        <li>
+          It is recommended that the registration specification and the underlying specifications be made available without cost (other than reasonable shipping and handling if not available by online means).
         </li>
       </ol>
       <p>
@@ -129,7 +135,10 @@
         the registry editors will review and merge the pull request.
       </p>
       <p>
-        Existing entries cannot be deleted or deprecated.
+        Existing entries may be changed after being published, through the same process as candidate entries. Possible changes include modification of the link to the public specification.
+      </p>
+      <p>
+        If a registration fails to satisfy a mandatory requirement specified above, then it may be removed from the registry. Existing entries cannot be deleted or deprecated otherwise.
       </p>
     </section>
 

--- a/format-registry/stream/index-respec.html
+++ b/format-registry/stream/index-respec.html
@@ -49,9 +49,7 @@
       // This is important for Rec-track documents, do not copy a patent URI from a random
       // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
       // Team Contact.
-      wgPatentURI: "https://www.w3.org/2004/01/pp-impl/115198/status",
-
-      xref: ["encrypted-media"]
+      wgPatentURI: "https://www.w3.org/2004/01/pp-impl/115198/status"
     };
     </script>
     <!-- script to register bugs -->
@@ -69,7 +67,7 @@
       #registry table td, table th { border-left: solid; border-right: solid; border-bottom: solid thin; vertical-align: top; padding: 0.2em; }
     </style>
   </head>
-  <body>
+  <body data-cite="encrypted-media mimesniff">
 
     <section id="abstract">
       <p>This specification defines the stream formats for use with the [[[ENCRYPTED-MEDIA]]] [[ENCRYPTED-MEDIA]].</p>
@@ -104,6 +102,10 @@
         so it can be discussed and evaluated for compliance before being added to the registry.
       </p>
       <p>
+        The Media Working Group may seek expertise from outside the Working Group as part of its evaluation,
+        e.g., from the editors or relevant standards group of the underlying format specification.
+        If the underlying format specification is not publicly available,
+        it must be made available to the Working Group for evaluation.
         For the entry to be included, there needs to be interest from at least one
         implementer in the Media Working Group.
         If the Media Working Group reaches consensus to accept the candidate,
@@ -113,16 +115,18 @@
       </p>
       <ol>
         <li>
-          Each entry must include a unique MIME-type/subtype pair. If the byte stream format is derived-from an existing file format, then it should use the MIME-type/subtype pairs typically used for the file format.
+          Each entry must include a unique [=MIME type=]/[=MIME type/subtype=] pair. If the byte stream format is derived-from an existing file format, then it should use the [=MIME type=]/[=MIME type/subtype=] pairs typically used for the file format.
         </li>
         <li>
-          Each entry must include a link that references a publicly available specification.
-          It is recommended that such a specification be made available without cost (other than reasonable shipping and handling if not available by online means).
+          Each entry must include a link that references a publicly available registration specification.
         </li>
         <li>
           Per the [[[ENCRYPTED-MEDIA]]] specification, the media container for a stream format must not be encrypted.</li>
         <li>
           Per the [[[ENCRYPTED-MEDIA]]] specification, entries must be fully specified and support "common encryption" such that the content can decrypted in a fully specified and compatible way when a key or keys are provided.
+        </li>
+        <li>
+          It is recommended that the registration specification and the underlying specifications be made available without cost (other than reasonable shipping and handling if not available by online means).
         </li>
       </ol>
       <p>
@@ -130,7 +134,10 @@
         the registry editors will review and merge the pull request.
       </p>
       <p>
-        Existing entries cannot be deleted or deprecated.
+        Existing entries may be changed after being published, through the same process as candidate entries. Possible changes include modification of the link to the public specification.
+      </p>
+      <p>
+        If a registration fails to satisfy a mandatory requirement specified above, then it may be removed from the registry. Existing entries cannot be deleted or deprecated otherwise.
       </p>
     </section>
 


### PR DESCRIPTION
This brings latest changes made to the MSE Byte stream format registry requirements to align and clarify the set of rules followed by the Media WG across registries:
https://github.com/w3c/mse-byte-stream-format-registry/pull/11