### PR TITLE
Align HDCP registration requirements

### DIFF
--- a/hdcp-version-registry-respec.html
+++ b/hdcp-version-registry-respec.html
@@ -149,6 +149,10 @@
         so it can be discussed and evaluated for compliance before being added to the registry.
       </p>
       <p>
+        The Media Working Group may seek expertise from outside the Working Group as part of its evaluation,
+        e.g., from the editors or relevant standards group of the HDCP specification.
+        If the HDCP specification is not publicly available,
+        it must be made available to the Working Group for evaluation.
         For the entry to be included, there needs to be interest from at least one
         implementer in the Media Working Group.
         If the Media Working Group reaches consensus to accept the candidate,
@@ -170,11 +174,11 @@
         the registry editors will review and merge the pull request.
       </p>
       <p>
-        Existing entries cannot be deleted or deprecated.
-      </p>
-      <p>
         Existing entries may be changed after being published through the same process as candidate entries.
         Possible changes include updating the link to the entry's specification.
+      </p>
+      <p>
+        Existing entries cannot be deleted or deprecated.
       </p>
     </section>
 


### PR DESCRIPTION
This change makes the requirements consistent with the EME stream format and initdata registries, as well as the MSE byte stream format registry. 